### PR TITLE
test: make two reference-aware guards visible to the manifest census

### DIFF
--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -104,7 +104,9 @@ jobs:
         test(/protein_cis_delins_decomposition::/) |
         test(/real_data_normalization_tests::/) |
         test(/accession_inventory::tests::corpus_missing_ng_against_real_reference_when_available/) |
-        test(/ng_placement_builder::tests::derive_for_real_reference_when_available/)
+        test(/ng_placement_builder::tests::derive_for_real_reference_when_available/) |
+        test(/coverage_gap_tests::issue_11::test_flt3_itd_insertion_position_order/) |
+        test(/normalize_tests::real_repeat_tests::test_real_repeat_pattern/)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/tests/it/coverage_gap_tests.rs
+++ b/tests/it/coverage_gap_tests.rs
@@ -790,9 +790,45 @@ mod inversions {
 
 mod issue_11 {
     use super::*;
+    use ferro_hgvs::{MultiFastaProvider, ReferenceProvider};
+    use std::path::{Path, PathBuf};
+
+    /// This module's name, as it appears in a `FERRO_REQUIRE_MANIFEST` failure.
+    const MODULE: &str = "coverage_gap_tests::issue_11";
+
+    /// The prepared manifest, by the convention every reference-aware module
+    /// here uses: `FERRO_MANIFEST` is authoritative when set, with
+    /// `benchmark-output/manifest.json` as the well-known fallback.
+    ///
+    /// This guard used to consult **only** the relative path *and* carry a
+    /// blanket `#[ignore]`, so it was hidden from the manifest census twice
+    /// over (#1862): the ignore kept it out of every run, and even un-ignored
+    /// it could not see a `FERRO_MANIFEST` the nightly provisions.
+    fn manifest_path() -> Option<PathBuf> {
+        if let Ok(path) = std::env::var(crate::common::manifest::MANIFEST_ENV) {
+            let path = PathBuf::from(path);
+            return path.exists().then_some(path);
+        }
+        let fallback = Path::new("benchmark-output/manifest.json");
+        fallback.exists().then(|| fallback.to_path_buf())
+    }
+
+    /// The provider, or `None` when there is no manifest to build one from.
+    ///
+    /// A manifest that is present but will not load panics rather than
+    /// returning `None` — the same convention `real_data_normalization_tests`
+    /// adopts — so an absent-manifest stand-down is never confused with a
+    /// broken reference, which matters on the one job that exists to notice
+    /// `ferro prepare` left nothing usable behind.
+    fn get_provider() -> Option<MultiFastaProvider> {
+        let path = manifest_path()?;
+        Some(
+            MultiFastaProvider::from_manifest(&path)
+                .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display())),
+        )
+    }
 
     #[test]
-    #[ignore] // Requires benchmark-output reference data
     fn test_flt3_itd_insertion_position_order() {
         // Issue #11: FLT3 ITD insertion on minus-strand gene
         // Mutalyzer normalizes to: NM_004119.3:c.1837+2_1837+3ins...
@@ -800,16 +836,23 @@ mod issue_11 {
         //
         // The HGVS spec requires flanking positions in 5'-to-3' coding order.
         // c.1837+2 is 5' of c.1837+3 in coding direction, so +2 must come first.
-        use ferro_hgvs::MultiFastaProvider;
-        use std::path::Path;
+        // This is an adjudicated-correct guard: the two assertions below pin a
+        // decided answer against a named Mutalyzer disagreement, so it must run
+        // (not skip green) whenever a reference is available.
+        let Some(provider) = get_provider() else {
+            crate::common::manifest::absent(MODULE);
+            return;
+        };
 
-        let ref_path = Path::new("benchmark-output/manifest.json");
-        if !ref_path.exists() {
-            eprintln!("Skipping: benchmark-output not available");
+        // A manifest that does not carry FLT3 leaves the assertions unreached,
+        // which is the same coverage loss an absent manifest causes and is
+        // promoted by the same `FERRO_REQUIRE_MANIFEST`.
+        let accession = "NM_004119.3";
+        if let Err(error) = provider.get_transcript(accession) {
+            crate::common::manifest::unserved(MODULE, accession, &error.to_string());
             return;
         }
-        let provider =
-            MultiFastaProvider::from_manifest(ref_path).expect("Failed to load reference data");
+
         let normalizer = Normalizer::new(provider);
 
         let input = "NM_004119.3:c.1837+2_1837+3insGGATATCTCAAATGGGAGTTTCCAAGAGAAAATTTAGAGTTTGGT";

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -2935,42 +2935,152 @@ mod repeat_position_tests {
     }
 }
 
-/// Integration test to check real repeat normalization behavior
-/// This test requires the benchmark-output directory with reference data
+/// Integration test to check real repeat normalization behavior.
+///
+/// The reference is located through `FERRO_MANIFEST`, falling back to
+/// `benchmark-output/manifest.json` — the convention every reference-aware
+/// module here uses. Without one this guard stands down; under
+/// `FERRO_REQUIRE_MANIFEST` standing down is a failure, whether the manifest is
+/// absent or does not carry the transcript the guard names.
+///
+/// This guard used to be `#[ignore]`d *and* gated on the relative path alone,
+/// so it was hidden from the manifest census twice over (#1862). It was also an
+/// investigation script — zero assertions, `println!` only — which per #1858 is
+/// no better than a skip: it "passed" without checking anything. It now pins
+/// what the reference measurably produces (#1858's "assert the answer" option).
+///
+/// It deliberately does **not** assert the property that script's own comment
+/// named — that a repeat unit not carried by the reference is preserved rather
+/// than read as a deletion. That property is false twice over on this locus:
+/// the reference does carry the `CA` unit here (twice), and a genuinely
+/// non-matching unit is refused before normalization ever runs, so no ferro
+/// output could witness it. The measurements are on the assertions below.
 #[cfg(test)]
 mod real_repeat_tests {
-    use ferro_hgvs::{parse_hgvs, MultiFastaProvider, Normalizer};
-    use std::path::Path;
+    use ferro_hgvs::{parse_hgvs, MultiFastaProvider, Normalizer, ReferenceProvider};
+    use std::path::{Path, PathBuf};
+
+    /// This module's name, as it appears in a `FERRO_REQUIRE_MANIFEST` failure.
+    const MODULE: &str = "normalize_tests::real_repeat_tests";
+
+    /// The prepared manifest: `FERRO_MANIFEST` authoritative when set, with the
+    /// well-known `benchmark-output/manifest.json` fallback.
+    fn manifest_path() -> Option<PathBuf> {
+        if let Ok(path) = std::env::var(crate::common::manifest::MANIFEST_ENV) {
+            let path = PathBuf::from(path);
+            return path.exists().then_some(path);
+        }
+        let fallback = Path::new("benchmark-output/manifest.json");
+        fallback.exists().then(|| fallback.to_path_buf())
+    }
+
+    /// The provider, or `None` when there is no manifest to build one from. A
+    /// manifest that is present but will not load panics rather than returning
+    /// `None`, so a stand-down is never confused with a broken reference.
+    fn get_provider() -> Option<MultiFastaProvider> {
+        let path = manifest_path()?;
+        Some(
+            MultiFastaProvider::from_manifest(&path)
+                .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display())),
+        )
+    }
 
     #[test]
-    #[ignore] // Requires reference data
     fn test_real_repeat_pattern() {
-        let ref_path = Path::new("benchmark-output/manifest.json");
-        if !ref_path.exists() {
-            eprintln!("Skipping test - benchmark-output not available");
+        let Some(provider) = get_provider() else {
+            crate::common::manifest::absent(MODULE);
+            return;
+        };
+
+        // A manifest that does not carry this transcript leaves the assertion
+        // unreached — the same coverage loss an absent manifest causes, and
+        // promoted by the same `FERRO_REQUIRE_MANIFEST`.
+        let accession = "NM_001407936.1";
+        if let Err(error) = provider.get_transcript(accession) {
+            crate::common::manifest::unserved(MODULE, accession, &error.to_string());
             return;
         }
 
-        let provider = MultiFastaProvider::from_manifest(ref_path).unwrap();
         let normalizer = Normalizer::new(provider);
+        let normalize = |input: &str| {
+            let variant =
+                parse_hgvs(input).unwrap_or_else(|error| panic!("parse {input}: {error}"));
+            let normalized = normalizer.normalize(&variant).unwrap_or_else(|error| {
+                panic!("normalize {input} against the prepared reference: {error}")
+            });
+            format!("{normalized}")
+        };
 
-        // Parse the variant
-        let variant = parse_hgvs("NM_001407936.1:c.4261_4262CA[1]").unwrap();
-        println!("Parsed: {:?}", variant);
+        // WHAT THE REFERENCE ACTUALLY READS HERE, because the whole point of
+        // this guard is that it runs against real bases. Probed base by base
+        // with `ferro normalize --reference <dir>` over the prepared reference
+        // (cdot-0.2.32): `c.4261C>T`, `c.4262A>T`, `c.4263C>T`, `c.4264A>T` and
+        // `c.4265G>T` all normalize, while `c.4260C>T`, `c.4261A>T` and
+        // `c.4265C>T` are refused at the reference check (`expected A, found C`
+        // / `expected C, found G`). So `NM_001407936.1` reads **CACAG** at
+        // c.4261-4265, preceded by `G`: the `CA` unit DOES match at 4261, and
+        // the tract is exactly two copies wide, ending at 4264.
+        //
+        // Three descriptions over that tract are pinned, because any one alone
+        // misleads about what the others do.
 
-        // Normalize
-        let result = normalizer.normalize(&variant);
-        match result {
-            Ok(normalized) => {
-                println!("Normalized: {}", normalized);
-                // If the repeat unit doesn't match at the position,
-                // we should get back the original (or c.=)
-                // NOT a deletion
-            }
-            Err(e) => {
-                println!("Error: {:?}", e);
-            }
-        }
+        // (1) THE CASE WITH TEETH — a count BELOW the reference's own copy
+        // number. The tract holds two copies of `CA` and one is asked for, so
+        // one copy goes, and ferro emits the deletion of the 3'-most one.
+        //
+        // **That deletion is correct**, and it is pinned here so that a
+        // maintainer meeting `c.4261_4264CA[1]` -> `c.4263_4264del` in the wild
+        // does not file it as a regression or "fix" it away. A shrunk repeat
+        // count denotes the removal of the surplus copies; there is no reading
+        // under which asking for one copy of a two-copy tract leaves the tract
+        // untouched.
+        //
+        // Note what is NOT reachable, since it is the property this guard's
+        // prose used to claim: a repeat unit that genuinely does not match the
+        // reference never reaches normalization at all. `c.4261_4262GT[1]` is
+        // refused up front with `Reference mismatch at 4461-4462: expected
+        // GT[1] (GT), found CA`, so "a non-matching unit is preserved rather
+        // than read as a deletion" is not a statement about any outcome ferro
+        // can produce.
+        assert_eq!(
+            normalize("NM_001407936.1:c.4261_4264CA[1]"),
+            "NM_001407936.1:c.4263_4264del",
+            "a repeat count below the reference's own copy number denotes the deletion of the \
+             surplus copies, not a preserved repeat"
+        );
+
+        // (2) THE NO-OP. Span equal to exactly ONE unit, count 1: the
+        // description asks for precisely what the reference already carries
+        // over c.4261-4262, so there is nothing to change and ferro returns it
+        // as it stands.
+        //
+        // The expected value is written out rather than compared against the
+        // input, deliberately. `c.4261_4262=` also normalizes to itself over
+        // this span, so two legal spellings of "no change" survive here, and
+        // `canonical-form-choice-when-both-legal` derives the emitted form from
+        // the RESULTING SEQUENCE rather than preserving what the caller wrote.
+        // An `assert_eq!(rendered, input)` would therefore pin
+        // spelling-preservation as though it were policy; this pins the string
+        // ferro measurably produces today. A future ruling that re-derives the
+        // no-op form has to re-pin this line on purpose, and cannot satisfy it
+        // by echoing whatever it was handed.
+        assert_eq!(
+            normalize("NM_001407936.1:c.4261_4262CA[1]"),
+            "NM_001407936.1:c.4261_4262CA[1]",
+            "a repeat description asking for the copy number the reference already carries over \
+             its own span is a no-op"
+        );
+
+        // (3) NON-VACUITY FOR (2). The preservation above is a property of that
+        // one description, not of repeats: the same one-unit span with count 2
+        // moves. So (2) is not "ferro leaves `CA[n]` alone", which is the
+        // reading it would otherwise invite.
+        assert_eq!(
+            normalize("NM_001407936.1:c.4261_4262CA[2]"),
+            "NM_001407936.1:c.4263_4264dup",
+            "the same span at a count ABOVE the reference's own is re-derived, so (2) is not \
+             repeat descriptions being passed through untouched"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #1862.

## The defect

Two reference-aware guards were hidden from #1851's manifest census twice over: both were `#[ignore]`d **and** gated on `Path::new("benchmark-output/manifest.json")` alone, ignoring `FERRO_MANIFEST`. The `#[ignore]` kept them out of every run, and the cwd-relative gate (the class #2019/#2032 address generally) meant that even un-ignored they could not see the manifest the nightly provisions. Neither was in `REFERENCE_AWARE_SELECTION`. So even on the one job that prepares a reference, these two never asserted.

| guard | file | before |
|---|---|---|
| `coverage_gap_tests::issue_11::test_flt3_itd_insertion_position_order` | `tests/it/coverage_gap_tests.rs` | 2 assertions (adjudicated-correct, issue #11) |
| `normalize_tests::real_repeat_tests::test_real_repeat_pattern` | `tests/it/normalize_tests.rs` | 0 assertions — `println!` only |

## The fix

- Give both the `FERRO_MANIFEST`-then-`benchmark-output` gate every other reference-aware module uses, routed through `ferro_hgvs::conformance::manifest_gate` (`absent` on a missing manifest, `unserved` when the reference does not carry the accession). A stand-down is now a *visible skip*, and a failure under `FERRO_REQUIRE_MANIFEST` rather than a green return.
- Drop the blanket `#[ignore]` — the gate is what it was standing in for, and it distinguishes "no reference here" from "the reference is here and this did not run".
- `test_flt3_itd_insertion_position_order` keeps its two assertions (they pin the decided `c.1837+2_1837+3` coding-order answer against the named Mutalyzer disagreement).
- `test_real_repeat_pattern` was an investigation script; per #1858's "assert the answer" option it now pins exact outputs measured against the prepared reference (cdot-0.2.32). Probed base by base, `NM_001407936.1` reads **CACAG** at `c.4261-4265`, preceded by `G` — so the `CA` unit *does* match at 4261 and the tract is exactly two copies wide, ending at 4264. Three descriptions over it are pinned:
  - **`c.4261_4264CA[1]` → `c.4263_4264del`.** This is the case that actually asks whether a shrunk repeat count is read as a deletion. It is — and **that is correct**: the tract holds two copies, one is asked for, so one goes. Pinned with that stated in the comment, so a maintainer meeting the deletion later does not file correct behaviour as a regression or "fix" it away.
  - **`c.4261_4262CA[1]` → itself.** Span equal to exactly one unit at count 1 is a no-op identity, and it round-trips.
  - **`c.4261_4262CA[2]` → `c.4263_4264dup`**, the non-vacuity control for the line above: the same span at a different count moves, so the no-op is a property of that one description and not of repeat descriptions being passed through.

  Each is pinned as an exact string rather than as `!contains("del")`, which a refusal or a dropped member would also satisfy. The no-op's expected value is written out rather than compared against the input: `c.4261_4262=` also normalizes to itself here, so two legal spellings of "no change" survive over that span, and `rulings[canonical-form-choice-when-both-legal]` derives the emitted form from the resulting sequence rather than preserving the input's spelling — an `assert_eq!(rendered, input)` would have pinned spelling-preservation as though it were policy, and would be satisfied by any implementation that echoed its input.

  **An earlier revision of this PR claimed the opposite** — that `c.4261_4262CA[1]` asks for a unit "at a position where the reference does not carry that repeat" and that "a non-matching repeat unit must be preserved unchanged, never read as a deletion". Both halves are false: the reference does carry the unit, and a genuinely non-matching one (`c.4261_4262GT[1]`) is refused before normalization runs (`expected GT[1] (GT), found CA`), so no ferro output could witness the stated property.
- Enroll both **by name** in `nightly-mutalyzer.yml`'s `REFERENCE_AWARE_SELECTION` (the only job that provisions a manifest), as specific test paths — the modules they live in carry many non-reference-aware tests, so a module-level entry would be wrong. This matches the enumerated (not globbed) convention #1851 requires.

## Scope

Held to the two guards #1862 names. The residual `#[ignore]`d reference-aware tests in `normalize_tests.rs` (tracked in #811/#834) are out of scope, as #1862 states.

## Non-vacuity (verified, not assumed)

- **Unarmed** (no manifest): both *run* (no longer ignored) and skip **visibly** (a printed `skipping — no reference manifest` line); full suite green — `11250 tests run: 11250 passed, 153 skipped`.
- **Armed** (`FERRO_MANIFEST` set to the blessed reference): both run genuinely (16.7 s / 5.2 s, not a 0.02 s stand-down) and their assertions pass.
- **Sabotage**: changing the expected `c.4263_4264del` to a wrong value goes **red** armed, printing the real computed string (`left: "NM_001407936.1:c.4263_4264del"`), then restored — proving the assertions fire against real data rather than standing down. Armed runtime is 25.5 s, not a 0.02 s stand-down.
- **Promotion**: with no manifest and `FERRO_REQUIRE_MANIFEST=1`, both **fail** rather than skip green.

## Representation stability

Representation-Change: none. Tests and CI workflow only; no watched `src/` prefix is touched.

## Verification

```
cargo fmt --all --check                                      # EXIT=0
cargo clippy --all-features --all-targets -- -D warnings     # EXIT=0
cargo nextest run --features dev --no-fail-fast              # EXIT=0, 11250 passed
actionlint .github/workflows/nightly-mutalyzer.yml           # OK
```

