### PR TITLE
fix: report Indeterminate when an equivalence comparison cannot read its reference

### DIFF
--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -541,6 +541,42 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                          sequence was reconstructed"
                     )));
             }
+            // The window is bounded and both sides convert to SPDI on a shared
+            // accession, but the provider could not serve its bases, so — as with
+            // `WindowTooWide` — nothing was reconstructed and nothing was
+            // compared (#1989). This is the "want of reference data" decline, and
+            // it must report `Indeterminate` for the same reason its sibling does:
+            // falling through to the `NotEquivalent` tail would assert a decided
+            // negative about a pair that was never examined. Pinned by
+            // `issue_1989_declined_is_indeterminate`.
+            SequenceVerdict::ReferenceUnavailable => {
+                return Ok(EquivalenceResult::new(EquivalenceLevel::Indeterminate)
+                    .with_normalized(str1, str2)
+                    .with_note(
+                        "The reference window covering both variants could not be read from the \
+                         provider, so neither resulting sequence was reconstructed"
+                            .to_string(),
+                    ));
+            }
+            // `Different` is a decided negative — both sides were reconstructed
+            // and disagree. `Declined` is the catch-all decline. The shapes the
+            // checker routes to `NotEquivalent` *deliberately* are an edit SPDI
+            // cannot carry (`issue_1578_followup_equivalence_rungs` for a
+            // fusion), a cross-accession pair (the mixed-accession arm of
+            // `same_resulting_sequence`) and an un-appliable overlapping allele
+            // (`issue_1244_equivalence_overlap_panic`), each pinned there.
+            //
+            // Those are not all of it, and the arm above does not make them so.
+            // `edit_triples` discards its conversion error —
+            // `hgvs_to_spdi(member, provider).ok()?`, `checker.rs:1114` — so a
+            // member whose conversion needed the reference and could not read it
+            // also arrives here as `Declined` and is read as a negative:
+            // `NC_ABSENT.1:g.2del` vs `g.2delC` answers `NotEquivalent` against
+            // a provider serving no bases and `CrossAxisSequenceMatch` against a
+            // served contig. So `ReferenceUnavailable` above is the
+            // reference-level decline reachable from the WINDOW FETCH, not every
+            // reference-level decline; the rest is #2056, a follow-up on
+            // `edit_triples`. These two fall through.
             SequenceVerdict::Different | SequenceVerdict::Declined => {}
         }
 
@@ -654,7 +690,9 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                     // nowhere else; carrying it in the level needs a rung of its
                     // own rather than a reuse of `Indeterminate`. Pinned by
                     // `a_second_axis_that_cannot_be_computed_stops_at_the_single_axis_rung`.
-                    SequenceVerdict::WindowTooWide | SequenceVerdict::Declined => (
+                    SequenceVerdict::WindowTooWide
+                    | SequenceVerdict::ReferenceUnavailable
+                    | SequenceVerdict::Declined => (
                         EquivalenceLevel::SequenceMatch,
                         format!(
                             "Variants produce the same resulting sequence on their own axis; the \
@@ -882,9 +920,23 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
     ///
     /// Best-effort and side-effect free. [`SequenceVerdict::Declined`] covers
     /// every variant that cannot be projected to SPDI triples on a single
-    /// shared accession; [`SequenceVerdict::WindowTooWide`] is split out from it
-    /// because it is the one decline that must not be read as a negative — see
-    /// [`MAX_SEQUENCE_COMPARE_WINDOW`].
+    /// shared accession. Two declines are split out of it because they must not
+    /// be read as a negative: [`SequenceVerdict::WindowTooWide`] when the union
+    /// window exceeds [`MAX_SEQUENCE_COMPARE_WINDOW`], and
+    /// [`SequenceVerdict::ReferenceUnavailable`] when the provider cannot serve
+    /// the window's bases (#1989). Both are resolved to
+    /// [`EquivalenceLevel::Indeterminate`] by the caller.
+    ///
+    /// **The split covers the window fetch, and not every reference failure.**
+    /// [`Self::edit_triples`] discards its conversion error —
+    /// `hgvs_to_spdi(member, provider).ok()?`, `checker.rs:1114` — so a member
+    /// whose SPDI conversion had to read the reference and could not is `None`
+    /// there and `Declined` here, indistinguishable from an edit SPDI cannot
+    /// carry. Measured on this revision, against a provider serving no bases:
+    /// `NC_ABSENT.1:g.2del` vs `g.2delC` — one edit, two spellings — answers
+    /// `NotEquivalent`, while the same pair on a served contig answers
+    /// `CrossAxisSequenceMatch`. Narrowing that is #2056, a follow-up on
+    /// `edit_triples`, not on this function.
     fn same_resulting_sequence(&self, v1: &HgvsVariant, v2: &HgvsVariant) -> SequenceVerdict {
         let Some((acc1, triples1)) = self.edit_triples(v1) else {
             return SequenceVerdict::Declined;
@@ -1171,11 +1223,32 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
 
 /// What a sequence-level comparison concluded.
 ///
-/// `Declined` and `WindowTooWide` are both "nothing was compared", and they are
-/// separate because only one of them is safe to read as a negative: a decline
-/// is usually a provider or representation limit that leaves the pre-existing
-/// verdict alone, while a window overrun is the case that would otherwise be
-/// argued into a decided negative it has not earned.
+/// Three of the four variants mean "nothing was compared", and they are kept
+/// apart because they are not read the same way. `WindowTooWide` and
+/// `ReferenceUnavailable` are the two declines [`compare_triples`] raises before
+/// it reconstructs anything — the window that would settle the pair was not
+/// obtained, once because it exceeds the cap and once because the provider could
+/// not serve it — and both must report `Indeterminate`, because arguing either
+/// into a decided negative claims a comparison that never ran (#1989).
+/// `Declined` is the catch-all; the checker deliberately routes it to
+/// `NotEquivalent`, and the shapes it is *meant* to carry — an edit SPDI cannot
+/// carry, a cross-accession pair, an un-appliable overlapping allele — are
+/// pinned elsewhere. `Different` is the one decided negative that was actually
+/// measured: both sides reconstructed, and they disagree.
+///
+/// **`Declined` is not purely representation-level.** `EquivalenceChecker::edit_triples`
+/// discards its conversion error — `hgvs_to_spdi(member, provider).ok()?`,
+/// `checker.rs:1114` — so a member whose SPDI conversion had to read the
+/// reference and could not is `None` there and `Declined` here, on the same
+/// footing as an unrepresentable edit. Measured on this revision:
+/// `NC_ABSENT.1:g.2del` vs `g.2delC` (one edit, two spellings) answers
+/// `NotEquivalent` against a provider serving no bases and
+/// `CrossAxisSequenceMatch` against a served contig; `g.2dup` vs `g.2_3insC`
+/// against the unserved provider, and two out-of-bounds substitutions on a
+/// *served* 12-base contig, answer `NotEquivalent` by the same route. Each of
+/// those declines before the fetch, which is how it is distinguishable from the
+/// `ReferenceUnavailable` arm at all. Distinguishing them is #2056, a follow-up
+/// on `edit_triples`; the split below is scoped to [`compare_triples`]'s fetch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SequenceVerdict {
     /// Both sides were reconstructed and the resulting sequences are equal.
@@ -1185,7 +1258,19 @@ enum SequenceVerdict {
     /// Nothing was reconstructed: the union window exceeds
     /// [`MAX_SEQUENCE_COMPARE_WINDOW`].
     WindowTooWide,
-    /// Nothing was reconstructed, for any other reason.
+    /// Nothing was reconstructed: the union window is bounded and both sides
+    /// convert to SPDI on a shared accession, but the provider could not serve
+    /// the reference bases needed to compare them (#1989). The "want of
+    /// reference data" decline — the sibling of [`Self::WindowTooWide`], and like
+    /// it a decline that must **not** be read as a negative.
+    ReferenceUnavailable,
+    /// Nothing was reconstructed, for any other reason. The shapes it is meant
+    /// to carry are representation-level — an edit SPDI cannot carry, a
+    /// cross-accession pair, an overlapping allele that cannot be applied — and
+    /// the checker deliberately reads this as a negative. It also carries a
+    /// reference failure that happened *before* the fetch, in `edit_triples`'s
+    /// discarded conversion error (`checker.rs:1114`) — that is #2056, and the
+    /// enum-level note has the measurements.
     Declined,
 }
 
@@ -1228,7 +1313,11 @@ where
     }
 
     let Some(reference) = fetch(win_start, win_end) else {
-        return SequenceVerdict::Declined;
+        // The window is bounded and both triple sets are in hand, but the
+        // provider could not serve the bases. This is "want of reference data",
+        // not a representation limit, so it is the `WindowTooWide` sibling and
+        // must not be read as a negative (#1989).
+        return SequenceVerdict::ReferenceUnavailable;
     };
 
     match (
@@ -1623,9 +1712,17 @@ mod tests {
 
     #[test]
     fn test_genomic_variants_different() {
-        let checker = checker();
-        let v1 = parse_hgvs("NC_000001.11:g.12345A>G").unwrap();
-        let v2 = parse_hgvs("NC_000001.11:g.12346A>G").unwrap();
+        // Two genuinely different substitutions must compare `NotEquivalent` —
+        // but only once the sequence rung can actually reconstruct their window.
+        // The reference is served here for exactly that reason: without it, the
+        // comparison never runs and the honest verdict is `Indeterminate`, not a
+        // decided negative (#1989). See
+        // `issue_1989_declined_is_indeterminate` for the unserved case.
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NC_000001.11", "ACGTACGTACGT");
+        let checker = EquivalenceChecker::new(provider);
+        let v1 = parse_hgvs("NC_000001.11:g.1A>G").unwrap();
+        let v2 = parse_hgvs("NC_000001.11:g.2C>G").unwrap();
 
         let result = checker.check(&v1, &v2).unwrap();
         assert_eq!(result.level, EquivalenceLevel::NotEquivalent);

--- a/tests/it/issue_1989_declined_is_indeterminate.rs
+++ b/tests/it/issue_1989_declined_is_indeterminate.rs
@@ -1,0 +1,138 @@
+//! #1989: a sequence comparison that could not be reconstructed **for want of
+//! reference data** must report [`EquivalenceLevel::Indeterminate`], not a
+//! decided negative.
+//!
+//! The sequence rung (`same_resulting_sequence`) reconstructs each side's edited
+//! window and compares the bases. When the two variants share an accession and
+//! both convert to SPDI triples, but the reference window itself cannot be
+//! obtained from the provider, **nothing was compared**. That is the same
+//! situation the [`SequenceVerdict::WindowTooWide`] arm already handles — the
+//! window that would settle the pair could not be reconstructed — and it
+//! resolves to `Indeterminate`. Its sibling, the *reference-unavailable* decline,
+//! used to fall through with `SequenceVerdict::Different` to the ladder's
+//! `NotEquivalent` tail, turning "I could not tell" into "they are different".
+//!
+//! # The measured wrong answer
+//!
+//! `g.2C>A` and `g.2delCinsA` are the **same edit** — both replace base 2's `C`
+//! with an `A`, i.e. identical SPDI triples — so the pair is equivalent. Both
+//! convert to SPDI without consulting the provider (their bases are stated), but
+//! on a provider that serves no bases for the accession the comparison window
+//! cannot be fetched. Before this fix the checker answered `NotEquivalent`: a
+//! decided negative asserted for two descriptions that denote the *same*
+//! sequence, reached without either sequence ever having been reconstructed.
+//!
+//! # Scope
+//!
+//! This targets exactly the `WindowTooWide` sibling: a bounded, same-accession,
+//! SPDI-representable window that could not be *reconstructed*. It deliberately
+//! does **not** touch the other declines the checker routes to `NotEquivalent`
+//! on purpose and pins elsewhere — an RNA fusion
+//! (`issue_1578_followup_equivalence_rungs`), a genuine cross-accession pair
+//! (a decided negative by construction), or an overlapping cis allele
+//! (`issue_1244_equivalence_overlap_panic`). Those are representation- and
+//! geometry-level declines, not "the reference could not be read".
+
+use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+use ferro_hgvs::{parse_hgvs, MockProvider};
+
+use crate::common::synthetic::SyntheticBuilder;
+
+/// An accession the provider serves no bases for, so the comparison window can
+/// never be reconstructed.
+const ABSENT: &str = "NC_ABSENT.1";
+
+/// The primary reproducer: two spellings of one edit, compared as written, on a
+/// provider that cannot serve the reference. The comparison never ran, so the
+/// verdict must be `Indeterminate` rather than a decided negative.
+#[test]
+fn an_equivalent_pair_whose_reference_is_unavailable_is_indeterminate() {
+    let checker = EquivalenceChecker::new(MockProvider::new());
+
+    let a = parse_hgvs(&format!("{ABSENT}:g.2C>A")).unwrap();
+    let b = parse_hgvs(&format!("{ABSENT}:g.2delCinsA")).unwrap();
+
+    // `compare_denotations` reaches the sequence rung over the pair as written,
+    // without normalizing — so the assertion cannot silently depend on whether
+    // the normalizer happens to converge the two spellings.
+    let result = checker.compare_denotations(&a, &b).unwrap();
+    assert_eq!(
+        result.level,
+        EquivalenceLevel::Indeterminate,
+        "a reference-unavailable decline is 'could not tell', not a decided negative; got {:?}",
+        result.level,
+    );
+    assert!(
+        !result.level.is_decided(),
+        "an unreconstructable comparison is not a decided verdict",
+    );
+    assert!(
+        !result.level.is_equivalent(),
+        "and it is not a positive one either",
+    );
+}
+
+/// The same rung reached through the other entry point. `check` normalizes both
+/// sides first; on a provider with no bases the two spellings do not converge,
+/// so it reaches the sequence rung and must report the same `Indeterminate`.
+///
+/// Two genuinely different substitutions are used here, so the point is not that
+/// the pair is equivalent but that the checker may not *assert a negative* about
+/// a pair it never compared.
+#[test]
+fn check_reports_indeterminate_when_the_reference_cannot_be_reconstructed() {
+    let checker = EquivalenceChecker::new(MockProvider::new());
+
+    let a = parse_hgvs(&format!("{ABSENT}:g.1A>G")).unwrap();
+    let b = parse_hgvs(&format!("{ABSENT}:g.2C>G")).unwrap();
+
+    let result = checker.check(&a, &b).unwrap();
+    assert_eq!(
+        result.level,
+        EquivalenceLevel::Indeterminate,
+        "the comparison window could not be reconstructed, so the verdict is not decided; got {:?}",
+        result.level,
+    );
+}
+
+/// The discriminating control, and the reason this fix does not over-map. When
+/// the reference **is** served, two variants that genuinely produce different
+/// sequences are reconstructed and compared, and that decided negative must
+/// survive unchanged.
+#[test]
+fn a_served_genuinely_different_pair_stays_a_decided_negative() {
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic("ACGTACGTACGT").build());
+
+    let a = parse_hgvs("NC_TEST.1:g.1A>G").unwrap();
+    let b = parse_hgvs("NC_TEST.1:g.5A>C").unwrap();
+
+    // Both entry points reach and run the sequence rung, which finds the two
+    // reconstructed windows differ.
+    assert_eq!(
+        checker.check(&a, &b).unwrap().level,
+        EquivalenceLevel::NotEquivalent,
+        "a reconstructed, genuinely different pair is still `NotEquivalent`",
+    );
+    assert_eq!(
+        checker.compare_denotations(&a, &b).unwrap().level,
+        EquivalenceLevel::NotEquivalent,
+    );
+}
+
+/// The other half of the control: when the reference is served, an equivalent
+/// pair still reaches a decided **positive**. The fix moves only the case where
+/// the window could not be reconstructed, never a case where it could.
+#[test]
+fn a_served_equivalent_pair_stays_a_decided_positive() {
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic("ACGTACGTACGT").build());
+
+    let a = parse_hgvs("NC_TEST.1:g.2C>A").unwrap();
+    let b = parse_hgvs("NC_TEST.1:g.2delCinsA").unwrap();
+
+    let result = checker.compare_denotations(&a, &b).unwrap();
+    assert!(
+        result.level.is_equivalent(),
+        "a reconstructed, equivalent pair still reaches a decided positive; got {:?}",
+        result.level,
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -48,6 +48,7 @@ mod issue_1870_cds_less_transcript_refusal;
 mod issue_1916_intron_distance_underflow;
 mod issue_1917_reversed_range_window;
 mod issue_1970_u16_cost_grid_bound;
+mod issue_1989_declined_is_indeterminate;
 mod recommended_form_pins;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;


### PR DESCRIPTION
Refs #1989 — deliberately not `Closes`. This splits the **fetch** path only (`compare_triples`'s window fetch at `checker.rs:1283`). A reference-data failure inside `hgvs_to_spdi` is still swallowed by `.ok()?` at `checker.rs:1094` and lands in `Declined`, so the commonest shape of #1989 is unfixed: measured on this head, `NC_ABSENT.1:g.2del` vs `NC_ABSENT.1:g.2delC` on an unserved reference still returns a decided **`NotEquivalent`**, while the same pair on a served contig returns `CrossAxisSequenceMatch` — they are the same variant, and the only difference is whether the reference could be read. Since HGVS routinely omits the deleted or duplicated bases (`g.2del`, `c.10_12del`, `g.2dup`), that residual is the larger population. Classifying at `:1094` is the follow-up.

Representation-Change: none. Only `src/equivalence/checker.rs` changes (not a watched prefix). The equivalence verdict is a downstream *consumer* of the normalizer and feeds no normalization path, so no normalized output moves.

## The defect

The equivalence sequence rung (`same_resulting_sequence` / `compare_triples`) reconstructs each variant's edited window from SPDI triples and compares the bases. Several outcomes all meant "nothing was compared" but were collapsed into one `SequenceVerdict::Declined`, which the `check` ladder groups with `Different` and falls through to its `NotEquivalent` tail. The sibling `WindowTooWide` outcome — the reference window would exceed the compare cap — was already split out and correctly reports `Indeterminate`.

Among the cases folded into `Declined` is the one #1989 names: **the reference window could not be read from the provider** even though both sides share an accession and both convert to SPDI. That is the exact sibling of `WindowTooWide` (both mean "the window that would settle the pair could not be reconstructed"), yet it was reported as a decided negative for a comparison that never ran.

Measured wrong answer (via `compare_denotations`, which does not normalize, so the result cannot depend on normalizer confluence):

```
NC_ABSENT.1:g.2C>A  vs  NC_ABSENT.1:g.2delCinsA   (the SAME edit — identical SPDI triples)
  provider serves no bases for the accession
  before: NotEquivalent   ← decided negative asserted without ever comparing
  after:  Indeterminate
```

## The fix

Split a dedicated `SequenceVerdict::ReferenceUnavailable` out of `Declined` for the fetch-unavailable case and resolve it to `EquivalenceLevel::Indeterminate`, exactly as `WindowTooWide` is resolved. The second-axis strengthening path treats it identically to its `WindowTooWide | Declined` siblings ("the axis could not be compared").

## Unchanged on purpose (why this does not over-map)

The checker routes several other `Declined` shapes to `NotEquivalent` **deliberately**, each with a documented decision and existing tests. This change leaves all of them alone — they are representation- or geometry-level declines, not "the reference could not be read":

- an **RNA fusion** (SPDI cannot represent it) — the deliberate scope boundary pinned by `issue_1578_followup_equivalence_rungs::an_rna_fusion_pair_is_still_answered_a_deliberate_scope_boundary`;
- a genuine **cross-accession** pair — a decided negative by construction (`same_resulting_sequence`'s mixed-accession arm);
- an **overlapping cis allele** that cannot be applied — `issue_1244_equivalence_overlap_panic`;
- and a **reconstructed, genuinely different** pair — still `Different` → `NotEquivalent`.

Only the reference-level decline moves.

## Tests

New `tests/it/issue_1989_declined_is_indeterminate.rs`:
- an equivalent pair whose reference is unavailable → `Indeterminate` (the measured wrong answer, via `compare_denotations`);
- `check` reports `Indeterminate` when the reference cannot be reconstructed (the other entry point);
- **discriminating controls**: a served + genuinely different pair stays `NotEquivalent` (both entry points), and a served + equivalent pair stays a decided positive.

`equivalence::checker::tests::test_genomic_variants_different` now serves its genomic reference, so it genuinely reconstructs and compares the two different substitutions (its original intent) instead of reaching `NotEquivalent` by luck on an unserved reference.

## Verification

- `cargo fmt --all --check` → clean
- `cargo clippy --all-features --all-targets -- -D warnings` → clean
- `cargo nextest run --features dev --no-fail-fast` → `11226 passed, 155 skipped` (only this fix's target test regressed before the reference-serving update; the whole equivalence suite of 75 tests passes, preserving the fusion / mixed-accession / overlap decisions above)
