### PR TITLE
refactor: make the derived/sourced split explicit so a hollow sidecar row is unrepresentable (R4)

### DIFF
--- a/src/benchmark/cache.rs
+++ b/src/benchmark/cache.rs
@@ -36,7 +36,7 @@ use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Get NCBI API key from environment variable.
@@ -1914,6 +1914,17 @@ fn fetch_fasta_fallback(
 }
 
 /// Supplemental transcript metadata extracted from GenBank records.
+///
+/// **Every field here is *sourced*** — only a GenBank record supplies it, and a FASTA cannot
+/// re-derive it. The one thing that used to sit beside them, `sequence_length`, is *derived*:
+/// its authority is the accession's bases in the supplemental FASTA. R4 dropped it from this
+/// type so the derived/sourced split is explicit in the shape rather than in prose. That
+/// makes a "hollow" row — one that claims a length it has no bases behind, the shape 116,572
+/// of the shipped `patterns_transcripts.metadata.json`'s 140,027 rows had (#1722) —
+/// *unrepresentable*: there is no length field to be zero, stale, or otherwise wrong, and so
+/// nothing to detect and repair. Length is read straight from the FASTA index at every point
+/// that needs it (see `MultiFastaProvider::get_supplemental_cds_info`, which already sourced
+/// it there since #1722).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SupplementalTranscript {
     /// Transcript accession (e.g., "NM_033517.1")
@@ -1924,8 +1935,6 @@ pub struct SupplementalTranscript {
     pub cds_start: Option<u64>,
     /// CDS end position (1-based, inclusive)
     pub cds_end: Option<u64>,
-    /// Sequence length
-    pub sequence_length: usize,
 }
 
 /// Supplemental metadata for transcripts not in cdot.
@@ -1937,29 +1946,6 @@ pub struct SupplementalMetadata {
     pub transcripts: std::collections::HashMap<String, SupplementalTranscript>,
 }
 
-impl SupplementalTranscript {
-    /// Whether this row claims no sequence at all — the shape #1722 calls **hollow**.
-    ///
-    /// A hollow row is not a row with missing *information*. `sequence_length` is a
-    /// **derived** field: all three sites that build a [`SupplementalTranscript`] set it to
-    /// the length of the sequence they just wrote to the FASTA and to nothing else, so the
-    /// FASTA is its authority and the sidecar is a cache of it. `gene_symbol`, `cds_start`
-    /// and `cds_end` are **sourced** — only a GenBank record supplies them — and a FASTA
-    /// cannot re-derive them.
-    ///
-    /// That split is what makes a hollow row repairable without a network round trip: if
-    /// the accession's bases are on disk, its length is not missing, merely not indexed.
-    ///
-    /// This is the **reporting** predicate, and deliberately not what
-    /// [`repair_derived_lengths`] keys on: the repair asks the strictly more complete
-    /// question — does this row's length agree with the FASTA — which also covers a
-    /// non-zero length that has drifted. `is_hollow` names the shape #1722 measured, so a
-    /// run can say how degraded the artifact it found was.
-    pub fn is_hollow(&self) -> bool {
-        self.sequence_length == 0
-    }
-}
-
 impl SupplementalMetadata {
     /// An empty artifact, stamped now — what a first run starts from.
     fn empty() -> Self {
@@ -1967,14 +1953,6 @@ impl SupplementalMetadata {
             generated_at: chrono::Utc::now().to_rfc3339(),
             transcripts: std::collections::HashMap::new(),
         }
-    }
-
-    /// How many rows are hollow, for the run to report.
-    fn hollow_record_count(&self) -> usize {
-        self.transcripts
-            .values()
-            .filter(|record| record.is_hollow())
-            .count()
     }
 }
 
@@ -1996,136 +1974,6 @@ fn load_supplemental_metadata(metadata_path: &Path) -> Result<SupplementalMetada
     })?;
     serde_json::from_reader(BufReader::new(file)).map_err(|e| FerroError::Json {
         msg: format!("Failed to parse {}: {}", metadata_path.display(), e),
-    })
-}
-
-/// Bases per accession in a supplemental FASTA, streamed, **first record winning**.
-///
-/// First-wins rather than last-wins so this agrees with
-/// [`SupplementalStore::commit`](crate::benchmark::supplemental_store::SupplementalStore::commit),
-/// which keeps the first record for an accession and drops every later duplicate. Reading a
-/// duplicate-bearing FASTA the other way round would repair a row to a length the commit is
-/// about to discard.
-///
-/// A header with **no** bases yields nothing, for the same reason the store's own reader
-/// skips one: it is a presence claim with nothing behind it, and recording a length of zero
-/// for it would write the very shape this repair exists to remove.
-///
-/// An absent FASTA is a genuine first run and yields nothing, not an error.
-fn supplemental_fasta_lengths(fasta_path: &Path) -> Result<HashMap<String, usize>, FerroError> {
-    let mut lengths: HashMap<String, usize> = HashMap::new();
-    if !fasta_path.exists() {
-        return Ok(lengths);
-    }
-    let file = File::open(fasta_path).map_err(|e| FerroError::Io {
-        msg: format!("Failed to open {}: {}", fasta_path.display(), e),
-    })?;
-
-    let mut accession: Option<String> = None;
-    let mut bases = 0usize;
-    for line in BufReader::new(file).lines() {
-        let line = line.map_err(|e| FerroError::Io {
-            msg: format!("Failed to read {}: {}", fasta_path.display(), e),
-        })?;
-        if let Some(header) = line.strip_prefix('>') {
-            if let Some(previous) = accession.take().filter(|_| bases > 0) {
-                lengths.entry(previous).or_insert(bases);
-            }
-            accession = header.split_whitespace().next().map(str::to_string);
-            bases = 0;
-        } else {
-            bases += line.trim().len();
-        }
-    }
-    if let Some(previous) = accession.filter(|_| bases > 0) {
-        lengths.entry(previous).or_insert(bases);
-    }
-
-    Ok(lengths)
-}
-
-/// Re-derive every sidecar row's `sequence_length` from the FASTA, returning how many moved.
-///
-/// **This is the repair #1722 needs, and it makes no network call.** The shipped
-/// `patterns_transcripts.metadata.json` carries 116,572 hollow rows out of 140,027, and all
-/// 116,572 of those accessions are already in the FASTA — which is exactly why the resume
-/// filter, keyed on the FASTA by #1791, admits none of them. A hollow row is therefore a
-/// stale *derived* field and not a missing fetch, and re-fetching to recover a value that
-/// can be computed would be a 116,572-accession round trip against a rate-limited endpoint
-/// to learn something already on disk.
-///
-/// Only `sequence_length` is touched. `gene_symbol`, `cds_start` and `cds_end` are sourced
-/// from a GenBank record and are carried through untouched, including on a row that has
-/// none — recovering those is a fetch, and a separate, per-accession change.
-///
-/// A row whose accession the FASTA has no record for is left alone: it is an orphan, and
-/// [`SupplementalStore::commit`](crate::benchmark::supplemental_store::SupplementalStore::commit)
-/// drops it as part of reconciling the key sets.
-///
-/// # Cost
-///
-/// One extra sequential read of the FASTA per run, on top of the one
-/// [`SupplementalStore::open`](crate::benchmark::supplemental_store::SupplementalStore::open)
-/// already does — the same trade that module makes, and taken for the reason it records
-/// there: it measures that scan at **2.08 s over the 1.3 GB shipped artifact**, against a
-/// provisioning run whose fetch half is a networked, rate-limited operation measured in
-/// hours. This scan has the same shape, so it costs about the same. It is run unconditionally
-/// rather than gated on the sidecar looking degraded, so that a length which has drifted to
-/// some *other* wrong value is repaired too — a derived field is derived, or it is not.
-/// The accession-to-length map it builds is bounded by the record count (140,027 on that
-/// artifact), not by the file's size.
-fn repair_derived_lengths(
-    fasta_path: &Path,
-    metadata: &mut SupplementalMetadata,
-) -> Result<usize, FerroError> {
-    let lengths = supplemental_fasta_lengths(fasta_path)?;
-    let mut repaired = 0usize;
-    for (accession, record) in metadata.transcripts.iter_mut() {
-        let Some(&bases) = lengths.get(accession) else {
-            continue;
-        };
-        if record.sequence_length != bases {
-            record.sequence_length = bases;
-            repaired += 1;
-        }
-    }
-    Ok(repaired)
-}
-
-/// Write the sidecar to `path` atomically: a temp file, `fsync`, then a rename over it.
-///
-/// Used for the repair path, where the FASTA and its index are already correct and only the
-/// derived sidecar is stale. Routing that through a full commit instead would re-emit the
-/// FASTA — 1.3 GB on the shipped artifact — to change one number per row in a 24 MB file
-/// beside it, and would move the mtime of two artifacts that did not change.
-fn write_supplemental_metadata(
-    path: &Path,
-    metadata: &SupplementalMetadata,
-) -> Result<(), FerroError> {
-    let json = serde_json::to_vec_pretty(metadata).map_err(|e| FerroError::Json {
-        msg: format!("Failed to serialize {}: {}", path.display(), e),
-    })?;
-    let mut tmp = std::ffi::OsString::from(path.as_os_str());
-    tmp.push(".tmp");
-    let tmp = PathBuf::from(tmp);
-    {
-        let mut file = File::create(&tmp).map_err(|e| FerroError::Io {
-            msg: format!("Failed to create {}: {}", tmp.display(), e),
-        })?;
-        std::io::Write::write_all(&mut file, &json).map_err(|e| FerroError::Io {
-            msg: format!("Failed to write {}: {}", tmp.display(), e),
-        })?;
-        file.sync_all().map_err(|e| FerroError::Io {
-            msg: format!("Failed to sync {}: {}", tmp.display(), e),
-        })?;
-    }
-    std::fs::rename(&tmp, path).map_err(|e| FerroError::Io {
-        msg: format!(
-            "Failed to install {} over {}: {}",
-            tmp.display(),
-            path.display(),
-            e
-        ),
     })
 }
 
@@ -2258,15 +2106,13 @@ pub fn fetch_fasta_to_file(
 ///
 /// # Repair, and why it is not a fetch
 ///
-/// A sidecar row can be **hollow** — `sequence_length: 0` for an accession whose bases are
-/// on disk (#1722). That is a stale *derived* field, not a missing fetch, so it is repaired
-/// from the FASTA by [`repair_derived_lengths`] before anything is fetched. **Never fetch
-/// to recover a value you can compute:** every hollow accession in the shipped artifact is
-/// already in the FASTA, so widening the resume filter to admit them would be a
-/// 116,572-accession round trip against a rate-limited endpoint to learn a number that is
-/// one sequential read away.
+/// The sidecar carries only *sourced* fields, so there is no derived length to fall stale or
+/// go "hollow" (#1722) and nothing to re-derive here before a fetch — R4 dropped the persisted
+/// `sequence_length`, and every consumer reads length from the FASTA index directly. Presence
+/// is a question about the FASTA, and the resume filter is keyed on it (#1791); a metadata row
+/// is an annotation claim, not a sequence.
 ///
-/// A run with nothing to fetch and nothing to repair writes no byte at all.
+/// A run with nothing to fetch writes no byte at all.
 pub fn fetch_fasta_to_file_with(
     accessions: &[String],
     output_file: &Path,
@@ -2348,24 +2194,6 @@ pub fn fetch_fasta_to_file_with(
     // reset to empty — see `load_supplemental_metadata`.
     let mut metadata = load_supplemental_metadata(&metadata_path)?;
 
-    // Re-derive stale `sequence_length` values from the FASTA before deciding anything
-    // else. This runs first so a fetch's own inserts, and the commit's reconciliation,
-    // both see repaired rows; and it runs unconditionally so a hollow row is repaired
-    // whether or not this run has anything to fetch.
-    let hollow_before = metadata.hollow_record_count();
-    let repaired = repair_derived_lengths(output_file, &mut metadata)?;
-    if repaired > 0 {
-        eprintln!(
-            "  Re-derived sequence_length for {} of {} records in {} from {} ({} were hollow); \
-             no fetch is needed for a derived field",
-            repaired,
-            metadata.transcripts.len(),
-            metadata_path.display(),
-            output_file.display(),
-            hollow_before
-        );
-    }
-
     let duplicates = store.duplicate_record_count();
     if duplicates > 0 {
         eprintln!(
@@ -2389,11 +2217,10 @@ pub fn fetch_fasta_to_file_with(
             "  All {} accessions already fetched (skipping)",
             original_count
         );
-        // Nothing to fetch is not necessarily nothing to do: a duplicate-bearing FASTA, a
-        // sidecar whose keys have drifted from it, or a row whose derived length was stale
-        // is repaired here. When none of those holds, this is the fixed point and not one
-        // byte is written.
-        if let Some(report) = commit_or_repair(store, &mut metadata, &metadata_path, repaired)? {
+        // Nothing to fetch is not necessarily nothing to do: a duplicate-bearing FASTA, or a
+        // sidecar whose keys have drifted from it, is reconciled here. When neither holds,
+        // this is the fixed point and not one byte is written.
+        if let Some(report) = commit_if_dirty(store, &mut metadata)? {
             eprintln!(
                 "  Repaired {}: {} records, {} duplicates removed, {} metadata rows dropped, {} synthesized",
                 output_file.display(),
@@ -2402,8 +2229,6 @@ pub fn fetch_fasta_to_file_with(
                 report.metadata_rows_dropped,
                 report.metadata_rows_synthesized
             );
-        } else if repaired > 0 {
-            eprintln!("  Wrote repaired metadata to {}", metadata_path.display());
         }
         return Ok(0);
     }
@@ -2487,7 +2312,6 @@ pub fn fetch_fasta_to_file_with(
                             },
                             cds_start,
                             cds_end,
-                            sequence_length: seq.len(),
                         },
                     );
 
@@ -2539,7 +2363,6 @@ pub fn fetch_fasta_to_file_with(
                                         },
                                         cds_start: None,
                                         cds_end: None,
-                                        sequence_length: current_seq.len(),
                                     },
                                 );
 
@@ -2571,7 +2394,6 @@ pub fn fetch_fasta_to_file_with(
                                 },
                                 cds_start: None,
                                 cds_end: None,
-                                sequence_length: current_seq.len(),
                             },
                         );
 
@@ -2620,7 +2442,7 @@ pub fn fetch_fasta_to_file_with(
     // Gated on `is_dirty` rather than unconditional: reaching here having staged nothing
     // is a real outcome — every batch can fail against a down or rate-limiting endpoint —
     // and a failed run must not rewrite the artifact it could not add to.
-    if let Some(report) = commit_or_repair(store, &mut metadata, &metadata_path, repaired)? {
+    if let Some(report) = commit_if_dirty(store, &mut metadata)? {
         eprintln!(
             "  Committed {} records to {} ({} replaced, {} duplicates removed)",
             report.records,
@@ -2629,37 +2451,26 @@ pub fn fetch_fasta_to_file_with(
             report.duplicates_removed
         );
         eprintln!("  Wrote metadata to {}", metadata_path.display());
-    } else if repaired > 0 {
-        eprintln!("  Wrote repaired metadata to {}", metadata_path.display());
     }
 
     Ok(fetched)
 }
 
-/// Persist whatever needs persisting, and nothing more.
+/// Commit when there is something to commit, and nothing more.
 ///
-/// A **commit** when the FASTA or its index has moved or the sidecar's key set disagrees
-/// with it: that is the merge-and-rename which makes all three artifacts consistent, and it
-/// carries any repaired rows out with it, since `commit` preserves the rows it already has.
+/// A **commit** — the merge-and-rename that makes the FASTA, its index, and the sidecar
+/// consistent — runs when the FASTA or its index has moved or the sidecar's key set disagrees
+/// with it. Otherwise every artifact is already the fixed point and nothing is written: the
+/// sidecar carries only sourced fields, so once its key set agrees with the FASTA there is no
+/// derived value left to fall stale and no reason to rewrite it.
 ///
-/// A **sidecar-only write** when the FASTA and its index are already the fixed point and the
-/// only thing that moved is a derived row. Repairing 116,572 lengths must not re-emit a
-/// 1.3 GB FASTA and a 4.9 MB index that are byte-for-byte correct; and the authority rule
-/// says the same thing from the other side — the sidecar is derived from the FASTA, so
-/// correcting the derived artifact is not a reason to rewrite the authoritative one.
-///
-/// `Ok(None)` means no commit was performed, which is the fixed point when `repaired` is 0.
-fn commit_or_repair(
+/// `Ok(None)` means the store was already the fixed point.
+fn commit_if_dirty(
     store: crate::benchmark::supplemental_store::SupplementalStore,
     metadata: &mut SupplementalMetadata,
-    metadata_path: &Path,
-    repaired: usize,
 ) -> Result<Option<crate::benchmark::supplemental_store::CommitReport>, FerroError> {
     if store.is_dirty(metadata) {
         return Ok(Some(store.commit(metadata)?));
-    }
-    if repaired > 0 {
-        write_supplemental_metadata(metadata_path, metadata)?;
     }
     Ok(None)
 }
@@ -4800,165 +4611,57 @@ fn save_protein_fasta(cache_dir: &Path, accession: &str, sequence: &str) -> Resu
 mod supplemental_metadata_tests {
     use super::*;
 
-    /// A sidecar row carrying no sequence length — the shape 116,572 of the shipped
-    /// `patterns_transcripts.metadata.json`'s 140,027 rows have (#1722).
-    fn hollow_row(accession: &str) -> SupplementalTranscript {
-        SupplementalTranscript {
-            id: accession.to_string(),
-            gene_symbol: Some("GENEA".to_string()),
-            cds_start: None,
-            cds_end: None,
-            sequence_length: 0,
-        }
-    }
-
-    fn metadata_with(rows: Vec<SupplementalTranscript>) -> SupplementalMetadata {
-        let mut metadata = SupplementalMetadata::empty();
-        for row in rows {
-            metadata.transcripts.insert(row.id.clone(), row);
-        }
-        metadata
-    }
-
-    /// Write a FASTA holding the given `(accession, description, sequence)` records, wrapped
-    /// so the reader has to sum several sequence lines per record.
-    fn write_fasta(path: &Path, records: &[(&str, &str, &str)]) {
-        let mut body = String::new();
-        for (accession, description, sequence) in records {
-            body.push_str(&format!(">{} {}\n", accession, description));
-            for chunk in sequence.as_bytes().chunks(4) {
-                body.push_str(std::str::from_utf8(chunk).unwrap());
-                body.push('\n');
-            }
-        }
-        std::fs::write(path, body).unwrap();
-    }
-
-    /// A wrapped record's length is the sum of its sequence lines, and the accession is the
-    /// header up to its first space.
+    /// R4: `sequence_length` is a **derived** field whose authority is the FASTA, so it is
+    /// not persisted. A "hollow" row — one that claims a length it has no bases behind —
+    /// is therefore *unrepresentable*: the type carries only sourced fields, and the
+    /// serialized sidecar has no length key at all for a later run to find stale or zero.
     #[test]
-    fn a_records_length_is_summed_across_its_wrapped_lines() {
-        let dir = tempfile::tempdir().unwrap();
-        let fasta = dir.path().join("supp.fna");
-        write_fasta(
-            &fasta,
-            &[
-                ("NM_000001.1", "GENEA (variant 1)", "ACGTACGTAC"),
-                ("NR_000002.1", "GENEB", "TTTT"),
-            ],
-        );
-
-        let lengths = supplemental_fasta_lengths(&fasta).unwrap();
-
-        assert_eq!(lengths.get("NM_000001.1"), Some(&10));
-        assert_eq!(lengths.get("NR_000002.1"), Some(&4));
-    }
-
-    /// An absent FASTA is a genuine first run, not a failure.
-    #[test]
-    fn an_absent_fasta_yields_no_lengths() {
-        let dir = tempfile::tempdir().unwrap();
-
-        let lengths = supplemental_fasta_lengths(&dir.path().join("absent.fna")).unwrap();
-
-        assert!(lengths.is_empty());
-    }
-
-    /// #1722, stated at the level the repair works at: a hollow row's `sequence_length` is
-    /// **derived**, so it comes back from the FASTA and never from a fetch.
-    #[test]
-    fn a_hollow_row_gets_its_length_back_from_the_fasta() {
-        let dir = tempfile::tempdir().unwrap();
-        let fasta = dir.path().join("supp.fna");
-        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
-        let mut metadata = metadata_with(vec![hollow_row("NM_000001.1")]);
-
-        let repaired = repair_derived_lengths(&fasta, &mut metadata).unwrap();
-
-        assert_eq!(repaired, 1);
-        assert_eq!(metadata.transcripts["NM_000001.1"].sequence_length, 10);
-        assert_eq!(metadata.hollow_record_count(), 0);
-    }
-
-    /// The other half of the derived/sourced split, and the reason this repair is safe to
-    /// run over a whole artifact: a FASTA cannot supply a CDS, so the repair must not
-    /// invent one, and must not disturb a `gene_symbol` that a GenBank record supplied.
-    #[test]
-    fn a_sourced_field_is_left_exactly_as_it_was() {
-        let dir = tempfile::tempdir().unwrap();
-        let fasta = dir.path().join("supp.fna");
-        write_fasta(&fasta, &[("NM_000001.1", "SOMETHING ELSE", "ACGTACGTAC")]);
-        let mut metadata = metadata_with(vec![SupplementalTranscript {
+    fn a_persisted_row_cannot_carry_a_derived_length() {
+        let row = SupplementalTranscript {
             id: "NM_000001.1".to_string(),
             gene_symbol: Some("GENEA".to_string()),
-            cds_start: Some(2),
-            cds_end: Some(7),
-            sequence_length: 0,
-        }]);
-
-        repair_derived_lengths(&fasta, &mut metadata).unwrap();
-
-        let row = &metadata.transcripts["NM_000001.1"];
-        assert_eq!(row.sequence_length, 10, "the derived field is re-derived");
-        assert_eq!(row.cds_start, Some(2), "a sourced field is untouched");
-        assert_eq!(row.cds_end, Some(7));
+            cds_start: Some(1),
+            cds_end: Some(9),
+        };
+        let json = serde_json::to_value(&row).unwrap();
+        assert!(
+            json.get("sequence_length").is_none(),
+            "the derived length must not be persisted: {json}"
+        );
+        // The sourced annotation is still carried.
+        assert_eq!(json.get("cds_start").and_then(|v| v.as_u64()), Some(1));
         assert_eq!(
-            row.gene_symbol.as_deref(),
-            Some("GENEA"),
-            "gene_symbol is sourced from a GenBank record, not from a FASTA description"
+            json.get("gene_symbol").and_then(|v| v.as_str()),
+            Some("GENEA")
         );
     }
 
-    /// A row the FASTA has no record for is an orphan, and dropping it belongs to the
-    /// store's key-set reconciliation. The repair must not fabricate a length of zero for
-    /// it, nor count it as repaired.
+    /// A sidecar written before R4 still carries `sequence_length`. Loading it must not
+    /// fail — serde ignores the now-unknown key — and the derived value is simply dropped,
+    /// because nothing in the type can hold it.
     #[test]
-    fn a_row_with_no_fasta_record_is_left_alone() {
-        let dir = tempfile::tempdir().unwrap();
-        let fasta = dir.path().join("supp.fna");
-        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGT")]);
-        let mut metadata = metadata_with(vec![hollow_row("NM_999999.9")]);
-
-        let repaired = repair_derived_lengths(&fasta, &mut metadata).unwrap();
-
-        assert_eq!(repaired, 0);
-        assert_eq!(metadata.transcripts["NM_999999.9"].sequence_length, 0);
+    fn an_older_sidecar_that_still_carries_a_length_loads_without_it() {
+        let old = r#"{
+            "generated_at": "2026-01-06T00:00:00Z",
+            "transcripts": {
+                "NM_000001.1": {
+                    "id": "NM_000001.1",
+                    "gene_symbol": "GENEA",
+                    "cds_start": 1,
+                    "cds_end": 9,
+                    "sequence_length": 9
+                }
+            }
+        }"#;
+        let metadata: SupplementalMetadata = serde_json::from_str(old).unwrap();
+        let row = &metadata.transcripts["NM_000001.1"];
+        assert_eq!(row.cds_start, Some(1));
+        assert_eq!(row.gene_symbol.as_deref(), Some("GENEA"));
     }
 
-    /// The repair is a fixed point after one pass, which is what lets the caller use
-    /// "anything was repaired" as its only reason to write the sidecar.
-    #[test]
-    fn a_second_repair_pass_moves_nothing() {
-        let dir = tempfile::tempdir().unwrap();
-        let fasta = dir.path().join("supp.fna");
-        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
-        let mut metadata = metadata_with(vec![hollow_row("NM_000001.1")]);
-
-        assert_eq!(repair_derived_lengths(&fasta, &mut metadata).unwrap(), 1);
-        assert_eq!(repair_derived_lengths(&fasta, &mut metadata).unwrap(), 0);
-    }
-
-    /// A duplicate-bearing FASTA is repaired from its **first** record, because that is the
-    /// one `SupplementalStore::commit` keeps. Reading it the other way round would repair a
-    /// row to a length the commit is about to discard.
-    #[test]
-    fn a_duplicate_bearing_fasta_repairs_from_the_record_the_commit_keeps() {
-        let dir = tempfile::tempdir().unwrap();
-        let fasta = dir.path().join("supp.fna");
-        write_fasta(
-            &fasta,
-            &[
-                ("NM_000001.1", "GENEA", "ACGTACGTAC"),
-                ("NM_000001.1", "GENEA", "ACGT"),
-            ],
-        );
-        let mut metadata = metadata_with(vec![hollow_row("NM_000001.1")]);
-
-        repair_derived_lengths(&fasta, &mut metadata).unwrap();
-
-        assert_eq!(metadata.transcripts["NM_000001.1"].sequence_length, 10);
-    }
-
+    /// A sidecar row carrying no CDS annotation — the shape 116,572 of the shipped
+    /// `patterns_transcripts.metadata.json`'s 140,027 rows have (#1722): a gene symbol
+    /// and nothing else. Its length is not "missing" — it is sourced from the FASTA index.
     /// An absent sidecar is the legitimate "nothing has been fetched yet" state and must
     /// stay silent.
     #[test]
@@ -5005,30 +4708,5 @@ mod supplemental_metadata_tests {
 
         assert!(load_supplemental_metadata(&absent).is_ok());
         assert!(load_supplemental_metadata(&corrupt).is_err());
-    }
-
-    /// The sidecar write is atomic and leaves no temp file behind, so an interrupted repair
-    /// cannot be what produces the corrupt sidecar the loader above refuses.
-    #[test]
-    fn the_repaired_sidecar_is_written_atomically_and_reads_back() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("patterns_transcripts.metadata.json");
-        let mut metadata = metadata_with(vec![hollow_row("NM_000001.1")]);
-        metadata
-            .transcripts
-            .get_mut("NM_000001.1")
-            .unwrap()
-            .sequence_length = 10;
-
-        write_supplemental_metadata(&path, &metadata).unwrap();
-
-        let reloaded = load_supplemental_metadata(&path).unwrap();
-        assert_eq!(reloaded.transcripts["NM_000001.1"].sequence_length, 10);
-        assert!(
-            !dir.path()
-                .join("patterns_transcripts.metadata.json.tmp")
-                .exists(),
-            "the temp file is renamed, not left behind"
-        );
     }
 }

--- a/src/benchmark/supplemental_store.rs
+++ b/src/benchmark/supplemental_store.rs
@@ -21,11 +21,11 @@
 //! | `<name>.fna.fai` | derived | rebuilt from the committed FASTA on every commit |
 //! | `<name>.metadata.json` | derived *key set*, carried-forward CDS annotation | keys reconciled against the FASTA on every commit; a missing row is synthesized from the FASTA record |
 //!
-//! The sidecar is not *fully* derived and this module does not pretend it is: CDS
-//! coordinates come from a GenBank record and cannot be recovered from a FASTA. What is
-//! derived is the sidecar's **key set** and each row's `sequence_length` — which is
-//! precisely the part that was being asked the presence question. A row whose CDS
-//! annotation already exists is carried forward untouched.
+//! The sidecar persists only *sourced* fields — CDS coordinates and gene symbol come from a
+//! GenBank record and cannot be recovered from a FASTA. What is derived is the sidecar's
+//! **key set**, reconciled against the FASTA on every commit; a row's length is derived too,
+//! but it is no longer persisted (R4) — it is read from the FASTA index at the point of use.
+//! A row whose CDS annotation already exists is carried forward untouched.
 //!
 //! # Why the FASTA and not the `.fai`
 //!
@@ -155,13 +155,15 @@ impl FastaRecord {
     }
 
     /// The sidecar row this record implies on its own, carrying no CDS annotation.
+    ///
+    /// Its length is not carried here: the sidecar persists only sourced fields (R4), and
+    /// length is read from the FASTA index wherever it is needed.
     fn synthesized_metadata(&self) -> SupplementalTranscript {
         SupplementalTranscript {
             id: self.accession.clone(),
             gene_symbol: self.gene_symbol(),
             cds_start: None,
             cds_end: None,
-            sequence_length: self.sequence.len(),
         }
     }
 }
@@ -840,25 +842,24 @@ mod tests {
         }
     }
 
-    /// A sidecar row carrying neither a CDS nor a length — the shape 116,572 of the
-    /// shipped artifact's 140,027 rows have.
-    fn hollow_row(accession: &str) -> SupplementalTranscript {
+    /// A sidecar row carrying no CDS annotation — the shape 116,572 of the shipped
+    /// artifact's 140,027 rows had (#1722): a gene symbol at most, and no CDS. Its length is
+    /// not "missing"; it is sourced from the FASTA index and never persisted here (R4).
+    fn annotation_free_row(accession: &str) -> SupplementalTranscript {
         SupplementalTranscript {
             id: accession.to_string(),
             gene_symbol: None,
             cds_start: None,
             cds_end: None,
-            sequence_length: 0,
         }
     }
 
-    fn annotated_row(accession: &str, cds: (u64, u64), length: usize) -> SupplementalTranscript {
+    fn annotated_row(accession: &str, cds: (u64, u64)) -> SupplementalTranscript {
         SupplementalTranscript {
             id: accession.to_string(),
             gene_symbol: Some("GENEA".to_string()),
             cds_start: Some(cds.0),
             cds_end: Some(cds.1),
-            sequence_length: length,
         }
     }
 
@@ -929,7 +930,7 @@ mod tests {
 
         let store = SupplementalStore::open(&fasta).unwrap();
 
-        // Bases on disk, sidecar row hollow -> still present. This is the accession the
+        // Bases on disk, sidecar row annotation-free -> still present. This is the accession the
         // issue's suggested acceptance test is about.
         assert!(store.has_sequence("NM_000001.1"));
         // A sidecar row with no FASTA record is not presence: the sidecar is not asked.
@@ -950,7 +951,10 @@ mod tests {
                 ("NM_000002.1", "", "CCCC"),
             ],
         );
-        let mut meta = metadata(vec![hollow_row("NM_000001.1"), hollow_row("NM_000002.1")]);
+        let mut meta = metadata(vec![
+            annotation_free_row("NM_000001.1"),
+            annotation_free_row("NM_000002.1"),
+        ]);
 
         let mut store = SupplementalStore::open(&fasta).unwrap();
         store
@@ -981,7 +985,10 @@ mod tests {
                 ("NM_000001.1", "GENEA", "AAAA"),
             ],
         );
-        let mut meta = metadata(vec![hollow_row("NM_000001.1"), hollow_row("NM_000002.1")]);
+        let mut meta = metadata(vec![
+            annotation_free_row("NM_000001.1"),
+            annotation_free_row("NM_000002.1"),
+        ]);
 
         let store = SupplementalStore::open(&fasta).unwrap();
         assert_eq!(store.duplicate_record_count(), 2);
@@ -1017,7 +1024,7 @@ mod tests {
             "staged bases are on disk"
         );
 
-        let mut meta = metadata(vec![hollow_row("NM_000001.1")]);
+        let mut meta = metadata(vec![annotation_free_row("NM_000001.1")]);
         assert!(store.is_dirty(&meta));
         store.commit(&mut meta).unwrap();
 
@@ -1031,7 +1038,7 @@ mod tests {
         let fasta = dir.path().join("supp.fna");
         write_fasta(&fasta, &[("NM_000001.1", "GENEA (variant 1)", "AAAACCCC")]);
         // One orphan row (no FASTA record) and no row at all for the record that exists.
-        let mut meta = metadata(vec![hollow_row("NM_999999.9")]);
+        let mut meta = metadata(vec![annotation_free_row("NM_999999.9")]);
 
         let store = SupplementalStore::open(&fasta).unwrap();
         assert!(store.is_dirty(&meta), "key sets disagree");
@@ -1041,7 +1048,6 @@ mod tests {
         assert_eq!(report.metadata_rows_synthesized, 1);
         assert_eq!(meta.transcripts.len(), 1);
         let row = &meta.transcripts["NM_000001.1"];
-        assert_eq!(row.sequence_length, 8);
         assert_eq!(row.gene_symbol.as_deref(), Some("GENEA"));
         assert_eq!(row.cds_start, None, "a FASTA cannot supply a CDS");
     }
@@ -1054,8 +1060,8 @@ mod tests {
         let fasta = dir.path().join("supp.fna");
         write_fasta(&fasta, &[("NM_000001.1", "GENEA", "AAAACCCC")]);
         let mut meta = metadata(vec![
-            annotated_row("NM_000001.1", (2, 7), 8),
-            hollow_row("NM_999999.9"),
+            annotated_row("NM_000001.1", (2, 7)),
+            annotation_free_row("NM_999999.9"),
         ]);
 
         SupplementalStore::open(&fasta)
@@ -1073,11 +1079,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let fasta = dir.path().join("supp.fna");
         write_fasta(&fasta, &[("NM_000001.1", "GENEA", "AAAA")]);
-        // A hollow row is still a row, so the key sets agree and this predicate is
-        // satisfied. Whether that row's DERIVED `sequence_length` is stale is PR #1732's
-        // question, and it is deliberately not a term here: re-deriving it from the FASTA
-        // rewrites only the sidecar, so it must not make a 1.3 GB artifact dirty.
-        let meta = metadata(vec![hollow_row("NM_000001.1")]);
+        // An annotation-free row is still a row, so the key sets agree and this predicate
+        // is satisfied. Length is not a term here at all: it is not persisted (R4), so a
+        // sidecar carrying only sourced fields cannot drift on it and force a rewrite.
+        let meta = metadata(vec![annotation_free_row("NM_000001.1")]);
         // A complete artifact carries its index; without one the store is dirty, which
         // `a_missing_or_drifted_index_makes_the_store_dirty` pins separately.
         std::fs::write(
@@ -1255,7 +1260,7 @@ mod tests {
         // sidecar-keyed resume filter skips correctly. The tests that are red on the old
         // behaviour are the ones seeded from a state where the two disagree —
         // `an_accession_in_the_fasta_but_missing_from_the_sidecar_is_not_re_fetched` and
-        // `a_duplicate_bearing_artifact_is_repaired_and_then_stable`. Do not delete those
+        // `a_duplicate_bearing_artifact_is_reconciled_and_then_stable`. Do not delete those
         // as redundant with this one.
         let dir = tempfile::tempdir().unwrap();
         let fasta = dir.path().join("supp.fna");
@@ -1318,24 +1323,29 @@ mod tests {
             vec!["NM_000001.1"],
             "the FASTA gained no second record"
         );
-        // The run still repaired the sidecar, because its key set had drifted.
-        let repaired: SupplementalMetadata =
+        // The run still reconciled the sidecar, because its key set had drifted: the
+        // missing row is synthesized from the FASTA record.
+        let reconciled: SupplementalMetadata =
             serde_json::from_slice(&std::fs::read(metadata_path_for(&fasta)).unwrap()).unwrap();
-        assert_eq!(repaired.transcripts.len(), 1);
-        assert_eq!(repaired.transcripts["NM_000001.1"].sequence_length, 10);
+        assert_eq!(reconciled.transcripts.len(), 1);
+        assert!(reconciled.transcripts.contains_key("NM_000001.1"));
     }
 
     #[test]
-    fn a_hollow_sidecar_row_does_not_produce_a_second_fasta_record() {
-        // The issue's own suggested acceptance test: run the resume filter over a cohort
-        // containing a hollow row whose sequence is already in the FASTA, and assert the
-        // FASTA gains no second header for it.
+    fn an_annotation_free_sidecar_row_does_not_produce_a_second_fasta_record() {
+        // #1722's suggested acceptance test, and R4's stronger invariant stated over it:
+        // run the resume filter over a cohort containing an annotation-free row whose
+        // sequence is already in the FASTA. The FASTA must gain no second header, and — the
+        // stronger claim — the whole artifact must be a fixed point that touches nothing and
+        // makes no source call. Length is no longer persisted (R4), so there is no derived
+        // field left to fall stale and repair, which is precisely why every artifact,
+        // sidecar included, is byte-identical afterwards.
         let dir = tempfile::tempdir().unwrap();
         let fasta = dir.path().join("supp.fna");
         write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
         std::fs::write(
             metadata_path_for(&fasta),
-            serde_json::to_vec_pretty(&metadata(vec![hollow_row("NM_000001.1")])).unwrap(),
+            serde_json::to_vec_pretty(&metadata(vec![annotation_free_row("NM_000001.1")])).unwrap(),
         )
         .unwrap();
         // A complete artifact has an index too; it is part of what must not move.
@@ -1351,105 +1361,25 @@ mod tests {
         fetch_fasta_to_file_with(&["NM_000001.1".to_string()], &fasta, false, &source).unwrap();
 
         assert_eq!(headers(&fasta), vec!["NM_000001.1"]);
-        assert_eq!(source.calls(), 0);
-        // Key sets already agreed, so the FASTA and its index were already the fixed point
-        // and neither is rewritten. The sidecar is: #1732 re-derives the hollow row's
-        // `sequence_length` from the FASTA, which is a **derived** field and therefore
-        // repairable with no source call — which is why `source.calls()` above is still 0.
-        // Pinned by `a_hollow_sidecar_row_is_repaired_from_the_fasta_without_a_fetch`.
-        assert_eq!(
-            before[..2],
-            artifact_state(&fasta)[..2],
-            "repairing a derived field must not rewrite the authoritative FASTA or its index"
-        );
-    }
-
-    #[test]
-    fn a_hollow_sidecar_row_is_repaired_from_the_fasta_without_a_fetch() {
-        // #1722's producer half, and the ruling it was fixed under: **never fetch to
-        // recover a value you can compute**. `sequence_length` is derived — every site
-        // that builds a row sets it to the length of the sequence it just wrote — so a
-        // hollow row whose accession is already in the FASTA is a stale derived field, not
-        // a missing fetch. All 116,572 hollow rows of the shipped artifact are in its
-        // FASTA, which is why #1791's presence-keyed resume filter admits none of them and
-        // why the repair has to be local.
-        let dir = tempfile::tempdir().unwrap();
-        let fasta = dir.path().join("supp.fna");
-        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
-        std::fs::write(
-            metadata_path_for(&fasta),
-            serde_json::to_vec_pretty(&metadata(vec![hollow_row("NM_000001.1")])).unwrap(),
-        )
-        .unwrap();
-        std::fs::write(
-            sibling_with_suffix(&fasta, ".fai"),
-            "NM_000001.1\t10\t19\t10\t11\n",
-        )
-        .unwrap();
-
-        let source = FakeEfetch::new(&[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
-        fetch_fasta_to_file_with(&["NM_000001.1".to_string()], &fasta, false, &source).unwrap();
-
         assert_eq!(
             source.calls(),
             0,
-            "a derived field is computed from the FASTA, never fetched"
-        );
-        let repaired: SupplementalMetadata =
-            serde_json::from_slice(&std::fs::read(metadata_path_for(&fasta)).unwrap()).unwrap();
-        let row = &repaired.transcripts["NM_000001.1"];
-        assert_eq!(
-            row.sequence_length, 10,
-            "the hollow row is no longer hollow"
+            "presence is a FASTA question; a row already on disk is never fetched"
         );
         assert_eq!(
-            row.cds_start, None,
-            "a CDS is sourced from GenBank and stays absent"
-        );
-    }
-
-    #[test]
-    fn a_repaired_sidecar_is_the_fixed_point_on_the_next_run() {
-        // The repair must converge, or every provisioning run rewrites a 24 MB sidecar for
-        // nothing. Seeded from the damaged state, as this module's fixed-point tests are.
-        let dir = tempfile::tempdir().unwrap();
-        let fasta = dir.path().join("supp.fna");
-        write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
-        std::fs::write(
-            metadata_path_for(&fasta),
-            serde_json::to_vec_pretty(&metadata(vec![hollow_row("NM_000001.1")])).unwrap(),
-        )
-        .unwrap();
-        std::fs::write(
-            sibling_with_suffix(&fasta, ".fai"),
-            "NM_000001.1\t10\t19\t10\t11\n",
-        )
-        .unwrap();
-        let source = FakeEfetch::new(&[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
-        let requested = vec!["NM_000001.1".to_string()];
-
-        fetch_fasta_to_file_with(&requested, &fasta, false, &source).unwrap();
-        let repaired = artifact_state(&fasta);
-
-        fetch_fasta_to_file_with(&requested, &fasta, false, &source).unwrap();
-
-        assert_eq!(
-            repaired,
+            before,
             artifact_state(&fasta),
-            "a repaired artifact is the fixed point; the second run writes no byte"
+            "no artifact — FASTA, index, or sidecar — is rewritten when there is nothing to do"
         );
-        assert_eq!(source.calls(), 0);
     }
 
     #[test]
-    fn a_repair_survives_the_commit_that_runs_alongside_it() {
-        // The two repairs compose or they do not, and `commit` fills only *missing* rows
-        // (`or_insert_with`), so a row it already has is carried through as-is. That is
-        // what makes the ordering load-bearing: the derived lengths are re-derived BEFORE
-        // the commit, so the commit carries them out rather than preserving the hollow
-        // shape. Seeded from an artifact that is damaged in both ways at once — duplicate
-        // records AND hollow rows — because that is the only state where the interaction
-        // is observable.
+    fn a_duplicate_bearing_artifact_is_reconciled_and_then_stable() {
+        // The other route the shipped `.bak` took: a duplicate-bearing FASTA with
+        // annotation-free sidecar rows is reconciled — the duplicate collapsed — with no
+        // source call, and the reconciled artifact is then a fixed point rather than
+        // churning. A stale artifact is repaired from the FASTA it already holds, never
+        // from the network.
         let dir = tempfile::tempdir().unwrap();
         let fasta = dir.path().join("supp.fna");
         write_fasta(
@@ -1463,46 +1393,8 @@ mod tests {
         std::fs::write(
             metadata_path_for(&fasta),
             serde_json::to_vec_pretty(&metadata(vec![
-                hollow_row("NM_000001.1"),
-                hollow_row("NM_000002.1"),
-            ]))
-            .unwrap(),
-        )
-        .unwrap();
-
-        let source = FakeEfetch::new(&[]);
-        fetch_fasta_to_file_with(
-            &["NM_000001.1".to_string(), "NM_000002.1".to_string()],
-            &fasta,
-            false,
-            &source,
-        )
-        .unwrap();
-
-        let committed: SupplementalMetadata =
-            serde_json::from_slice(&std::fs::read(metadata_path_for(&fasta)).unwrap()).unwrap();
-        assert_eq!(committed.transcripts["NM_000001.1"].sequence_length, 10);
-        assert_eq!(committed.transcripts["NM_000002.1"].sequence_length, 4);
-        assert_eq!(source.calls(), 0);
-    }
-
-    #[test]
-    fn a_duplicate_bearing_artifact_is_repaired_and_then_stable() {
-        let dir = tempfile::tempdir().unwrap();
-        let fasta = dir.path().join("supp.fna");
-        write_fasta(
-            &fasta,
-            &[
-                ("NM_000001.1", "GENEA", "ACGTACGTAC"),
-                ("NM_000002.1", "GENEB", "TTTT"),
-                ("NM_000001.1", "GENEA", "ACGTACGTAC"),
-            ],
-        );
-        std::fs::write(
-            metadata_path_for(&fasta),
-            serde_json::to_vec_pretty(&metadata(vec![
-                hollow_row("NM_000001.1"),
-                hollow_row("NM_000002.1"),
+                annotation_free_row("NM_000001.1"),
+                annotation_free_row("NM_000002.1"),
             ]))
             .unwrap(),
         )
@@ -1513,11 +1405,11 @@ mod tests {
 
         fetch_fasta_to_file_with(&requested, &fasta, false, &source).unwrap();
         assert_eq!(headers(&fasta), vec!["NM_000001.1", "NM_000002.1"]);
-        let repaired = artifact_state(&fasta);
+        let reconciled = artifact_state(&fasta);
 
-        // Repair reaches a fixed point rather than churning.
+        // Reconciliation reaches a fixed point rather than churning.
         fetch_fasta_to_file_with(&requested, &fasta, false, &source).unwrap();
-        assert_eq!(repaired, artifact_state(&fasta));
+        assert_eq!(reconciled, artifact_state(&fasta));
         assert_eq!(source.calls(), 0);
     }
 
@@ -1560,7 +1452,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let fasta = dir.path().join("supp.fna");
         write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGT")]);
-        let meta = metadata(vec![hollow_row("NM_000001.1")]);
+        let meta = metadata(vec![annotation_free_row("NM_000001.1")]);
 
         // No index at all.
         assert!(SupplementalStore::open(&fasta).unwrap().is_dirty(&meta));
@@ -1590,14 +1482,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let fasta = dir.path().join("supp.fna");
         write_fasta(&fasta, &[("NM_000001.1", "GENEA", "ACGTACGTAC")]);
-        // Seeded with a HEALTHY row, whose length already agrees with the FASTA, so the
-        // only thing this test can observe is the failed fetch. A hollow row here would
-        // also make #1732's derived-length repair fire, and the sidecar would move for a
-        // reason that has nothing to do with the property being pinned — that repair is
-        // orthogonal and has its own tests.
+        // Seeded with a row whose key set already agrees with the FASTA, so the only thing
+        // this test can observe is the failed fetch and that a failed run rewrites nothing.
         std::fs::write(
             metadata_path_for(&fasta),
-            serde_json::to_vec_pretty(&metadata(vec![annotated_row("NM_000001.1", (1, 9), 10)]))
+            serde_json::to_vec_pretty(&metadata(vec![annotated_row("NM_000001.1", (1, 9))]))
                 .unwrap(),
         )
         .unwrap();

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -86,12 +86,16 @@ use crate::reference::provider::{AlignmentGap, GenomicPlacement, ReferenceProvid
 use crate::reference::transcript::Transcript;
 
 /// Supplemental transcript info for a single transcript.
+///
+/// Carries only the *sourced* fields the sidecar persists (R4): a curated CDS and gene
+/// symbol, which come from a GenBank record. The transcript's length is *derived* — its
+/// authority is the FASTA index — so it is not held here; every consumer that needs it reads
+/// it from the index at the point of use (see [`MultiFastaProvider::get_supplemental_cds_info`]).
 #[derive(Debug, Clone)]
 pub struct SupplementalTranscriptInfo {
     pub cds_start: Option<u64>,
     pub cds_end: Option<u64>,
     pub gene_symbol: Option<String>,
-    pub sequence_length: u64,
 }
 
 impl SupplementalTranscriptInfo {
@@ -113,12 +117,13 @@ impl SupplementalTranscriptInfo {
         self.cds_start.is_some() && self.cds_end.is_some()
     }
 
-    /// Whether the record carries a CDS bound or a length — the two fields any
-    /// transcript *geometry* could be built from.
+    /// Whether the record carries either CDS bound — the only *sourced* geometry a
+    /// supplemental row can add over the FASTA index.
     ///
-    /// Used at load to report how much of a supplemental artifact supplies neither,
-    /// rather than inserting such rows and letting `contains_key` imply they mean
-    /// something.
+    /// Used at load to report how much of a supplemental artifact supplies none, rather than
+    /// inserting such rows and letting `contains_key` imply they mean something. Length is no
+    /// longer a term: it is derived from the FASTA index and never persisted (R4), so it is
+    /// present for every row and could not distinguish one row from another.
     ///
     /// **`gene_symbol` is deliberately excluded, which is why this is not named
     /// "is informative".** It is not a dead field: [`Self::can_replace_cdot_table`]'s
@@ -129,8 +134,8 @@ impl SupplementalTranscriptInfo {
     /// this returns `false` for carries a `gene_symbol` (116,572 of 116,572), so
     /// calling that population "inert" would be the same presence-vs-usability
     /// conflation this type exists to stop, run the other way.
-    pub fn carries_cds_or_length(&self) -> bool {
-        self.cds_start.is_some() || self.cds_end.is_some() || self.sequence_length > 0
+    pub fn carries_a_cds_bound(&self) -> bool {
+        self.cds_start.is_some() || self.cds_end.is_some()
     }
 }
 
@@ -1229,7 +1234,7 @@ impl MultiFastaProvider {
                             if let Some(transcripts) =
                                 metadata.get("transcripts").and_then(|v| v.as_object())
                             {
-                                let mut without_cds_or_length = 0usize;
+                                let mut without_cds = 0usize;
                                 let mut with_cds = 0usize;
                                 for (accession, info) in transcripts {
                                     let cds_start = info.get("cds_start").and_then(|v| v.as_u64());
@@ -1238,18 +1243,17 @@ impl MultiFastaProvider {
                                         .get("gene_symbol")
                                         .and_then(|v| v.as_str())
                                         .map(|s| s.to_string());
-                                    let sequence_length = info
-                                        .get("sequence_length")
-                                        .and_then(|v| v.as_u64())
-                                        .unwrap_or(0);
+                                    // `sequence_length` is deliberately not read: it is a
+                                    // derived field the sidecar no longer persists (R4), and
+                                    // an older artifact that still carries it is ignored here
+                                    // because length is sourced from the FASTA index at use.
                                     let record = SupplementalTranscriptInfo {
                                         cds_start,
                                         cds_end,
                                         gene_symbol,
-                                        sequence_length,
                                     };
-                                    if !record.carries_cds_or_length() {
-                                        without_cds_or_length += 1;
+                                    if !record.carries_a_cds_bound() {
+                                        without_cds += 1;
                                     }
                                     if record.can_replace_cdot_table() {
                                         with_cds += 1;
@@ -1265,8 +1269,8 @@ impl MultiFastaProvider {
                                 let total = provider.supplemental_cds.transcripts.len();
                                 eprintln!(
                                     "Loaded {} supplemental transcripts ({} with a CDS, {} with \
-                                     neither a CDS nor a length)",
-                                    total, with_cds, without_cds_or_length
+                                     no CDS bound)",
+                                    total, with_cds, without_cds
                                 );
                                 // A supplemental artifact that carries almost no CDS is a
                                 // data defect, not a normal state, and it used to be
@@ -10602,7 +10606,6 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
                 cds_start: None,
                 cds_end: None,
                 gene_symbol: Some("GAPPY".to_string()),
-                sequence_length: 0,
             },
         );
 
@@ -10630,7 +10633,6 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
                 cds_start: Some(7),
                 cds_end: Some(24),
                 gene_symbol: Some("GAPPY".to_string()),
-                sequence_length: 0, // deliberately 0: the span comes from the index
             },
         );
 
@@ -10670,7 +10672,6 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
                     cds_start,
                     cds_end,
                     gene_symbol: Some("GAPPY".to_string()),
-                    sequence_length: 0,
                 },
             );
 
@@ -10708,21 +10709,20 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
         assert!(!artifact_is_largely_without_cds(usize::MAX, usize::MAX));
     }
 
-    /// `carries_cds_or_length` deliberately ignores `gene_symbol`, and the counter
+    /// `carries_a_cds_bound` deliberately ignores `gene_symbol`, and the counter
     /// it feeds is named for that. Pinned because the earlier spelling
     /// (`is_informative`, "carries any information at all") was measurably false:
     /// every one of the 116,572 records it returned `false` for on the shipped
     /// artifact carries a gene symbol, and that symbol IS propagated onto the
     /// served transcript.
     #[test]
-    fn carries_cds_or_length_ignores_the_gene_symbol_it_still_propagates() {
+    fn carries_a_cds_bound_ignores_the_gene_symbol_it_still_propagates() {
         let name_only = SupplementalTranscriptInfo {
             cds_start: None,
             cds_end: None,
             gene_symbol: Some("SHANK3".to_string()),
-            sequence_length: 0,
         };
-        assert!(!name_only.carries_cds_or_length());
+        assert!(!name_only.carries_a_cds_bound());
         assert!(!name_only.can_replace_cdot_table());
 
         // …and the symbol still reaches the served transcript, which is why the


### PR DESCRIPTION
Closes #1993.

## Load-time banner changes on the shipped artifact

Measured against `supplemental/patterns_transcripts.metadata.json` (140,027 rows, 24 MB) on the prepared reference:

```
before   carries_cds_or_length  ->  "116572 with neither a CDS nor a length"
after    carries_a_cds_bound    ->  "140008 with no CDS bound"
```

Both are correct statements of their own predicate, and the message text moves with it. The +23,436 is the rows that carried a non-zero persisted `sequence_length` and no CDS, which the old predicate excluded and the new one cannot see — 116,572 rows have `sequence_length: 0` and 19 have a CDS.

Flagged because an operator who knows the old banner will read the new one as a large regression, and it is not one. No threshold moves: the `artifact_is_largely_without_cds` warning gates on `with_cds`, which is unchanged.


Representation-Change: none. Type/persistence refactor of the benchmark supplemental sidecar; touches `src/reference/multi_fasta.rs` (a watched prefix) but changes no normalized HGVS output. No consumer of `Normalizer`/`VariantProjector` is affected, and the reference identity is unchanged (see below).

## The problem R4 names

The supplemental transcript sidecar (`patterns_transcripts.metadata.json`) persisted `sequence_length` as a field on `SupplementalTranscript`, and "hollow" (#1722) was a *value* of it — `sequence_length == 0` for an accession whose bases are actually on disk. Because the type could represent that state, the code had to detect it (`is_hollow`, `hollow_record_count`) and repair it from the FASTA before use (`repair_derived_lengths`, `supplemental_fasta_lengths`, `write_supplemental_metadata`, the `commit_or_repair` sidecar-only write). The shipped artifact carried 116,572 hollow rows of 140,027.

R4 (accepted operator ruling, the principled follow-up to #1732's tactical fix): drop `sequence_length` as a persisted field and let the FASTA index be its sole authority, so a hollow row becomes **unrepresentable** rather than detectable-and-repairable.

## Why this is a deletion, not a rewrite

#1722 had already routed the one real length consumer off the persisted field: `MultiFastaProvider::get_supplemental_cds_info` takes its `sequence_length` from `entry.length` (the FASTA index), not the sidecar. So the persisted `sequence_length` fed only the hollow/repair machinery and a load-time reporting heuristic. With the field gone there is no hollow state to detect or repair, and the whole repair pass is removed.

## Type before / after

`SupplementalTranscript` (persisted, `src/benchmark/cache.rs`):

```rust
// before
pub struct SupplementalTranscript { id, gene_symbol, cds_start, cds_end, sequence_length: usize }
// after — only sourced fields; a length-0 "hollow" row cannot be constructed
pub struct SupplementalTranscript { id, gene_symbol, cds_start, cds_end }
```

`SupplementalTranscriptInfo` (consumer, `src/reference/multi_fasta.rs`): `sequence_length: u64` dropped; `carries_cds_or_length` → `carries_a_cds_bound` (length is present for every row via the index, so it never distinguished rows); the load path no longer reads the JSON `sequence_length` key.

## Consumers changed

- `SupplementalStore::synthesized_metadata` — no longer sets a length.
- `fetch_fasta_to_file_with` — the re-derive/repair block is gone.
- `commit_or_repair` → `commit_if_dirty` — its sidecar-only-write branch was dead once repair was removed.
- Deleted: `is_hollow`, `hollow_record_count`, `repair_derived_lengths`, `supplemental_fasta_lengths`, `write_supplemental_metadata`.

## The stronger invariant (R4 second half)

"Repairing a derived field makes no source call" is now **structural** — there is no derived field to repair. Pinned by `an_annotation_free_sidecar_row_does_not_produce_a_second_fasta_record` (a fixed point with `source.calls() == 0` and every artifact byte-identical), and by a new `cache.rs` test asserting the serialized row carries no length key.

## Backward compatibility

A pre-R4 sidecar still carries `sequence_length`; serde ignores the now-unknown key on load, so existing on-disk artifacts read fine. Pinned by `an_older_sidecar_that_still_carries_a_length_loads_without_it`. A later commit that touches the sidecar drops the field; a run that only reads it does not rewrite it (no churn).

## Reference identity

Unchanged. The sidecar is not in `CONTENT_STAMPED_ARTIFACTS`, `supplemental_fasta` is explicitly excluded from stamping, and the basename is unchanged — so neither Part 1 (basenames) nor Part 2 (content stamps) of the identity moves. Blessed identity `aa8b3246d83055cc` is unaffected.

## Verification

- `cargo fmt --all --check` — clean.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- `cargo nextest run --features dev --no-fail-fast` — 11218 passed, 0 failed, 155 skipped.
