### PR TITLE
docs: correct canonicalize_from_sequence gating premise (#1709)

### DIFF
--- a/examples/generate_cis_confluence_corpus.rs
+++ b/examples/generate_cis_confluence_corpus.rs
@@ -3,14 +3,30 @@
 //!
 //! # Why this exists
 //!
-//! `canonicalize_from_sequence` is gated on `members.len() > 1`
-//! (`src/normalize/mod.rs`), so only a multi-member cis allele reaches the
-//! partitioner. Part 1 of this issue harvested every such input out of the bulk
-//! corpora: **650 rows out of 9 949 738**. Real corpora are observed variants,
+//! `canonicalize_from_sequence` (via `sequence_first_pass` in
+//! `src/normalize/mod.rs`) reaches the partitioner by two routes: a multi-member
+//! cis allele (`members.len() >= 2`), and a splittable single-member input — any
+//! single-member `g.`/`m.`/`c.`/`n.`/`r.` variant **with a present edit**, via
+//! `is_splittable_single_member` (a `?` edit is refused).
+//! So `members.len() > 1` is one of two admitting routes, not the gate. This
+//! corpus designs the multi-member route. Part 1 of this issue harvested every
+//! such input out of the bulk corpora: **592 rows out of 9 949 738** — and even
+//! that is an upper bound, since the harvest selects on shape and the gate
+//! refuses an uncertain or overlap-conflicting allele on top of it. Real corpora
+//! are observed variants,
 //! where two changes rarely land close enough to share a block, so no amount of
 //! real data will cover the partitioner. Consumers who submit *designed*
 //! alleles — a systematic indel design walking a window — have the opposite
 //! distribution, and that is the shape this generates.
+//!
+//! **The figure is 592, not 650.** 650 was this passage's number until #1709 and
+//! it was stale from the day it landed: #1458 measured 650 with a bracket-scan
+//! selector, replaced that selector with `parse_hgvs` inside the same PR — which
+//! is what stopped an inserted-range payload's own `;` counting as a member
+//! separator — and re-measured 592, updating the fixture and the harvester but
+//! not this file or `tests/it/cis_confluence_axis.rs`. 592 is what the committed
+//! fixture, `multi_member_cis_axis`'s `assert_eq!` and a re-run of the harvester
+//! all report.
 //!
 //! # What a confluence class is, and how it differs from a dump
 //!

--- a/examples/harvest_multi_member_cis.rs
+++ b/examples/harvest_multi_member_cis.rs
@@ -2,15 +2,38 @@
 //!
 //! # Why this exists
 //!
-//! `canonicalize_from_sequence` is gated on `members.len() > 1`
-//! (`src/normalize/mod.rs`), so a single-member input never reaches the
-//! partitioner, the changed-column bound, or the member-ordering rules. Across
-//! the four bulk corpora — 9 949 738 rows — only **592** inputs are
-//! multi-member cis alleles. Everything else exercises the per-member path.
+//! `canonicalize_from_sequence` (via `sequence_first_pass` in
+//! `src/normalize/mod.rs`) admits **two** shapes, not one: a multi-member cis
+//! allele (`members.len() >= 2`), and a splittable single-member input — any
+//! single-member `g.`/`m.`/`c.`/`n.`/`r.` variant **whose edit is present**
+//! (`is_splittable_single_member` is `edit.inner().is_some()`, so a `?` edit is
+//! refused). So `members.len() > 1` is one of two admitting routes, not the
+//! gate.
 //!
-//! Those 592 are the only real-world evidence the repo has for that code path,
-//! and they currently sit inside bulk corpora whose test modules *skip green*
-//! when the fixtures are absent (`clinvar_hgvs_tests`, `cmrg_exhaustive_tests`,
+//! This harvest captures the multi-member route only: across the four bulk
+//! corpora — 9 949 738 rows — **592** inputs are multi-member cis alleles. The
+//! single-member route is not a rounding error beside it. Measured over the same
+//! four corpora, **9 935 060 of the 9 949 738 rows (99.85 %)** parse to a
+//! single-member `g.`/`m.`/`c.`/`n.`/`r.` variant with a present edit — that is,
+//! the other route admits almost the whole corpus.
+//!
+//! # "Harvested" is not "reaches", and the gap is deliberate
+//!
+//! [`multi_member_cis`] selects on **shape**: a `Cis` allele the parser reports
+//! with two or more members. `sequence_first_pass` then refuses two further
+//! things this predicate never asks about — an `uncertain` allele, and one
+//! `detect_overlap_conflicts` reports a conflict on. `NC_000001.11:g.[(100del;110del)]`
+//! parses `uncertain: true, phase: Cis, n: 2`, so it would be harvested and is
+//! declined by the gate. So **592 is an upper bound** on the rows that reach the
+//! partitioner, not a count of them.
+//!
+//! Measured, the first refusal removes none: of every multi-member cis allele in
+//! these corpora, **zero** are `uncertain`. The second is not measured here.
+//!
+//! Those 592 are the only real-world evidence the repo has for the multi-member
+//! route specifically, and they currently sit inside bulk corpora whose test
+//! modules *skip green* when the fixtures are absent
+//! (`clinvar_hgvs_tests`, `cmrg_exhaustive_tests`,
 //! `paraphase_exhaustive_tests` all `return` on a missing file). Those corpora
 //! are not in the git tree — they are release assets fetched by
 //! `scripts/fetch-test-fixtures.sh` — so on a checkout that has not fetched
@@ -50,6 +73,23 @@ const SOURCES: &[&str] = &[
 ];
 
 const DEFAULT_OUTPUT: &str = "tests/fixtures/cis/multi_member_cis_alleles.json";
+
+/// The `description` written into the fixture, as a named constant so the
+/// committed copy can be checked against it without the bulk corpora.
+///
+/// `--check` already compares the whole rendered file, but it needs all four
+/// release-asset corpora to rebuild one — so on CI and on any checkout that has
+/// not fetched them, nothing looks at this string at all.
+/// [`the_committed_fixture_description_matches_this_generator`] closes that: it
+/// reads only the committed JSON, so it runs everywhere.
+const DESCRIPTION: &str = "Multi-member cis alleles harvested from the bulk corpora. Selected on \
+     shape — a `Cis` allele the parser reports with two or more members — which is \
+     `canonicalize_from_sequence`'s multi-member route (`members.len() >= 2`). Shape is all this \
+     asks, so the count is an upper bound on the rows that reach the partitioner rather than a \
+     count of them: `sequence_first_pass` additionally refuses an uncertain allele and one \
+     carrying an overlap conflict. The other admitting route — a single-member g./m./c./n./r. \
+     variant with a present edit, via `is_splittable_single_member` — reaches the same code path \
+     and is not harvested here.";
 
 /// One harvested row, plus enough provenance to find it again upstream.
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -237,10 +277,7 @@ fn harvest() -> Result<Fixture, String> {
     rows.dedup_by(|a, b| a.input == b.input);
 
     Ok(Fixture {
-        description: "Multi-member cis alleles harvested from the bulk corpora. These are the \
-                      only inputs in those corpora that reach `canonicalize_from_sequence`, \
-                      which is gated on `members.len() > 1`."
-            .to_string(),
+        description: DESCRIPTION.to_string(),
         generator: "cargo run --features dev --example harvest_multi_member_cis".to_string(),
         sources: SOURCES.iter().map(|s| s.to_string()).collect(),
         rows_scanned: scanned,
@@ -323,6 +360,38 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The committed fixture's `description` must be the string this generator
+    /// writes.
+    ///
+    /// Without this, [`DESCRIPTION`] and the JSON are a seventh and eighth copy
+    /// of one paragraph with nothing behind them: `--check` compares them, but
+    /// it needs all four release-asset corpora to rebuild a fixture, so it never
+    /// runs in CI and does not run on a checkout that has not fetched them. This
+    /// reads the committed JSON alone, so it runs everywhere the suite does.
+    ///
+    /// It deliberately checks only the `description`. The rows are what `--check`
+    /// is for, and re-deriving them here would need the corpora again.
+    #[test]
+    fn the_committed_fixture_description_matches_this_generator() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(DEFAULT_OUTPUT);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        let fixture: serde_json::Value =
+            serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+        let committed = fixture
+            .get("description")
+            .and_then(serde_json::Value::as_str)
+            .expect("fixture carries a `description` string");
+        assert_eq!(
+            committed,
+            DESCRIPTION,
+            "{} is stale against this generator's DESCRIPTION. Re-run \
+             `cargo run --features dev --example harvest_multi_member_cis` (needs the bulk \
+             corpora), or edit the committed `description` to match.",
+            path.display()
+        );
+    }
 
     #[test]
     fn selects_only_multi_member_cis() {

--- a/src/conformance/spec_corpus.rs
+++ b/src/conformance/spec_corpus.rs
@@ -157,12 +157,37 @@ pub const DENSE_SEPARATIONS: &[usize] = &[0, 1, 2, 3, 5, 8];
 /// Member footprint / payload sizes in the dense strata.
 pub const DENSE_PAYLOADS: &[usize] = &[1, 2, 4];
 
-/// Member counts the dense multi-member strata enumerate.
+/// Member counts the dense **multi-member** strata enumerate.
 ///
-/// Two is the smallest allele that reaches the partitioner at all
-/// (`canonicalize_from_sequence` is gated on `members.len() > 1`); four is where
-/// the bulk corpora run out of evidence entirely — the real-data harvest found
-/// seven three-member and three four-member rows in 9.9M.
+/// Two is the floor because two is the smallest allele: these strata exist to
+/// vary how members sit relative to one another — [`Geometry`], separation,
+/// payload — and a one-member design has no such relation to vary. It is **not**
+/// because one member cannot reach the partitioner. It can:
+/// `canonicalize_from_sequence` admits two routes, a multi-member `Cis` allele
+/// (`members.len() >= 2`) *and* a single-member `g.`/`m.`/`c.`/`n.`/`r.` variant
+/// with a present edit (`is_splittable_single_member`, which is
+/// `edit.inner().is_some()`, so `?` is refused). The premise that
+/// `members.len() > 1` is the gate was stated here and in five sibling files
+/// until #1709; it is false.
+///
+/// **Single-member rows are therefore in this corpus, just not from these
+/// strata.** At `CorpusBounds::default()`, **450** of 12,946 rows carry one
+/// member — 402 [`Mechanism::Lone`], 24 [`Mechanism::CompositePayload`] and 24
+/// [`Mechanism::RepeatCount`], the last two being single-member shapes that only
+/// look otherwise. Of the 450, **404** parse and satisfy
+/// `is_splittable_single_member`; the other 46 are [`RowKind::Prohibited`]
+/// spellings deliberately malformed enough that no parse succeeds, so they reach
+/// nothing.
+///
+/// The 450 is guarded rather than merely asserted here: `spec_conformance_axis`'s
+/// `CorpusShape` pins `rows` at 12,946 and `multi_member_rows` at 12,496, and no
+/// row has `members > 1` under a non-combining mechanism, so their difference
+/// *is* this figure. The 402/24/24 and 404/46 splits are measurements at those
+/// bounds and are not pinned anywhere.
+///
+/// Four is the ceiling because four is where the bulk corpora run out of
+/// evidence entirely — the real-data harvest found seven three-member and three
+/// four-member rows in 9.9M.
 pub const MEMBER_COUNTS: &[usize] = &[2, 3, 4];
 
 /// The bounds of one corpus. Every pinned number is measured over these, so

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3390,11 +3390,21 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // way-point the loop stopped on.
         //
         // Cloned lazily. Exhaustion requires the loop to have advanced at least
-        // once, so a variant the pass declines on the first line never needs the
-        // copy — and that is the overwhelming majority, since this method runs on
-        // every `normalize()` and every projection while `sequence_first_pass`
-        // serves only cis alleles and lone `delins`/`inv` members. Cloning
-        // eagerly put a heap allocation on that whole path.
+        // once, so nothing that breaks on the FIRST iteration ever needs the
+        // copy — and all three breaks below precede it: the pass declining, the
+        // re-derivation reproducing `current`, and `normalize_core` handing back
+        // `current`. This method runs on every `normalize()` and every
+        // projection, so keeping the allocation off those paths is the whole
+        // point; cloning eagerly put a heap allocation on all of them.
+        //
+        // The reason used to be given as "`sequence_first_pass` serves only cis
+        // alleles and lone `delins`/`inv` members", which is false and was
+        // corrected by #1709: the pass also admits any single-member
+        // `g.`/`m.`/`c.`/`n.`/`r.` variant with a present edit, via
+        // `is_splittable_single_member`. The optimisation is unaffected, because
+        // it never depended on the pass *declining* — a variant the pass admits
+        // but re-derives unchanged breaks on `canonical == current`, which is
+        // also before `original` is set.
         let mut original: Option<HgvsVariant> = None;
         // Warnings belonging to the pass whose result is the one we return.
         //
@@ -3467,13 +3477,22 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// One sequence-first re-derivation. `None` when the variant is not a shape
     /// the pass serves (protein, trans alleles, fusions, and so on).
     fn sequence_first_pass(&self, variant: &HgvsVariant) -> Option<HgvsVariant> {
-        // Only shapes where a partition decision actually exists. A lone
-        // substitution / deletion / insertion / duplication already has exactly
-        // one canonical partition, so re-deriving it can only lose what the
-        // per-member pipeline added (gene symbol, RNA `U` alphabet, boundary and
-        // exon-junction clamps). A lone `delins` or `inv` is different: those are
-        // precisely the single-member forms that may need splitting (#1230,
-        // #1232).
+        // Only shapes where a partition decision can exist. The allele arm takes
+        // a non-uncertain `Cis` allele with two or more members; the
+        // single-member arm takes whatever `is_splittable_single_member` admits
+        // — any `g.`/`m.`/`c.`/`n.`/`r.` variant whose edit is present, `?`
+        // excluded. Everything else (protein, trans, unphased, fusions) returns
+        // `None` below.
+        //
+        // The single-member arm is **not** restricted to a lone `delins`/`inv`,
+        // as this comment claimed until #1709. #1235 removed that restriction on
+        // purpose: the re-derivation is a function of (reference, denoted
+        // sequence), so admitting by the input's *spelling* is exactly the
+        // input-relativity that issue is about — `g.263_264insGAAA` and
+        // `g.[261_262insGA;263_264insAA]` denote one variant and only one of them
+        // used to be allowed to be re-derived. The reasoning, and what widening
+        // the axis gate cost, are on `is_splittable_single_member` itself; do not
+        // re-narrow it from here.
         //
         // Borrowed, not cloned: `canonicalize_from_sequence` refuses far more
         // often than it rebuilds, and every refusal used to cost a full copy of

--- a/tests/fixtures/cis/multi_member_cis_alleles.json
+++ b/tests/fixtures/cis/multi_member_cis_alleles.json
@@ -1,5 +1,5 @@
 {
-  "description": "Multi-member cis alleles harvested from the bulk corpora. These are the only inputs in those corpora that reach `canonicalize_from_sequence`, which is gated on `members.len() > 1`.",
+  "description": "Multi-member cis alleles harvested from the bulk corpora. Selected on shape — a `Cis` allele the parser reports with two or more members — which is `canonicalize_from_sequence`'s multi-member route (`members.len() >= 2`). Shape is all this asks, so the count is an upper bound on the rows that reach the partitioner rather than a count of them: `sequence_first_pass` additionally refuses an uncertain allele and one carrying an overlap conflict. The other admitting route — a single-member g./m./c./n./r. variant with a present edit, via `is_splittable_single_member` — reaches the same code path and is not harvested here.",
   "generator": "cargo run --features dev --example harvest_multi_member_cis",
   "sources": [
     "tests/fixtures/bulk/clinvar_hgvs_500k.json.gz",

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -2,13 +2,26 @@
 //!
 //! # The gap
 //!
-//! `canonicalize_from_sequence` is gated on `members.len() > 1`, so only a
-//! multi-member cis allele reaches the partitioner at all. Part 1 of #1443
-//! harvested every such input from the bulk corpora and found **650 rows out of
+//! `canonicalize_from_sequence` (via `sequence_first_pass`) reaches the
+//! partitioner by two routes: a multi-member cis allele (`members.len() >= 2`),
+//! and a splittable single-member input — any single-member
+//! `g.`/`m.`/`c.`/`n.`/`r.` variant **with a present edit**, via
+//! `is_splittable_single_member` (a `?` edit is refused). So
+//! `members.len() > 1` is one of two admitting routes, not the gate. This axis
+//! exercises the multi-member route. Part 1 of #1443 harvested every such input
+//! from the bulk corpora and found **592 rows out of
 //! 9 949 738** — real corpora are observed variants, where two changes rarely
 //! land close enough to share a block. Consumers submitting *designed* alleles
 //! have the opposite distribution, so the partitioner is effectively untested
 //! and no real corpus can fix that.
+//!
+//! **592, not the 650 this passage carried until #1709.** 650 was #1458's
+//! bracket-scan measurement, superseded inside that same PR when the selector
+//! became `parse_hgvs`; the fixture, the harvester and `multi_member_cis_axis`
+//! were updated and this file was not. See
+//! `examples/generate_cis_confluence_corpus.rs` for the full account. Read 592
+//! as an upper bound in any case: the harvest selects on shape, and the gate
+//! additionally refuses an uncertain or overlap-conflicting allele.
 //!
 //! `examples/generate_cis_confluence_corpus.rs` fills it. Each class it emits is
 //! one synthetic reference, one denoted sequence, and N ≥ 2 distinct spellings
@@ -129,9 +142,12 @@ const CDS_END: u64 = 63;
 ///
 /// **100.0% of designed classes converge** (11 270 of 11 272). The 2 that do
 /// not are the measurement this module exists to make: nothing in the repo could
-/// state that number before, because only 650 real rows reach the partitioner at
-/// all — and `multi_member_cis_axis` measures convergence over the respellable
-/// ones of those, which is what a corpus of far-apart members looks like.
+/// state that number before, because at most 592 real rows reach the
+/// partitioner **by the multi-member route** — and `multi_member_cis_axis`
+/// measures convergence over the respellable ones of those, which is what a
+/// corpus of far-apart members looks like. (The single-member route reaches it
+/// far more often; what no real corpus supplies is members close enough to share
+/// a block, which is the shape this axis designs.)
 ///
 /// **Read the percentage as rounded, not as exact.** 11 270 of 11 272 is
 /// 99.982 %, and the guard below rounds to the nearest tenth, so the headline

--- a/tests/it/multi_member_cis_axis.rs
+++ b/tests/it/multi_member_cis_axis.rs
@@ -1,10 +1,23 @@
 //! The real-world multi-member cis alleles, as an axis (#1443, part 1).
 //!
-//! `canonicalize_from_sequence` is gated on `members.len() > 1`, so a
-//! single-member input never reaches the partitioner, the changed-column bound
-//! or the member-ordering rules. `examples/harvest_multi_member_cis.rs` swept
-//! all four bulk corpora for inputs that do: **592 out of 9 949 738 rows**.
-//! Those 592 are the entire real-world evidence base for that code path, and
+//! `canonicalize_from_sequence` (via `sequence_first_pass`) admits **two**
+//! shapes, not one: a multi-member cis allele (`members.len() >= 2`), and a
+//! splittable single-member input — any single-member `g.`/`m.`/`c.`/`n.`/`r.`
+//! variant **with a present edit** (`is_splittable_single_member` is
+//! `edit.inner().is_some()`, so a `?` edit is refused). So `members.len() > 1` is
+//! one of two admitting routes, not the gate. `examples/harvest_multi_member_cis.rs`
+//! swept all four bulk corpora for the multi-member route: **592 out of
+//! 9 949 738 rows**. The other route is where the rest of that corpus goes —
+//! 9 935 060 of the same 9 949 738 rows (99.85 %) are single-member variants
+//! with a present edit.
+//!
+//! Those 592 are the entire real-world evidence base for the multi-member route
+//! specifically. Read them as an **upper bound** on what reaches the
+//! partitioner, not a count of it: the harvester selects on shape and never asks
+//! the two further questions `sequence_first_pass` asks — whether the allele is
+//! `uncertain`, and whether `detect_overlap_conflicts` reports a conflict on it.
+//! Measured, the first removes none of the 592 (see the harvester's own module
+//! docs); the second is unmeasured. And
 //! before this module they lived only inside bulk corpora whose test suites
 //! *skip green* when the fixtures are absent — and those corpora are not in the
 //! git tree (they are release assets, fetched by


### PR DESCRIPTION
Closes #1709.

## Also corrected here

**The `650` was stale, not a second measurement.** `generate_cis_confluence_corpus.rs` and `cis_confluence_axis.rs` said 650 rows out of 9,949,738 while the fixture, the harvester, `assert_eq!(accepted, 592)` and the census pin said 592 — same denominator. Both figures landed in the same commit (`5a800838`, #1458): the fixture read 650 across that PR's pre-squash commits and 592 at the squash, because the selector was rewritten from a bracket scan to `parse_hgvs` so an inserted-range payload's own `;` stops counting as a member separator. Re-derived directly: `harvest_multi_member_cis -- --check` reports `592 multi-member cis alleles` and `up to date`. All three sites now say 592, with the provenance recorded so it is not "corrected" back.

**"Harvested" is not "reaches".** The harvest predicate checks only `phase == Cis && variants.len() > 1`; `sequence_first_pass` additionally refuses an `uncertain` allele and one `detect_overlap_conflicts` flags. `NC_000001.11:g.[(100del;110del)]` parses `uncertain: true, phase: Cis, n: 2` — harvested, declined. So 592 is an **upper bound**, and the prose now says so. Measured, the `uncertain` refusal removes none: 0 of the 733 raw multi-member cis alleles in the four corpora (592 after dedup) are uncertain, and all 592 committed rows parse certain. The overlap refusal is unmeasured and is stated as such.

**The single-member route's size is now measured, not asserted.** Over the same four corpora, **9,935,060 of 9,949,738 rows (99.85%)** parse to a single-member `g.`/`m.`/`c.`/`n.`/`r.` variant with a present edit. The PR previously called it "far more populous" with nothing behind it.

**`spec_corpus.rs`'s `MEMBER_COUNTS` doc is rewritten rather than annotated.** Its lead sentence ("Two is the smallest allele that reaches the partitioner at all") was the false premise, so it could not be kept beside the correction. The floor is 2 because these strata vary *relations between members* and a one-member design has none. Single-member rows do exist in the corpus and do reach the partitioner: **450** of 12,946 at default bounds (402 `Lone`, 24 composite-payload, 24 repeat-count), of which **404** parse and satisfy `is_splittable_single_member` — the other 46 are `RowKind::Prohibited` spellings that do not parse at all. The 450 is derivable from two figures `spec_conformance_axis` already pins (12,946 − 12,496), so it is guarded rather than a new unbacked number.

**A guard now ties the fixture `description` to the generator.** The literal is a named `DESCRIPTION` constant and `the_committed_fixture_description_matches_this_generator` asserts the committed JSON matches it. `--check` already compares the whole file but needs all four release-asset corpora, so it never runs in CI; this reads only the committed JSON and runs everywhere. Verified to fail when the JSON is mutated.

**Two `src/normalize/mod.rs` comments carried the false premise in stronger form and are corrected.** The lazy-clone rationale at the `canonicalize_from_sequence` loop justified itself on "`sequence_first_pass` serves only cis alleles and lone `delins`/`inv` members"; the optimisation survives, but for a better reason — the clone sits after all three `break`s, so a variant the pass *admits and reproduces unchanged* is also on the no-clone side. The `sequence_first_pass` arm comment claimed a lone `delins`/`inv` restriction that #1235 removed on purpose, and which `is_splittable_single_member`'s own doc already contradicted.


Representation-Change: none. Comment/docs-only. The two `src/normalize/mod.rs` edits are comments, the `src/conformance/spec_corpus.rs` edit is a doc comment on a `const` (and that tree cannot move normalized output anyway), and the JSON change is a `description` string. No code path changes.

## The defect

Six committed sites stated that `canonicalize_from_sequence` "is gated on `members.len() > 1`", and concluded from that premise that only multi-member cis alleles reach the partitioner and that the 592 harvested rows are the only real-world evidence for that code path. **The premise is false**, so the conclusion reads as a coverage claim while understating the path's reach.

## The real gating

The entry point routes through `sequence_first_pass` (`src/normalize/mod.rs`), which admits **two** shapes, not one:

- a multi-member cis allele — a non-uncertain `Cis` `Allele` with `variants.len() >= 2`; and
- a splittable single-member input, accepted by `is_splittable_single_member`.

So `members.len() > 1` is one of two admitting routes, not the gate.

`is_splittable_single_member` returns `edit.inner().is_some()` over the five `HgvsVariant` kinds `Genome`/`Mt`/`Cds`/`Tx`/`Rna` (`g.`/`m.`/`c.`/`n.`/`r.`). `Mu::inner()` is `Some` for `Certain` **or** `Uncertain` and `None` only for `Unknown` (`?`), so the single-member route admits **any** single-member `g.`/`m.`/`c.`/`n.`/`r.` variant with a present edit — not merely a lone `delins`/`inv`. The corrected prose says exactly that, rather than repeating the narrower "lone delins/inv" phrasing some in-code docs use.

## The fix

Corrected all six sites to state the two routes and name `is_splittable_single_member`, and narrowed the "real-world evidence" claims to the multi-member route specifically:

| file | site |
|---|---|
| `examples/harvest_multi_member_cis.rs` | module doc + the fixture `description` constant it emits |
| `tests/it/multi_member_cis_axis.rs` | module doc |
| `examples/generate_cis_confluence_corpus.rs` | module doc |
| `tests/it/cis_confluence_axis.rs` | module doc |
| `src/conformance/spec_corpus.rs` | `MEMBER_COUNTS` doc |
| `tests/fixtures/cis/multi_member_cis_alleles.json` | committed `description` |

The committed fixture's `description` is updated to byte-match the regenerated generator constant; its 592 rows and `rows_scanned` are unchanged (the bulk `.json.gz` corpora the harvester reads are release assets, absent on this checkout, so the rows could not and did not change — verified the new `description` equals the generator's produced string exactly).

## Unchanged on purpose

- No code behavior changes — this is comment/docs/description-only.
- Left `from_sequences_multi_member_axis.rs` and `tests/fixtures/CORPUS_LAYOUT.md`: they describe the separate `from_sequences` surface and do not state the false `members.len() > 1` gate.

## Verification

- `cargo fmt --all --check` — clean.
- `cargo nextest run --features dev` — `11240 passed, 0 failed, 155 skipped` (EXIT=0), including `only_a_certain_cis_allele_is_counted_as_multi_member`.
- JSON `description` confirmed byte-identical to the generator constant.
