### PR TITLE
test(ci): derive the release tag gate's workflow set instead of naming it

### DIFF
--- a/tests/it/release_tag_gate.rs
+++ b/tests/it/release_tag_gate.rs
@@ -1,5 +1,5 @@
-//! Ties the tag release-plz will actually mint to the tag prefixes
-//! `release-wheels.yml` will actually accept.
+//! Ties the tag release-plz will actually mint to the tag prefixes **every**
+//! release-triggered workflow will actually accept.
 //!
 //! # The failure this exists for
 //!
@@ -26,17 +26,41 @@
 //! had to agree, living in two files, with nothing relating them. This test is
 //! that relation.
 //!
+//! # The second failure, which is why the workflow set is DERIVED
+//!
+//! The first version of this file named its subject: `const WHEELS_YML: &str =
+//! ".github/workflows/release-wheels.yml"`, with the gated and publishing job
+//! names hardcoded beside it. That is a roster, and a roster has the same drift
+//! problem one level up from the one this guard was written to close — a second
+//! release-triggered workflow is simply invisible to it.
+//!
+//! It did not stay hypothetical for long. #2055 added
+//! `release-binaries.yml`, carrying the same `release: published` trigger and a
+//! copy of the same gate, and **deleting that gate outright left all four of the
+//! old assertions passing, EXIT=0**. The workflow set is therefore derived from
+//! `.github/workflows/` rather than named, following the precedent
+//! `spec_fixture_setup_filter.rs` (#2033) sets: derive the set, assert equality
+//! in both directions, and floor it so a matcher that has gone blind cannot pass
+//! as "nothing to check".
+//!
+//! [`release_workflows`] keeps every `.github/workflows/*.{yml,yaml}` whose `on:`
+//! block declares a `release` trigger whose `types:` includes `published` — or
+//! declares no `types:` at all, which in GitHub Actions means every activity
+//! type. `publish.yml` triggers on `push: main` and is correctly out of scope.
+//!
 //! # What it does
 //!
 //! [`minted_tag`] derives the tag from the release configuration — from
 //! `release-plz.toml`'s `git_tag_name` when it is pinned (it is, to
 //! `v{{ version }}`), and otherwise by modelling release-plz's package-count
 //! default off `Cargo.toml`. [`gate_prefixes_for`] reads the `startsWith(…,
-//! '<prefix>')` literals out of **one** job's `if:` condition. The assertions
-//! are that every gated job accepts the minted tag, that no gated job accepts
-//! the `test-fixtures-v1` data release, that all four gated jobs carry the
-//! *same* gate, and that the two jobs which can publish still require a real
-//! `release` event.
+//! '<prefix>')` literals out of **one** job's `if:` condition.
+//!
+//! The assertions are that every job a release reaches *directly* is gated, that
+//! every gate accepts the minted tag, that no gate accepts the
+//! `test-fixtures-v1` data release, that every gate in every release workflow
+//! agrees on one prefix set, and that every job which can ship something still
+//! requires a real `release` event.
 //!
 //! The gate is deliberately narrow — one accepted prefix, matching the pinned
 //! format and nothing else. That is what makes this guard able to see the pin
@@ -44,16 +68,33 @@
 //! when the pin is reverted or deleted, which is a guard that has been
 //! configured not to ring.
 //!
+//! # A deleted gate is invisible to any check that iterates over gates
+//!
+//! This is the measurement that decides the shape of the file, and it is worth
+//! stating in one line because it is not obvious: **both** of the assertions
+//! that read every gate and check it — the minted-tag/data-release pair and the
+//! cross-workflow agreement — passed on a tree where the gate had been *deleted*
+//! from `release-binaries.yml`. They iterate over the gates they can find, and a
+//! deleted gate is not one of them.
+//!
+//! Only [`every_release_reachable_root_job_is_tag_gated`] fires, because it
+//! iterates over **jobs** and asks each one whether it is gated. It derives the
+//! root set — every job with no `needs:`, i.e. every job a release reaches
+//! without passing through another — which on `release-wheels.yml` is exactly
+//! `{linux, macos, windows, sdist}` and on `release-binaries.yml` is exactly
+//! `{build}`. That derivation is what lets the hardcoded `GATED_JOBS` roster be
+//! deleted rather than gain a sibling.
+//!
 //! # Everything is read per-job, and counted
 //!
 //! Two misses that a whole-workflow reading has, both of which reproduce real
 //! failure modes:
 //!
 //! - Unioning every job's prefixes into one set answers "does *some* job accept
-//!   this tag", when the question is "does *each* job accept it". These four are
-//!   siblings, not a chain — nothing downstream re-checks the tag, it only
-//!   `needs:` these four — so a gate dropped from one of four near-identical
-//!   blocks is a hole, and it is the v0.14.0 skip-chain verbatim.
+//!   this tag", when the question is "does *each* job accept it". The four wheel
+//!   builds are siblings, not a chain — nothing downstream re-checks the tag, it
+//!   only `needs:` those four — so a gate dropped from one of four
+//!   near-identical blocks is a hole, and it is the v0.14.0 skip-chain verbatim.
 //! - Reading only the `startsWith` literals ignores whatever *else* the
 //!   condition says. Someone repairing a too-narrow gate does not delete the arm
 //!   that works, they add breadth: `… || contains(tag_name, 'v')` is valid GHA,
@@ -75,16 +116,16 @@
 //!   the package-count model is never consulted.
 //! - **It does not check that the release was created with that tag.** A human
 //!   tagging by hand, or a release-plz run with a different config, is outside
-//!   what any test of these two files can see.
+//!   what any test of these files can see.
 //! - **`startsWith(tag, 'v')` still admits any `v`-prefixed name.** The pinned
 //!   format is all this repo will *mint*, but releases are also published here by
 //!   hand — `test-fixtures-v1` is one — under no naming rule, and a future
-//!   `validation-corpus-v1` would fire the whole matrix. GitHub expressions have
+//!   `validation-corpus-v1` would fire every matrix. GitHub expressions have
 //!   no regex, so requiring a digit after the `v` means either ten `'v0'…'v9'`
-//!   arms or hoisting the decision into a one-job `bash` regex the four jobs
-//!   consume through `needs:`. The second also removes the four-way duplication
-//!   above; both are follow-ups, deliberately not folded into a release-blocking
-//!   fix.
+//!   arms or hoisting the decision into a one-job `bash` regex the building jobs
+//!   consume through `needs:`. The second also removes the duplication across
+//!   sibling jobs; both are follow-ups, deliberately not folded into a
+//!   release-blocking fix.
 //! - **It does not check the rest of the pipeline.** A release can still skip
 //!   silently through a broken `needs:` chain, a downstream job-level `if:`, an
 //!   unapproved deployment environment, or a missing trusted-publisher config.
@@ -94,36 +135,91 @@
 //!   '…')` would make [`gate_prefixes_for`] read nothing — which is why every
 //!   extraction below asserts it found something, rather than letting an empty
 //!   read pass as agreement.
+//! - **[`RELEASE_UNREACHABLE_CONDITIONS`] is a closed list, not an evaluator.**
+//!   A root job whose `if:` cannot be true on a release needs no tag gate, but
+//!   deciding that in general means evaluating GitHub expressions. The list
+//!   holds the two spellings that mean it unambiguously; anything else must
+//!   carry the gate, so the failure direction is "a legitimate exemption is
+//!   rejected until somebody adds it", not "an ungated job passes".
 
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
-/// The workflow whose gate decides whether wheels get built and published.
-const WHEELS_YML: &str = ".github/workflows/release-wheels.yml";
+use serde_yaml::Value;
+
+/// Where the workflows live. The release-triggered subset is derived from this
+/// directory rather than named; see the module docs for the roster that used to
+/// sit here and what it missed.
+const WORKFLOW_DIR: &str = ".github/workflows";
 
 /// The release automation whose configuration decides what the tag is called.
 const RELEASE_PLZ_TOML: &str = "release-plz.toml";
 
-/// The four jobs that carry the gate. Everything else in the workflow reaches
-/// them through `needs:` and skips with them, which is why a wrong gate takes
-/// out the whole pipeline rather than one job.
-const GATED_JOBS: &[&str] = &["linux", "macos", "windows", "sdist"];
+/// The `release` activity type this repository's release workflows trigger on.
+/// A `release:` trigger declaring no `types:` at all fires on *every* activity
+/// type and so includes this one; [`release_trigger_types`] represents that as
+/// an empty set rather than as an absent trigger.
+const PUBLISHED: &str = "published";
 
-/// The two jobs that can ship something.
-const PUBLISHING_JOBS: &[&str] = &["upload", "publish-pypi"];
+/// A floor on the derived release-workflow set, so a parser that has silently
+/// stopped matching fails loudly rather than passing vacuously over an empty
+/// set — the direct analogue of `spec_fixture_setup_filter.rs`'s
+/// `MINIMUM_CONSUMERS`.
+///
+/// **One, not two, and deliberately.** `release-wheels.yml` is the only
+/// release-triggered workflow on `main` today; `release-binaries.yml` (#2055) is
+/// the second and has not landed. A floor of 2 would make this file red on the
+/// branch it is written for, which would make it un-landable except stacked on
+/// #2055 — and the point of deriving the set is that the two changes are
+/// independent. Raise it to 2 when `release-binaries.yml` lands; the floor's
+/// whole job (a blind derivation cannot read as "nothing to check") is done at
+/// 1 either way.
+const MINIMUM_RELEASE_WORKFLOWS: usize = 1;
+
+/// A floor on the derived publishing-job set, for the same reason. Today
+/// `release-wheels.yml`'s `upload` and `publish-pypi` supply both;
+/// `release-binaries.yml` adds a third.
+const MINIMUM_PUBLISHING_JOBS: usize = 2;
 
 /// The data release that hosts the bulk test corpora. It is published through
 /// the same `release: published` event, carries no code, and must never trigger
-/// a wheel build — it did once, and had to be cancelled by hand.
+/// a build matrix. It did once, and had to be cancelled by hand.
 const DATA_RELEASE_TAG: &str = "test-fixtures-v1";
 
-/// The `startsWith` call whose literal argument is a prefix this gate accepts.
+/// The `startsWith` call whose literal argument is a prefix a gate accepts.
 const GATE_CALL: &str = "startsWith(github.event.release.tag_name, '";
 
-/// The context the gate reads. Every mention of it in a gated job's condition
+/// The context a gate reads. Every mention of it in a gated job's condition
 /// must be inside a [`GATE_CALL`], or the guard is reading less than the gate
 /// says.
 const TAG_CONTEXT: &str = "tag_name";
+
+/// The condition a job that can ship something must carry.
+const RELEASE_EVENT: &str = "github.event_name == 'release'";
+
+/// The step text that marks a job as able to ship something, in `run:` scripts
+/// and in `uses:` action references alike.
+///
+/// Derived from what the jobs *do* rather than from a roster of job names, which
+/// is the same argument the workflow set is derived on: `PUBLISHING_JOBS` used
+/// to name `["upload", "publish-pypi"]`, which said nothing at all about a
+/// second workflow's `upload`.
+const PUBLISHING_MARKERS: &[&str] = &[
+    "gh release upload",
+    "cargo publish",
+    "pypa/gh-action-pypi-publish",
+];
+
+/// Job-level `if:` conditions that cannot be true on a `release` event, and so
+/// exempt a root job from carrying a tag gate.
+///
+/// A closed, exact-match list rather than an expression evaluator — see the
+/// module docs. Nothing uses it today: every root job in every release workflow
+/// currently carries a real gate.
+const RELEASE_UNREACHABLE_CONDITIONS: &[&str] = &[
+    "github.event_name != 'release'",
+    "github.event_name == 'workflow_dispatch'",
+];
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -132,6 +228,179 @@ fn repo_root() -> PathBuf {
 fn read(relative: &str) -> String {
     let path = repo_root().join(relative);
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// A workflow's `on:` block.
+///
+/// Looked up as **both** the string `"on"` and the boolean `true`: YAML 1.1
+/// resolves a bare `on` key to a boolean, YAML 1.2 leaves it a string, and which
+/// one a given serde_yaml release produces is not something this guard's
+/// correctness should depend on. Getting that wrong yields an empty workflow set
+/// rather than an error, which is why [`MINIMUM_RELEASE_WORKFLOWS`] exists.
+fn on_block(workflow: &Value) -> Option<&Value> {
+    workflow.as_mapping()?.iter().find_map(|(key, value)| {
+        let is_on = match key {
+            Value::String(name) => name == "on",
+            Value::Bool(resolved) => *resolved,
+            _ => false,
+        };
+        is_on.then_some(value)
+    })
+}
+
+/// The `release` activity types a workflow triggers on, or `None` if it declares
+/// no `release` trigger at all.
+///
+/// An **empty** set is not "no types" — it is what GitHub Actions means by a
+/// `release:` trigger with no `types:` key, namely every activity type. The
+/// scalar (`on: release`) and sequence (`on: [release, push]`) shorthands are
+/// the same case: neither can carry a `types:` filter.
+fn release_trigger_types(workflow: &Value) -> Option<BTreeSet<String>> {
+    match on_block(workflow)? {
+        Value::String(event) => (event == "release").then(BTreeSet::new),
+        Value::Sequence(events) => events
+            .iter()
+            .any(|event| event.as_str() == Some("release"))
+            .then(BTreeSet::new),
+        Value::Mapping(events) => {
+            let release = events
+                .iter()
+                .find_map(|(event, body)| (event.as_str() == Some("release")).then_some(body))?;
+            Some(match release.get("types").and_then(Value::as_sequence) {
+                None => BTreeSet::new(),
+                Some(types) => types
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect(),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Every workflow a published release fires, as `(repo-relative path, parsed
+/// document)` pairs sorted by path.
+fn release_workflows() -> Vec<(String, Value)> {
+    let dir = repo_root().join(WORKFLOW_DIR);
+    let entries = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+        .filter_map(Result::ok);
+
+    let mut workflows = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        if path
+            .extension()
+            .is_none_or(|extension| extension != "yml" && extension != "yaml")
+        {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .expect("a file has a name")
+            .to_string_lossy()
+            .into_owned();
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        let document: Value = serde_yaml::from_str(&text)
+            .unwrap_or_else(|e| panic!("{WORKFLOW_DIR}/{name} is not valid YAML: {e}"));
+        let Some(types) = release_trigger_types(&document) else {
+            continue;
+        };
+        if types.is_empty() || types.contains(PUBLISHED) {
+            workflows.push((format!("{WORKFLOW_DIR}/{name}"), document));
+        }
+    }
+    workflows.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    assert!(
+        workflows.len() >= MINIMUM_RELEASE_WORKFLOWS,
+        "found {} release-triggered workflow(s) in {WORKFLOW_DIR} ({:?}); at least \
+         {MINIMUM_RELEASE_WORKFLOWS} trigger on `release: {PUBLISHED}` today, so the `on:` \
+         parse has gone blind rather than the repository having shrunk. Every assertion in \
+         this file iterates over that set, so an empty one passes them all.",
+        workflows.len(),
+        workflows.iter().map(|(file, _)| file).collect::<Vec<_>>(),
+    );
+    workflows
+}
+
+/// A workflow's jobs, as `(name, body)` pairs.
+fn jobs<'a>(file: &str, workflow: &'a Value) -> Vec<(String, &'a Value)> {
+    let jobs = workflow
+        .get("jobs")
+        .and_then(Value::as_mapping)
+        .unwrap_or_else(|| panic!("{file} declares no jobs mapping"));
+    let jobs: Vec<(String, &Value)> = jobs
+        .iter()
+        .filter_map(|(name, body)| Some((name.as_str()?.to_string(), body)))
+        .collect();
+    assert!(
+        !jobs.is_empty(),
+        "{file} triggers on a release and declares no jobs this guard could read"
+    );
+    jobs
+}
+
+/// The jobs a release reaches **directly** — those with no `needs:`.
+///
+/// Everything else is downstream and skips with whatever it depends on, which is
+/// why gating the roots is sufficient and why the roots are where a missing gate
+/// is a hole rather than a redundancy.
+fn root_jobs<'a>(file: &str, workflow: &'a Value) -> Vec<(String, &'a Value)> {
+    let roots: Vec<(String, &Value)> = jobs(file, workflow)
+        .into_iter()
+        .filter(|(_, body)| body.get("needs").is_none())
+        .collect();
+    assert!(
+        !roots.is_empty(),
+        "{file} triggers on a release and every one of its jobs declares `needs:`. That is \
+         either a cycle or a `needs:` shape this guard cannot read; either way it leaves no \
+         job for the tag gate to sit on."
+    );
+    roots
+}
+
+/// A condition with its `${{ }}` wrapper, quoting style and whitespace
+/// normalised, so [`RELEASE_UNREACHABLE_CONDITIONS`] can be matched exactly.
+fn normalize_condition(condition: &str) -> String {
+    let trimmed = condition.trim();
+    let inner = trimmed
+        .strip_prefix("${{")
+        .and_then(|rest| rest.strip_suffix("}}"))
+        .unwrap_or(trimmed);
+    inner
+        .replace('"', "'")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn is_unreachable_on_a_release(condition: &str) -> bool {
+    let normalized = normalize_condition(condition);
+    RELEASE_UNREACHABLE_CONDITIONS
+        .iter()
+        .any(|exempt| normalize_condition(exempt) == normalized)
+}
+
+/// Whether a job's steps can ship something, read from the step text rather than
+/// from the job's name.
+fn job_publishes(job: &Value) -> bool {
+    let steps = job
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    steps.iter().any(|step| {
+        ["run", "uses"].iter().any(|key| {
+            step.get(key).and_then(Value::as_str).is_some_and(|text| {
+                PUBLISHING_MARKERS
+                    .iter()
+                    .any(|marker| text.contains(marker))
+            })
+        })
+    })
 }
 
 /// Where the expected tag came from, so a failure can say which half to fix.
@@ -214,50 +483,14 @@ fn render(template: &str, package: &str, version: &str) -> String {
         .replace("{{version}}", version)
 }
 
-/// Every job-level `if:` in `release-wheels.yml`, by job name.
-fn job_conditions() -> Vec<(String, String)> {
-    let workflow: serde_yaml::Value =
-        serde_yaml::from_str(&read(WHEELS_YML)).expect("release-wheels.yml parses as YAML");
-    let jobs = workflow
-        .get("jobs")
-        .and_then(serde_yaml::Value::as_mapping)
-        .expect("release-wheels.yml declares jobs");
-    jobs.iter()
-        .filter_map(|(name, body)| {
-            let name = name.as_str()?.to_string();
-            let condition = body.get("if")?.as_str()?.to_string();
-            Some((name, condition))
-        })
-        .collect()
-}
-
-/// The `if:` condition of one named job, or a failure naming the job.
-///
-/// A building job with no condition at all is the whole defect in one line: it
-/// fires on every release, including a data release.
-fn condition_of(job: &str) -> String {
-    job_conditions()
-        .into_iter()
-        .find(|(name, _)| name == job)
-        .map(|(_, condition)| condition)
-        .unwrap_or_else(|| {
-            panic!(
-                "{WHEELS_YML} has no `{job}` job, or it carries no `if:` at all. Nothing \
-                 downstream re-checks the release tag — it only `needs:` the building jobs — \
-                 so an ungated one fires the whole matrix on any release, and a gate present \
-                 on its three siblings does not cover it."
-            )
-        })
-}
-
 /// The tag prefixes **one** job will accept, read out of the
 /// `startsWith(github.event.release.tag_name, '<prefix>')` calls in its
 /// job-level condition.
 ///
-/// Per-job on purpose: unioning the four answers "does some job accept this
-/// tag", and a gate dropped from one of four near-identical blocks is exactly
-/// the skip-chain that cost v0.14.0 its wheels.
-fn gate_prefixes_for(job: &str, condition: &str) -> BTreeSet<String> {
+/// Per-job on purpose: unioning a workflow's jobs answers "does some job accept
+/// this tag", and a gate dropped from one of four near-identical blocks is
+/// exactly the skip-chain that cost v0.14.0 its wheels.
+fn gate_prefixes_for(file: &str, job: &str, condition: &str) -> BTreeSet<String> {
     let mut prefixes = BTreeSet::new();
     let mut rest = condition;
     while let Some(at) = rest.find(GATE_CALL) {
@@ -271,10 +504,10 @@ fn gate_prefixes_for(job: &str, condition: &str) -> BTreeSet<String> {
 
     assert!(
         !prefixes.is_empty(),
-        "{WHEELS_YML}'s `{job}` job does not gate on \
+        "{file}'s `{job}` job does not gate on \
          `startsWith(github.event.release.tag_name, …)`: {condition:?}. Either the tag gate \
          was removed — in which case the `{DATA_RELEASE_TAG}` data release fires the whole \
-         wheel matrix again — or it was rewritten in a form this guard cannot read, in which \
+         matrix again — or it was rewritten in a form this guard cannot read, in which \
          case every assertion here is vacuous. Both need a human."
     );
 
@@ -286,7 +519,7 @@ fn gate_prefixes_for(job: &str, condition: &str) -> BTreeSet<String> {
     let mentions = condition.matches(TAG_CONTEXT).count();
     assert_eq!(
         mentions, read_calls,
-        "{WHEELS_YML}'s `{job}` job mentions `{TAG_CONTEXT}` {mentions} times but only \
+        "{file}'s `{job}` job mentions `{TAG_CONTEXT}` {mentions} times but only \
          {read_calls} of those are `{GATE_CALL}…')` calls this guard can read: {condition:?}.\n\
          An arm this guard cannot read is an arm it cannot judge — a `contains(…, 'v')` or a \
          `startsWith(…,'…')` written without the space added *beside* the working arms leaves \
@@ -298,105 +531,198 @@ fn gate_prefixes_for(job: &str, condition: &str) -> BTreeSet<String> {
     prefixes
 }
 
-/// Each gated job's accepted prefixes, in `GATED_JOBS` order.
-fn gated_job_prefixes() -> Vec<(&'static str, BTreeSet<String>)> {
-    GATED_JOBS
-        .iter()
-        .map(|job| {
-            let condition = condition_of(job);
-            (*job, gate_prefixes_for(job, &condition))
-        })
-        .collect()
+/// One job's tag gate, located.
+#[derive(Debug)]
+struct Gate {
+    /// Repo-relative path of the workflow the gate lives in.
+    file: String,
+    /// The job carrying it.
+    job: String,
+    /// The tag prefixes it accepts.
+    prefixes: BTreeSet<String>,
 }
 
-/// Every gated job must accept the tag the release automation is actually going
-/// to mint.
+/// Every tag gate in every release-triggered workflow.
 ///
-/// This is the assertion that would have failed on the v0.14.0 tree: the gate
-/// held `v`, the workspace had gone multi-package, and the minted tag was
-/// `ferro-hgvs-v0.14.0`.
+/// Read from **all** jobs rather than only the root ones: a downstream job may
+/// carry a gate of its own, and if it does it is subject to the same agreement
+/// and same accept/reject assertions as the roots.
+fn all_release_gates() -> Vec<Gate> {
+    let mut gates = Vec::new();
+    for (file, workflow) in &release_workflows() {
+        for (job, body) in jobs(file, workflow) {
+            let Some(condition) = body.get("if").and_then(Value::as_str) else {
+                continue;
+            };
+            if !condition.contains(GATE_CALL) {
+                continue;
+            }
+            gates.push(Gate {
+                file: file.clone(),
+                job: job.clone(),
+                prefixes: gate_prefixes_for(file, &job, condition),
+            });
+        }
+    }
+    assert!(
+        !gates.is_empty(),
+        "no `{GATE_CALL}…')` call was found in any release-triggered workflow. Either every \
+         gate has been deleted, or this guard's extraction has stopped matching — and a \
+         guard that reads no gates passes every assertion about gates."
+    );
+    gates
+}
+
+/// Every job a release reaches directly carries a tag gate.
+///
+/// **This is the assertion that catches a gate being deleted**, and it is the
+/// only one that can: the two below iterate over the gates they find, so a gate
+/// that is no longer there is not among them. Measured — deleting the gate line
+/// from `release-binaries.yml` leaves both of them green.
+///
+/// It also subsumes the old `every_building_job_carries_the_tag_gate`'s
+/// per-workflow half without naming a single job: the root set is derived from
+/// `needs:`, so a fifth wheel build or a second binaries matrix is covered the
+/// day it is added.
 #[test]
-fn the_wheels_gate_accepts_the_tag_release_plz_will_mint() {
+fn every_release_reachable_root_job_is_tag_gated() {
+    let mut checked = 0usize;
+    for (file, workflow) in &release_workflows() {
+        for (job, body) in root_jobs(file, workflow) {
+            checked += 1;
+            let condition = body.get("if").and_then(Value::as_str).unwrap_or_else(|| {
+                panic!(
+                    "{file}'s `{job}` job declares no `needs:` and carries no `if:`, so a \
+                     release reaches it directly and ungated. That is the whole defect in one \
+                     line: the `{DATA_RELEASE_TAG}` data release fires it, and every release \
+                     does, whatever the tag says."
+                )
+            });
+            if is_unreachable_on_a_release(condition) {
+                continue;
+            }
+            // Asserts the gate is present and readable, and that no arm of the
+            // condition touches the tag outside a gate this guard read.
+            gate_prefixes_for(file, &job, condition);
+        }
+    }
+    eprintln!("{checked} release-reachable root job(s) checked");
+}
+
+/// Every gate accepts the tag release-plz will actually mint, and none of them
+/// accepts the data release.
+///
+/// The first half is the assertion that would have failed on the v0.14.0 tree:
+/// the gate held `v`, the workspace had gone multi-package, and the minted tag
+/// was `ferro-hgvs-v0.14.0`.
+///
+/// The second half is asserted with it rather than beside it because the obvious
+/// repair for the first is a looser predicate: a `contains('v')` or a bare
+/// suffix match would accept `test-fixtures-v1` and re-break the thing the gate
+/// was added for. Neither half can be satisfied alone.
+#[test]
+fn all_release_gates_accept_the_minted_tag_and_reject_the_data_release() {
     let (tag, source) = minted_tag();
-    let declining: Vec<(&str, BTreeSet<String>)> = gated_job_prefixes()
-        .into_iter()
-        .filter(|(_, prefixes)| !prefixes.iter().any(|p| tag.starts_with(p)))
+    let gates = all_release_gates();
+
+    let declining: Vec<&Gate> = gates
+        .iter()
+        .filter(|gate| !gate.prefixes.iter().any(|prefix| tag.starts_with(prefix)))
         .collect();
     assert!(
         declining.is_empty(),
-        "release-plz will tag the next release `{tag}` ({source:?}), and these jobs in \
-         {WHEELS_YML} do not accept it: {declining:?}.\n\
+        "release-plz will tag the next release `{tag}` ({source:?}), and these gates do not \
+         accept it: {declining:?}.\n\
          Each of those jobs would skip, and everything that `needs:` it skips with it — \
          including `verify-pypi`, which exists to catch exactly this. `publish.yml` would \
-         still report success, so the release would look green while the wheels never \
-         reached PyPI. That is what happened to v0.14.0.\n\
+         still report success, so the release would look green while nothing shipped. That is \
+         what happened to v0.14.0.\n\
          Fix whichever half is wrong: `git_tag_name` in {RELEASE_PLZ_TOML} is the pin, and \
-         the gate must match it."
+         every gate must match it."
     );
-}
 
-/// …and must still reject the data release, which is why the gate exists.
-///
-/// The obvious repair for the failure above is a looser predicate. A
-/// `contains('v')` or a bare suffix match would accept `{DATA_RELEASE_TAG}` and
-/// re-break the thing the gate was added for, so the two halves are asserted
-/// together and neither can be satisfied alone.
-#[test]
-fn the_wheels_gate_still_rejects_the_data_release() {
-    let accepting: Vec<(&str, Vec<String>)> = gated_job_prefixes()
-        .into_iter()
-        .filter_map(|(job, prefixes)| {
-            let matched: Vec<String> = prefixes
-                .into_iter()
-                .filter(|p| DATA_RELEASE_TAG.starts_with(p))
+    let accepting: Vec<(&Gate, Vec<&String>)> = gates
+        .iter()
+        .filter_map(|gate| {
+            let matched: Vec<&String> = gate
+                .prefixes
+                .iter()
+                .filter(|prefix| DATA_RELEASE_TAG.starts_with(prefix.as_str()))
                 .collect();
-            (!matched.is_empty()).then_some((job, matched))
+            (!matched.is_empty()).then_some((gate, matched))
         })
         .collect();
     assert!(
         accepting.is_empty(),
-        "{WHEELS_YML} accepts the `{DATA_RELEASE_TAG}` data release: {accepting:?}. That \
-         release carries the bulk test corpora and no code; firing the wheel matrix on it \
-         uploads wheels onto a data release and attempts a PyPI publish. It happened once \
-         and had to be cancelled by hand."
+        "these gates accept the `{DATA_RELEASE_TAG}` data release: {accepting:?}. That \
+         release carries the bulk test corpora and no code; firing a build matrix on it \
+         uploads artifacts onto a data release and attempts a publish. It happened once and \
+         had to be cancelled by hand."
+    );
+
+    eprintln!(
+        "{} gates checked, all accepting {:?}",
+        gates.len(),
+        gates[0].prefixes
     );
 }
 
-/// All four building jobs carry the *same* gate.
+/// Every release workflow gates on the *same* tag prefixes.
 ///
-/// They are siblings, not a chain — nothing downstream re-checks the tag, it
-/// only `needs:` these four — so a gate dropped from one job, or narrowed in one
-/// job, is a hole rather than a redundancy. Requiring the four prefix sets to be
-/// equal is what makes hand-editing three of four near-identical blocks fail
-/// here instead of at the next release: `condition_of` fails on a job that lost
-/// its `if:` entirely, `gate_prefixes_for` fails on one whose gate no longer
-/// reads, and this fails on one whose gate merely disagrees with its siblings.
+/// This is the cross-file strengthening of the old
+/// `every_building_job_carries_the_tag_gate`, which compared four jobs inside
+/// one file. Nothing downstream re-checks the tag, so the narrowest gate decides
+/// which jobs run and the widest decides which releases reach them — and once
+/// there are two release workflows, a release accepted by one and declined by
+/// the other ships half a release, which is materially the v0.14.0 outcome with
+/// a different half missing.
 #[test]
-fn every_building_job_carries_the_tag_gate() {
-    let per_job = gated_job_prefixes();
-    let (first_job, expected) = per_job.first().expect("GATED_JOBS is not empty");
-    let disagreeing: Vec<&(&str, BTreeSet<String>)> = per_job
-        .iter()
-        .filter(|(_, prefixes)| prefixes != expected)
-        .collect();
-    assert!(
-        disagreeing.is_empty(),
-        "the building jobs in {WHEELS_YML} do not all gate on the same tag prefixes. \
-         `{first_job}` accepts {expected:?}, and these disagree: {disagreeing:?}.\n\
-         Nothing downstream re-checks the tag, so the narrowest gate decides which jobs run \
-         and the widest decides which releases reach them — a release accepted by three of \
-         the four builds wheels, skips one, and takes `check-metadata` and every publishing \
-         job down with the one it skipped."
-    );
+fn every_release_workflow_gates_on_the_same_tag_prefixes() {
+    let gates = all_release_gates();
+    let (first, rest) = gates.split_first().expect("all_release_gates is non-empty");
+    for gate in rest {
+        assert_eq!(
+            gate.prefixes,
+            first.prefixes,
+            "the release tag gates disagree. `{}`'s `{}` job accepts {:?}, `{}`'s `{}` job \
+             accepts {:?}.\n  \
+             accepted by `{}` only: {:?}\n  \
+             accepted by `{}` only: {:?}\n\
+             All release workflows must agree on one gate: nothing downstream re-checks the \
+             tag, so a release the wheels build and the binaries decline is a release that \
+             looks green and ships half of what it should.",
+            first.file,
+            first.job,
+            first.prefixes,
+            gate.file,
+            gate.job,
+            gate.prefixes,
+            first.job,
+            first
+                .prefixes
+                .difference(&gate.prefixes)
+                .collect::<Vec<_>>(),
+            gate.job,
+            gate.prefixes
+                .difference(&first.prefixes)
+                .collect::<Vec<_>>(),
+        );
+    }
 }
 
 /// Widening the tag gate must not let a `workflow_dispatch` dry-run publish.
 ///
 /// `workflow_dispatch` is deliberately outside the tag gate — the dry-run form
 /// takes a blank tag — so the only thing keeping a dry run from uploading to a
-/// GitHub Release or to PyPI is these two jobs' own conditions. A change to the
-/// gate above cannot weaken them, but it is the change most likely to be
+/// GitHub Release or to PyPI is the publishing jobs' own conditions. A change to
+/// the gate above cannot weaken them, but it is the change most likely to be
 /// accompanied by a well-meant edit here.
+///
+/// The publisher set is **derived from what the steps do** — `gh release
+/// upload`, `cargo publish`, `pypa/gh-action-pypi-publish` — rather than from a
+/// list of job names. The list it replaces held `["upload", "publish-pypi"]`,
+/// which named `release-wheels.yml`'s two jobs and could say nothing whatever
+/// about a second workflow's `upload`.
 ///
 /// A floor, and only a floor: this requires each job to *mention* a real release
 /// event, not that it fires on nothing else. `upload` deliberately also runs on a
@@ -404,13 +730,34 @@ fn every_building_job_carries_the_tag_gate() {
 /// re-attached its wheels — so the assertion cannot be stronger than a substring
 /// test without pinning that second arm too.
 #[test]
-fn only_a_real_release_can_publish() {
-    for job in PUBLISHING_JOBS {
-        let condition = condition_of(job);
-        assert!(
-            condition.contains("github.event_name == 'release'"),
-            "{WHEELS_YML}'s `{job}` job can ship artifacts and its condition does not \
-             require a real release event: {condition:?}"
-        );
+fn every_publishing_job_requires_a_release() {
+    let mut publishers = Vec::new();
+    for (file, workflow) in &release_workflows() {
+        for (job, body) in jobs(file, workflow) {
+            if !job_publishes(body) {
+                continue;
+            }
+            publishers.push(format!("{file}:{job}"));
+            let condition = body.get("if").and_then(Value::as_str).unwrap_or_else(|| {
+                panic!(
+                    "{file}'s `{job}` job can ship artifacts and carries no `if:` at all, so a \
+                     `workflow_dispatch` dry-run publishes."
+                )
+            });
+            assert!(
+                condition.contains(RELEASE_EVENT),
+                "{file}'s `{job}` job can ship artifacts and its condition does not require a \
+                 real release event: {condition:?}"
+            );
+        }
     }
+
+    assert!(
+        publishers.len() >= MINIMUM_PUBLISHING_JOBS,
+        "found {} publishing job(s) ({publishers:?}) across the release workflows; at least \
+         {MINIMUM_PUBLISHING_JOBS} ship something today, so the scan for {PUBLISHING_MARKERS:?} \
+         has gone blind rather than the pipeline having shrunk — and a scan that finds no \
+         publisher asserts nothing about publishing.",
+        publishers.len(),
+    );
 }


### PR DESCRIPTION
`tests/it/release_tag_gate.rs` was written against one workflow and says so in its source: `const WHEELS_YML: &str = ".github/workflows/release-wheels.yml"`, with `GATED_JOBS` and `PUBLISHING_JOBS` hardcoded to that file's job names beside it. That is a roster, and it has the same drift problem one level up from the one the guard was written to close — a second release-triggered workflow is invisible to it.

It did not stay hypothetical. #2055 adds `.github/workflows/release-binaries.yml`, carrying the same `release: published` trigger and a copy of the same `startsWith(github.event.release.tag_name, 'v')` gate. Measured on a tree with that workflow present: **deleting its gate line outright leaves all four existing `release_tag_gate` tests passing, EXIT=0.**

## What changes

The workflow set is derived from `.github/workflows/` rather than named — every file whose `on:` block declares a `release` trigger whose `types:` includes `published`, or declares no `types:` at all, which in GitHub Actions means every activity type. `publish.yml` triggers on `push: main` and is correctly out of scope. This follows the precedent #2033 set for `spec_fixture_setup_filter.rs`: derive the set, report both difference directions on a disagreement, and floor it so a matcher that has gone blind cannot pass as "nothing to check".

The `on:` key is looked up as both the string `"on"` and the boolean `true`, because YAML 1.1 resolves a bare `on` key to a boolean and YAML 1.2 leaves it a string — this guard's correctness should not depend on which one a given serde_yaml release produces.

Both hardcoded job rosters go the same way. The gated set is derived from `needs:`: a job with none is one a release reaches directly, which is `{linux, macos, windows, sdist}` on `release-wheels.yml` and `{build}` on `release-binaries.yml`. The publishing set is derived from step text — `gh release upload`, `cargo publish`, `pypa/gh-action-pypi-publish` — rather than from `["upload", "publish-pypi"]`, which named one workflow's two jobs and could say nothing whatever about a second workflow's `upload`.

## Four assertions, and which one is load-bearing

1. `every_release_reachable_root_job_is_tag_gated` — new. Every job a release reaches directly carries a readable gate, or an `if:` that cannot be true on a release.
2. `all_release_gates_accept_the_minted_tag_and_reject_the_data_release` — the two existing assertions, now run over every gate in every derived workflow.
3. `every_release_workflow_gates_on_the_same_tag_prefixes` — replaces `every_building_job_carries_the_tag_gate`, strengthened from within-file to across-file.
4. `every_publishing_job_requires_a_release` — unchanged in substance, derived publisher set.

Assertion 1 is not garnish. **A gate that has been deleted is invisible to any check that iterates over gates it can find**, so 2 and 3 both stay green through a deletion — they iterate over the gates present, and a deleted gate is not one of them. Only iterating over *jobs* and asking each whether it is gated catches it.

## Measurements

Both new assertions were proven able to fail, each in isolation, on a scratch worktree holding this branch plus #2055's commit cherry-picked (so both release workflows are present). `release-binaries.yml` was restored byte-for-byte after each, verified by `shasum -a 256` and by an empty `git diff` against #2055's commit.

| tree | result |
|---|---|
| clean, both workflows | 4 passed. `5 gates checked, all accepting {"v"}` (4 wheels + 1 binaries), 5 release-reachable root jobs |
| gate line deleted from `release-binaries.yml` | 3 passed, **1 failed** — only `every_release_reachable_root_job_is_tag_gated`, naming the `build` job. The gate-iterating assertion reported `4 gates checked` and passed |
| binaries gate prefix widened `'v'` to `'v0'` | 3 passed, **1 failed** — only `every_release_workflow_gates_on_the_same_tag_prefixes` |

## The floor is 1, not 2, and deliberately

`MINIMUM_RELEASE_WORKFLOWS` is the direct analogue of `spec_fixture_setup_filter.rs`'s `MINIMUM_CONSUMERS`, and its whole job is that a parser which has silently stopped matching fails loudly rather than passing vacuously over an empty set. A floor of 1 does that job in full.

It is not 2 because `release-wheels.yml` is the only release-triggered workflow on `main` today. A floor of 2 would make this branch red against its own base, and the point of deriving the set is that this change and #2055 are independent and can land in either order. Raise it to 2 when `release-binaries.yml` lands.

## Scope

Touches `tests/it/release_tag_gate.rs` and nothing else. `tests/it/main.rs` already registers the module. Not stacked on #2055; the two cannot conflict.

Representation-Change: none
