### PR TITLE
feat(equivalence): opt-in confluence self-check for consumer corpora

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1302,6 +1302,76 @@ class EquivalenceChecker:
         """
         ...
 
+    def check_confluence(
+        self,
+        variants: list[HgvsVariant],
+        relation: Literal["cross_axis", "spdi"] = "cross_axis",
+    ) -> dict[str, Any]:
+        """Run the opt-in confluence self-check over a corpus of variants.
+
+        Groups the inputs into equivalence classes under ``relation`` and reports
+        every class whose members normalize to more than one distinct output — a
+        non-confluence witness. A diagnostic: it reports, and never emits a
+        pass/fail release verdict.
+
+        Args:
+            variants: The variants to check.
+            relation: ``"cross_axis"`` (default) is apply-equality on every
+                determined axis — the relation that establishes variant identity.
+                ``"spdi"`` groups by same denoted bases on the description's own
+                axis; it is weaker and insufficient for identity. Typed as a
+                ``Literal`` so a misspelling is a type error rather than a
+                runtime ``ValueError``; the binding still validates at runtime,
+                for callers that are not type-checked.
+
+                ``"cross_axis"`` has no key and so compares every pair, which is
+                quadratic in the corpus size; ``"spdi"`` keys each input once and
+                is linear. Batch by accession or sample for a large call set —
+                classes never span accessions under either relation.
+
+        Returns:
+            A dict with keys ``relation`` (str), ``is_confluent`` (bool),
+            ``is_complete`` (bool), ``classes_checked`` (int),
+            ``undecided_pairs`` (int), ``violations`` (list of
+            ``{"inputs": list[str], "outputs": list[str]}``), and ``skipped``
+            (list of ``{"input": str, "kind": str, "reason": str,
+            "decline_class": str | None, "decline_site": str | None}``).
+
+            ``is_confluent`` is an observation about this corpus under this
+            relation, not a release gate, and it is a statement about the *whole*
+            corpus only when ``is_complete`` is true — nothing skipped, and no
+            comparison undecidable. ``undecided_pairs`` counts comparisons that
+            came back undecidable rather than deciding a pair apart; such a pair
+            fails to merge exactly as a decided-apart pair does, so a non-zero
+            count means the classes are coarser than reported and violations
+            inside them are invisible. It is always 0 for ``"spdi"``, which
+            compares keys rather than pairs.
+
+            A skip's ``kind`` is ``"unplaceable"`` (the relation never placed it,
+            so it is in no class) or ``"normalization_declined"`` (it was placed,
+            and its class is counted, but it contributed no output). Coverage is
+            therefore ``classes_checked`` plus the ``"unplaceable"`` skips —
+            never ``classes_checked + len(skipped)``, which double-counts.
+
+            ``decline_class`` and ``decline_site`` are the skip's refusal as
+            machine-readable names rather than prose: the class is
+            ``"reference_unavailable"`` (the reference could not serve the bases,
+            so the description is not at fault) or ``"unrepresentable"`` (it
+            denotes no single sequence SPDI can address), and the site names
+            which check refused — ``"multi_molecule_allele"``,
+            ``"null_or_unknown_allele"``, ``"empty_allele"``,
+            ``"member_conversion"``, ``"cross_accession"`` or
+            ``"unresolved_accession"``. Compare these rather than searching
+            ``reason`` for a keyword; ``reason`` is a rendering of them and its
+            wording is not API. Both are ``None`` where there is no such refusal
+            to report: a ``"normalization_declined"`` skip, and the ``"spdi"``
+            first-pass mismatch (keyless here, yet its triples project).
+
+        Raises:
+            ValueError: If ``relation`` is not ``"cross_axis"`` or ``"spdi"``.
+        """
+        ...
+
 # ============================================================================
 # Effect Prediction Classes
 # ============================================================================

--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -1,5 +1,8 @@
 //! Equivalence checker implementation.
 
+use super::confluence::{
+    ConfluenceGroup, ConfluenceRelation, ConfluenceReport, ConfluenceSkip, ConfluenceSkipKind,
+};
 use crate::convert::CoordinateMapper;
 use crate::error::FerroError;
 use crate::hgvs::edit::{InsertedPart, InsertedSequence, NaEdit, RepeatCount};
@@ -1125,17 +1128,23 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                 // A single resulting sequence is only well-defined for a cis
                 // allele — all edits applied to the same molecule.
                 if allele.phase != AllelePhase::Cis {
-                    return Err(TripleDecline::Unrepresentable);
+                    return Err(TripleDecline::Unrepresentable(
+                        DeclineSite::MultiMoleculeAllele {
+                            phase: allele.phase,
+                        },
+                    ));
                 }
                 allele.variants.iter().collect()
             }
             HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => {
-                return Err(TripleDecline::Unrepresentable)
+                return Err(TripleDecline::Unrepresentable(
+                    DeclineSite::NullOrUnknownAllele,
+                ))
             }
             single => vec![single],
         };
         if members.is_empty() {
-            return Err(TripleDecline::Unrepresentable);
+            return Err(TripleDecline::Unrepresentable(DeclineSite::EmptyAllele));
         }
 
         let mut accession: Option<String> = None;
@@ -1145,14 +1154,23 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                 .map_err(TripleDecline::from_conversion_error)?;
             match &accession {
                 None => accession = Some(spdi.sequence.clone()),
-                Some(acc) if *acc != spdi.sequence => return Err(TripleDecline::Unrepresentable),
+                Some(acc) if *acc != spdi.sequence => {
+                    return Err(TripleDecline::Unrepresentable(
+                        DeclineSite::CrossAccession {
+                            first: acc.clone(),
+                            second: spdi.sequence,
+                        },
+                    ))
+                }
                 Some(_) => {}
             }
             triples.push(spdi);
         }
         accession
             .map(|acc| (acc, triples))
-            .ok_or(TripleDecline::Unrepresentable)
+            .ok_or(TripleDecline::Unrepresentable(
+                DeclineSite::UnresolvedAccession,
+            ))
     }
 
     /// Fetch reference bases for the 0-based half-open interval
@@ -1252,6 +1270,252 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
 
         Ok(groups)
     }
+
+    /// Run the opt-in confluence self-check over `variants` (#1892).
+    ///
+    /// Groups the inputs into equivalence classes under `relation` and reports
+    /// every class whose members normalize to more than one distinct output — a
+    /// non-confluence witness. It is a **diagnostic**: it reports, it never emits
+    /// a pass/fail release verdict, and it does not decide which relation gates a
+    /// release (that is the deferred adjudication in #1890 — the caller chooses
+    /// `relation`).
+    ///
+    /// The grouping never consults the normalizer, so it cannot collapse into the
+    /// outputs it checks:
+    ///
+    /// * [`ConfluenceRelation::CrossAxisSequenceMatch`] groups pairwise via
+    ///   [`Self::compare_denotations`], greedily against each class's first
+    ///   member. Apply-equality is a true equivalence relation over decided
+    ///   pairs, so a greedy pass is sound for them.
+    /// * [`ConfluenceRelation::Spdi`] groups by
+    ///   [`spdi_key`](super::key::spdi_key), via the public
+    ///   [`group_by_spdi_key`](super::key::group_by_spdi_key), so there is one
+    ///   grouping rule rather than two spellings of it.
+    ///
+    /// # What the run could not cover, and why it is never silence
+    ///
+    /// Under **either** relation an input whose denotation is not computable
+    /// against this reference is
+    /// [`skipped`](ConfluenceReport::skipped) as
+    /// [`Unplaceable`](super::ConfluenceSkipKind::Unplaceable), carrying the
+    /// underlying refusal. Placing such an input as a singleton would be a false
+    /// claim that the relation had placed it, and a singleton can never be a
+    /// violation, so the corpus would read cleaner than it was examined.
+    ///
+    /// A member the normalizer declines is skipped as
+    /// [`NormalizationDeclined`](super::ConfluenceSkipKind::NormalizationDeclined)
+    /// and excluded from its class's output set, so one bad input never aborts
+    /// the run. Its class *was* formed and is counted in
+    /// [`classes_checked`](ConfluenceReport::classes_checked) — the two skip
+    /// kinds are excluded from the accounting differently, which is why they are
+    /// distinguishable.
+    ///
+    /// Under [`ConfluenceRelation::CrossAxisSequenceMatch`] a *pair* whose
+    /// comparison came back undecidable — over the checker's window cap, or a
+    /// shape the relation errors on — does not merge, which is byte-identical to
+    /// what a pair decided *apart* does. Left there, a class the checker could
+    /// not examine would be split into singletons and reported exactly like a
+    /// clean corpus. Each such comparison is therefore counted in
+    /// [`undecided_pairs`](ConfluenceReport::undecided_pairs), and
+    /// [`is_complete`](ConfluenceReport::is_complete) is the one predicate that
+    /// says the report covers everything it was handed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ferro_hgvs::equivalence::{ConfluenceRelation, EquivalenceChecker};
+    /// use ferro_hgvs::{parse_hgvs, MockProvider};
+    ///
+    /// let mut provider = MockProvider::new();
+    /// provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCTGA");
+    /// let checker = EquivalenceChecker::new(provider);
+    ///
+    /// let corpus = [
+    ///     parse_hgvs("NC_KEY.1:g.13_14insT").unwrap(),
+    ///     parse_hgvs("NC_KEY.1:g.14dup").unwrap(),
+    /// ];
+    /// let report =
+    ///     checker.check_confluence(&corpus, ConfluenceRelation::CrossAxisSequenceMatch);
+    /// assert!(report.is_confluent());
+    /// ```
+    pub fn check_confluence(
+        &self,
+        variants: &[HgvsVariant],
+        relation: ConfluenceRelation,
+    ) -> ConfluenceReport {
+        let mut skipped: Vec<ConfluenceSkip> = Vec::new();
+        let (classes, undecided_pairs) = match relation {
+            ConfluenceRelation::CrossAxisSequenceMatch => {
+                self.group_by_cross_axis(variants, &mut skipped)
+            }
+            // Key equality is exact: there is no pair to fail to decide.
+            ConfluenceRelation::Spdi => (self.group_by_spdi(variants, &mut skipped), 0),
+        };
+
+        let mut violations = Vec::new();
+        let classes_checked = classes.len();
+        for class in &classes {
+            let mut members = Vec::with_capacity(class.len());
+            for variant in class {
+                let input = variant.to_string();
+                match self.normalizer.normalize(variant) {
+                    Ok(normalized) => members.push((input, normalized.to_string())),
+                    Err(error) => skipped.push(ConfluenceSkip {
+                        input,
+                        kind: ConfluenceSkipKind::NormalizationDeclined,
+                        reason: format!("normalization failed: {error}"),
+                        // The normalizer refused, not the projection — this input
+                        // *was* placed. There is no `TripleDecline` to report.
+                        decline: None,
+                    }),
+                }
+            }
+            if let Some(group) = ConfluenceGroup::from_class(members) {
+                violations.push(group);
+            }
+        }
+
+        ConfluenceReport::new(
+            relation,
+            violations,
+            classes_checked,
+            skipped,
+            undecided_pairs,
+        )
+    }
+
+    /// Group inputs into equivalence classes under
+    /// [`ConfluenceRelation::CrossAxisSequenceMatch`], greedily: each variant
+    /// joins the first class whose representative it is apply-equal to on every
+    /// determined axis, or starts a new one. Uses [`Self::compare_denotations`],
+    /// which never normalizes, so the grouping is independent of the outputs the
+    /// caller will compare.
+    ///
+    /// Returns the classes and **how many comparisons came back undecidable**.
+    /// That second number is the whole reason this is not a two-line function.
+    /// A greedy pass is sound over *decided* pairs, and apply-equality is only
+    /// an equivalence relation over those; a pair the checker could not examine
+    /// does not merge, and a non-merge is what a decided negative looks like
+    /// too. Reporting only the classes would therefore present a corpus the
+    /// checker could not read as one it read and found clean. So the three
+    /// outcomes are kept apart:
+    ///
+    /// * **merge** — the pair is at least
+    ///   [`EquivalenceLevel::CrossAxisSequenceMatch`];
+    /// * **decided apart** — the checker examined the pair and reported a
+    ///   verdict ([`is_decided`](EquivalenceLevel::is_decided)) that is not at
+    ///   that rung: two different variants, two accession versions, or agreement
+    ///   on the own axis only;
+    /// * **undecidable** — [`EquivalenceLevel::Indeterminate`], or an `Err` for
+    ///   a shape the relation refuses to answer about. Counted.
+    ///
+    /// Inputs with no computable denotation are screened out **before** the
+    /// pairwise pass, once each rather than once per comparison: every
+    /// comparison involving one of them declines, so leaving them in would both
+    /// inflate the undecidable count quadratically and place, as a singleton
+    /// class, an input the relation never placed. They are reported as
+    /// [`Unplaceable`](super::ConfluenceSkipKind::Unplaceable) skips instead —
+    /// the same treatment [`ConfluenceRelation::Spdi`] already gives a keyless
+    /// input.
+    fn group_by_cross_axis<'v>(
+        &self,
+        variants: &'v [HgvsVariant],
+        skipped: &mut Vec<ConfluenceSkip>,
+    ) -> (Vec<Vec<&'v HgvsVariant>>, usize) {
+        let mut groups: Vec<Vec<&'v HgvsVariant>> = Vec::new();
+        let mut undecided_pairs = 0usize;
+        for variant in variants {
+            if let Err(decline) = self.edit_triples(variant) {
+                skipped.push(ConfluenceSkip {
+                    input: variant.to_string(),
+                    kind: ConfluenceSkipKind::Unplaceable,
+                    reason: decline.clone().into_reason(variant),
+                    decline: Some(decline),
+                });
+                continue;
+            }
+            let mut placed = false;
+            for group in &mut groups {
+                let representative = group[0];
+                match self.compare_denotations(representative, variant) {
+                    Ok(result)
+                        if result
+                            .level
+                            .is_at_least(EquivalenceLevel::CrossAxisSequenceMatch) =>
+                    {
+                        group.push(variant);
+                        placed = true;
+                        break;
+                    }
+                    // Examined and not equal at the required rung. A real
+                    // non-merge; nothing is lost by it.
+                    Ok(result) if result.level.is_decided() => {}
+                    // Nothing examined the pair. It does not merge either, and
+                    // that is exactly the outcome that must not pass as a
+                    // decision.
+                    Ok(_) | Err(_) => undecided_pairs += 1,
+                }
+            }
+            if !placed {
+                groups.push(vec![variant]);
+            }
+        }
+        (groups, undecided_pairs)
+    }
+
+    /// Group inputs under [`ConfluenceRelation::Spdi`], by
+    /// [`spdi_key`](super::key::spdi_key). An input with no key cannot be placed
+    /// and is recorded in `skipped` rather than grouped, because two keyless
+    /// inputs say nothing about each other. Buckets are returned in a
+    /// deterministic (key) order.
+    ///
+    /// Delegates to the public [`group_by_spdi_key`](super::key::group_by_spdi_key)
+    /// rather than re-deriving the buckets, so this module cannot drift from the
+    /// crate's one SPDI grouping rule. What it adds is the *reason* for each
+    /// refusal, which the grouping does not carry: `spdi_key` answers `None`
+    /// both for a description that denotes no single resolvable sequence to
+    /// anyone **and** for reference bases this provider could not serve, and
+    /// telling a consumer with a partly-provisioned reference that its own
+    /// well-formed descriptions were at fault is a misdiagnosis. The reason is
+    /// recovered from [`canonical_spdi`](crate::spdi::canonical_spdi), which
+    /// `spdi_key` documents as the route to it — paid only on the inputs that
+    /// were refused.
+    fn group_by_spdi<'v>(
+        &self,
+        variants: &'v [HgvsVariant],
+        skipped: &mut Vec<ConfluenceSkip>,
+    ) -> Vec<Vec<&'v HgvsVariant>> {
+        let grouping = super::key::group_by_spdi_key(variants.iter(), self.normalizer.provider());
+        let (buckets, unkeyable) = grouping.into_parts();
+        for variant in unkeyable {
+            // Ask the *classifier* for the reason, not `canonical_spdi`'s
+            // `FerroError`. Both answer "this input has no SPDI denotation here",
+            // but only `edit_triples` splits that into the two readings a consumer
+            // acts on differently, so this is what gives the SPDI relation the
+            // same derived reference-vs-description split the cross-axis relation
+            // has — rather than leaving it to be recovered by sniffing an error
+            // string for the word "reference".
+            let decline = self.edit_triples(variant).err();
+            let reason = match &decline {
+                Some(decline) => decline.clone().into_reason(variant),
+                // The two routes disagree: `spdi_key` is `canonical_spdi().ok()`,
+                // which shifts against the reference, while `edit_triples` converts
+                // in place — so an input can be keyless here and still project. It
+                // is genuinely unplaceable (the grouping refused it) and there is no
+                // classified refusal to report, which is what `decline: None` says.
+                None => format!(
+                    "{variant}: no SPDI key on the first pass, though its triples do project"
+                ),
+            };
+            skipped.push(ConfluenceSkip {
+                input: variant.to_string(),
+                kind: ConfluenceSkipKind::Unplaceable,
+                reason,
+                decline,
+            });
+        }
+        buckets.into_values().collect()
+    }
 }
 
 /// What a sequence-level comparison concluded.
@@ -1326,18 +1590,125 @@ enum SequenceVerdict {
 /// same distinction one step earlier, at the per-member HGVS→SPDI conversion,
 /// which the ordinary short forms (`g.2del`, `g.2dup`) must run against the
 /// provider.
-enum TripleDecline {
+///
+/// # Scope: this covers ONE of the three reference-failure routes
+///
+/// A reference-level obstacle reaches the checker by three distinct routes, at
+/// three different stages, and this type is the vocabulary for exactly one of
+/// them. Filing a decline under the wrong one is the mistake to avoid:
+///
+/// 1. **Projection** — a member's HGVS→SPDI conversion needs bases the provider
+///    cannot serve (#2056). **This type**, as
+///    [`ReferenceUnavailable`](Self::ReferenceUnavailable) with site
+///    [`DeclineSite::MemberConversion`]. It is a property of a *single input*, so
+///    it is the only one of the three that can become a
+///    [`ConfluenceSkip`](super::ConfluenceSkip).
+/// 2. **Window fetch** — both sides convert, but the union window cannot be
+///    served (#1989/#2053). [`SequenceVerdict::ReferenceUnavailable`], raised in
+///    [`compare_triples`].
+/// 3. **Application** — the window is served, and a triple's stated bases
+///    contradict the bases it actually carries (#2075). Also
+///    [`SequenceVerdict::ReferenceUnavailable`].
+///
+/// Routes 2 and 3 are properties of a *pair*, decided after projection, so they
+/// are deliberately absent here: they make a comparison undecidable rather than
+/// making an input unplaceable, and the confluence report counts them in
+/// [`undecided_pairs`](super::ConfluenceReport::undecided_pairs) rather than
+/// skipping anything. **Do not add a route-2 or route-3 variant to
+/// [`DeclineSite`]** — no `edit_triples` call site could construct it, which
+/// would make the exhaustive match in [`Self::into_reason`] guard nothing.
+///
+/// If an apply-stage decline is ever surfaced to a consumer, note that route 3
+/// is a **third class**, not a third site: the description is well formed *and*
+/// the reference is available *and* they contradict each other, which a consumer
+/// acts on differently from either arm below (fix the input, versus provision the
+/// reference). It would be a new [`TripleDecline`] variant — or, better, its own
+/// type — never a re-use of one of these two.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TripleDecline {
     /// A member's HGVS→SPDI conversion needed reference bases the provider could
     /// not serve ([`ConversionError::MissingReferenceData`] or
     /// [`ConversionError::ProviderRequired`]). "Want of reference data", not a
     /// representation limit — resolves to [`EquivalenceLevel::Indeterminate`].
-    ReferenceUnavailable,
+    ReferenceUnavailable(DeclineSite),
     /// No single resulting sequence exists to compare: an edit SPDI cannot
     /// carry, a position SPDI cannot address
     /// ([`ConversionError::UnrepresentableInSpdi`] — an intronic `c.`/`n.`/`r.`
     /// offset), a null/unknown or multi-molecule allele, an empty member list,
     /// or members spanning more than one accession. Read as a decided negative.
-    Unrepresentable,
+    Unrepresentable(DeclineSite),
+}
+
+/// **Which** of [`EquivalenceChecker::edit_triples`]' refusal sites declined,
+/// with the detail only that site can state.
+///
+/// This is the machine-readable half of a decline. [`TripleDecline`] says which
+/// *class* the refusal is in — the distinction that decides a verdict, and the
+/// one a consumer with a partly-provisioned reference most needs — and this says
+/// which *site* produced it. Neither is prose: the sentence a
+/// [`ConfluenceSkip`](super::ConfluenceSkip) carries is rendered from the pair by
+/// [`TripleDecline::into_reason`], in one place, so a consumer can `match` on why
+/// grouping declined instead of parsing English.
+///
+/// Note the two axes are not independent in practice: every site except
+/// [`MemberConversion`](Self::MemberConversion) is reached only by a direct
+/// `Unrepresentable` construction, because only a [`ConversionError`] can be
+/// "want of reference data". So six sites yield **seven** reachable
+/// `(class, site)` pairs, which is what
+/// `every_reachable_decline_renders_a_distinct_message` enumerates.
+///
+/// `#[non_exhaustive]` is for downstream crates only — within this crate the
+/// attribute has no effect, which is exactly what makes
+/// [`TripleDecline::into_reason`]'s wildcard-free match a compile error when a
+/// seventh site is added. That is deliberate and is the same reasoning
+/// [`TripleDecline::from_conversion_error`] records for [`ConversionError`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DeclineSite {
+    /// The description is an allele whose phase names more than one molecule
+    /// (trans / mosaic / chimeric / and-or / products / unknown).
+    MultiMoleculeAllele {
+        /// The phase that said so.
+        phase: AllelePhase,
+    },
+    /// The description is `0` or `?` — it states no sequence at all.
+    NullOrUnknownAllele,
+    /// The description is an allele with no members.
+    EmptyAllele,
+    /// A member's HGVS→SPDI conversion refused. **The only site that can be
+    /// either class**, since it is the only one holding a [`ConversionError`].
+    MemberConversion {
+        /// The conversion's own refusal, kept rather than discarded.
+        error: ConversionError,
+    },
+    /// The allele's members do not all act on one accession.
+    CrossAccession {
+        /// The accession the earlier members fixed.
+        first: String,
+        /// The differing accession a later member named.
+        second: String,
+    },
+    /// No member fixed an accession, so there is nothing to act on.
+    UnresolvedAccession,
+}
+
+impl DeclineSite {
+    /// The stable name this site is spelled with outside Rust — the
+    /// `decline_site` field of a rendered report.
+    ///
+    /// Wildcard-free for the same reason
+    /// [`TripleDecline::into_reason`] is: a seventh site must be a compile error
+    /// here rather than silently borrowing a sixth site's name.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DeclineSite::MultiMoleculeAllele { .. } => "multi_molecule_allele",
+            DeclineSite::NullOrUnknownAllele => "null_or_unknown_allele",
+            DeclineSite::EmptyAllele => "empty_allele",
+            DeclineSite::MemberConversion { .. } => "member_conversion",
+            DeclineSite::CrossAccession { .. } => "cross_accession",
+            DeclineSite::UnresolvedAccession => "unresolved_accession",
+        }
+    }
 }
 
 impl TripleDecline {
@@ -1355,24 +1726,106 @@ impl TripleDecline {
     /// [`ConversionError`] is a compile error at exactly the site that has to
     /// decide what it means.
     fn from_conversion_error(err: ConversionError) -> Self {
+        let site = DeclineSite::MemberConversion { error: err.clone() };
         match err {
             // Answerable by a better-provisioned provider: "could not tell".
             ConversionError::MissingReferenceData { .. }
-            | ConversionError::ProviderRequired { .. } => TripleDecline::ReferenceUnavailable,
+            | ConversionError::ProviderRequired { .. } => TripleDecline::ReferenceUnavailable(site),
             // Decided by the description alone; no provider changes the answer.
             ConversionError::UnrepresentableInSpdi { .. }
             | ConversionError::UnsupportedVariantType { .. }
             | ConversionError::UnsupportedEditType { .. }
             | ConversionError::InvalidPosition { .. }
-            | ConversionError::InvalidAccession { .. } => TripleDecline::Unrepresentable,
+            | ConversionError::InvalidAccession { .. } => TripleDecline::Unrepresentable(site),
         }
+    }
+
+    /// The refusal site this decline came from.
+    pub fn site(&self) -> &DeclineSite {
+        match self {
+            TripleDecline::ReferenceUnavailable(site) | TripleDecline::Unrepresentable(site) => {
+                site
+            }
+        }
+    }
+
+    /// The stable name this decline's **class** is spelled with outside Rust —
+    /// the `decline_class` field of a rendered report. It is the same split
+    /// [`Self::class_clause`] renders in prose, in a form a caller can compare
+    /// without parsing English.
+    pub fn class_str(&self) -> &'static str {
+        match self {
+            TripleDecline::ReferenceUnavailable(_) => "reference_unavailable",
+            TripleDecline::Unrepresentable(_) => "unrepresentable",
+        }
+    }
+
+    /// The class-level clause, which is what separates the two readings a
+    /// consumer acts on differently. Kept as a `&'static str` so a test can key
+    /// on **this constant** rather than on a literal it retypes — rewording it
+    /// moves the assertion with it, while misclassifying a site emits the other
+    /// clause and fails.
+    fn class_clause(&self) -> &'static str {
+        match self {
+            TripleDecline::ReferenceUnavailable(_) => {
+                "the reference could not serve the bases its SPDI conversion needs, so this is \
+                 not a fault in the description"
+            }
+            TripleDecline::Unrepresentable(_) => {
+                "it denotes no single resulting sequence SPDI can address"
+            }
+        }
+    }
+
+    /// Render this decline as the sentence a [`ConfluenceSkip`] carries for `v`.
+    ///
+    /// **The only place decline prose exists.** The call sites construct typed
+    /// [`DeclineSite`]s and state no message, so there is one wording per
+    /// `(class, site)` pair and no second copy to drift from it. The sentence is
+    /// a *rendering* of the pair — a consumer that needs to act on the reason
+    /// matches on [`TripleDecline`] and [`DeclineSite`] instead of reading this.
+    ///
+    /// **The site match is deliberately wildcard-free.** A `_ =>` arm would let a
+    /// seventh refusal site compile and render as whichever generic sentence sat
+    /// in it, telling the consumer "could not group" with no way to tell a site
+    /// we understand from one we forgot — the same shape as a check that cannot
+    /// distinguish "examined and fine" from "never examined". Spelled out, adding
+    /// a site is a compile error here, at the one place that has to decide what
+    /// it means.
+    ///
+    /// Rendering is deliberately **not** done at the decline site. `edit_triples`
+    /// runs on the ladder's `O(n²)` pairwise path, where every decline would then
+    /// pay a `Display` of the whole variant and an allocation for a string
+    /// nothing reads. Here it is paid once, only when a skip is actually
+    /// recorded.
+    pub fn into_reason(self, v: &HgvsVariant) -> String {
+        let clause = self.class_clause();
+        let detail = match self.site() {
+            DeclineSite::MultiMoleculeAllele { phase } => {
+                format!("a {phase} allele names more than one molecule")
+            }
+            DeclineSite::NullOrUnknownAllele => {
+                "a null or unknown allele states no sequence at all".to_string()
+            }
+            DeclineSite::EmptyAllele => "an allele with no members states no sequence".to_string(),
+            DeclineSite::MemberConversion { error } => {
+                format!("a member's HGVS→SPDI conversion refused: {error}")
+            }
+            DeclineSite::CrossAccession { first, second } => {
+                format!("its members span more than one accession ({first} and {second})")
+            }
+            DeclineSite::UnresolvedAccession => {
+                "no accession could be resolved for its members".to_string()
+            }
+        };
+        format!("{v}: {clause} — {detail}")
     }
 
     /// The [`SequenceVerdict`] this decline maps to at the sequence rung.
     fn into_sequence_verdict(self) -> SequenceVerdict {
         match self {
-            TripleDecline::ReferenceUnavailable => SequenceVerdict::ReferenceUnavailable,
-            TripleDecline::Unrepresentable => SequenceVerdict::Declined,
+            TripleDecline::ReferenceUnavailable(_) => SequenceVerdict::ReferenceUnavailable,
+            TripleDecline::Unrepresentable(_) => SequenceVerdict::Declined,
         }
     }
 }

--- a/src/equivalence/confluence.rs
+++ b/src/equivalence/confluence.rs
@@ -1,0 +1,614 @@
+//! An opt-in confluence self-check a consumer can run on its own data (#1892).
+//!
+//! # What confluence is here
+//!
+//! The property the project states is "`normalize` is constant on each
+//! equivalence class" — the ruling
+//! `confluence-gate-is-apply-equality-on-every-determined-axis`. The equivalence
+//! class is defined by `apply` (description → bases), never by `normalize`, so
+//! the statement is not circular: two descriptions that are apply-equal must
+//! normalize to one string, and a class that reaches two is a **non-confluence
+//! witness**.
+//!
+//! # Why a consumer needs to run it on their own data
+//!
+//! The designed cis corpus is enriched for multi-member shapes, so its
+//! non-confluence rate is a rate *of that shape family* and tells a consumer
+//! nothing about the variants they actually hold. This self-check answers the
+//! question they can only answer for themselves: over *my* call set, are any two
+//! apply-equal descriptions normalized apart?
+//!
+//! # What it is, and what it deliberately is not
+//!
+//! It **composes** two pieces of decided machinery — the equivalence relation
+//! ([`EquivalenceChecker`](crate::equivalence::EquivalenceChecker)) and the
+//! normalizer — and reports. It groups the inputs into equivalence classes under
+//! a caller-chosen [`ConfluenceRelation`], normalizes each member, and records
+//! every class that reaches more than one distinct normalized output.
+//!
+//! It is a **diagnostic**, not an error and not a release gate:
+//!
+//! * It reports offending groups so a consumer can count them and sample in
+//!   production; making it an error would make it unusable in a pipeline.
+//! * It does **not** decide *which* relation gates a release — that is the
+//!   deferred adjudication in #1890. The relation is the caller's parameter, and
+//!   both variants of [`ConfluenceRelation`] name relations that are already
+//!   decided and documented in this module. The check emits no pass/fail verdict.
+//!
+//! # Choosing the relation
+//!
+//! [`ConfluenceRelation::CrossAxisSequenceMatch`] is the relation the confluence
+//! ruling names: apply-equality on **every determined axis**
+//! ([`EquivalenceLevel::CrossAxisSequenceMatch`](crate::equivalence::EquivalenceLevel::CrossAxisSequenceMatch)),
+//! the rung that establishes variant identity. It is the right default for
+//! "are two descriptions of *one variant* normalized apart?".
+//!
+//! [`ConfluenceRelation::Spdi`] groups by the encoding-invariant
+//! [`SpdiKey`](crate::equivalence::SpdiKey) — same bases on the description's own
+//! axis. It is **weaker** and *insufficient for variant identity*: it buckets
+//! `c.3921dup` with `c.3922dup`, which denote the same transcript bases but
+//! project ~2,790 bp apart into different exons. It is offered because a consumer
+//! counting distinct edits may want it and because #1892 names it, never as a
+//! confluence gate.
+//!
+//! # Cost: the default relation is quadratic, the SPDI one is not
+//!
+//! The two relations are not interchangeable on cost, and the difference is a
+//! complexity class rather than a constant. [`ConfluenceRelation::Spdi`] keys
+//! each input **once** and buckets it, so it is `O(n)` key derivations.
+//! [`ConfluenceRelation::CrossAxisSequenceMatch`] has no key — apply-equality is
+//! only computable pairwise — so it compares each input against every class
+//! representative so far, which is `O(n²)`
+//! [`compare_denotations`](crate::equivalence::EquivalenceChecker::compare_denotations)
+//! calls in the worst case (a corpus of distinct variants, which is the usual
+//! shape of a call set). Each call does its own SPDI conversion and reference
+//! fetches.
+//!
+//! **The ratio is the claim; the milliseconds are not.** Two independent debug
+//! builds over `n` distinct genomic substitutions agree on the shape and not on
+//! the constants, so read the growth and re-measure the absolutes rather than
+//! quoting them. One of the two, `n` = 50 / 100 / 200 / 400: cross-axis
+//! 18.7 / 60.0 / 218.9 / 1032.2 ms against SPDI 5.1 / 3.6 / 11.0 / 15.0 ms —
+//! that is roughly 3–5x per doubling on the left and no consistent growth at
+//! this scale on the right. The corpus is the worst case by construction: every
+//! input is a distinct variant, so no class ever absorbs another and every
+//! comparison is paid.
+//!
+//! **There is deliberately no cap and no automatic downgrade.** A cap would have
+//! to decide *which* pairs to stop comparing, and every such choice silently
+//! shrinks the classes — which is the failure this module exists to prevent (see
+//! [`ConfluenceSkip`]): a corpus whose comparisons were truncated reports fewer
+//! violations, not more skips. Downgrading to [`ConfluenceRelation::Spdi`] on
+//! size would answer a *different question* under the same name, and that
+//! relation is documented as insufficient for variant identity. So the cost is
+//! stated here and left to the caller, who is the only party that can choose
+//! between "the identity relation over a sample" and "a weaker relation over
+//! everything". For a call-set-scale run, batch by accession (classes never span
+//! accessions under either relation) or sample.
+//!
+//! ```
+//! use ferro_hgvs::equivalence::{ConfluenceRelation, EquivalenceChecker};
+//! use ferro_hgvs::{parse_hgvs, MockProvider};
+//!
+//! let mut provider = MockProvider::new();
+//! provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCTGA");
+//! let checker = EquivalenceChecker::new(provider);
+//!
+//! // Two spellings of one insertion — apply-equal, and the normalizer converges
+//! // them, so the corpus is confluent.
+//! let corpus = [
+//!     parse_hgvs("NC_KEY.1:g.13_14insT").unwrap(),
+//!     parse_hgvs("NC_KEY.1:g.14dup").unwrap(),
+//! ];
+//! let report = checker.check_confluence(&corpus, ConfluenceRelation::CrossAxisSequenceMatch);
+//! assert!(report.is_confluent());
+//! ```
+
+use super::checker::TripleDecline;
+use std::collections::BTreeSet;
+
+/// The equivalence relation a [`check_confluence`] run groups its inputs by.
+///
+/// Confluence is "`normalize` is constant on each equivalence class"; this names
+/// which relation defines the class. Both variants are **decided, documented**
+/// relations already in this crate — the caller chooses; the self-check does not
+/// decide which relation gates a release (#1890).
+///
+/// `#[non_exhaustive]` so a future relation is not a breaking change, mirroring
+/// [`EquivalenceLevel`](crate::equivalence::EquivalenceLevel).
+///
+/// [`check_confluence`]: crate::equivalence::EquivalenceChecker::check_confluence
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ConfluenceRelation {
+    /// Apply-equality on **every determined axis**
+    /// ([`EquivalenceLevel::CrossAxisSequenceMatch`](crate::equivalence::EquivalenceLevel::CrossAxisSequenceMatch)) —
+    /// the relation the confluence ruling names and the rung that establishes
+    /// variant identity. Grouped pairwise via
+    /// [`EquivalenceChecker::compare_denotations`](crate::equivalence::EquivalenceChecker::compare_denotations),
+    /// which never consults the normalizer, so the grouping cannot collapse into
+    /// the outputs it is checking.
+    CrossAxisSequenceMatch,
+    /// Same denoted bases on the description's own axis, via the
+    /// encoding-invariant [`SpdiKey`](crate::equivalence::SpdiKey). **Weaker**
+    /// than the above and insufficient for variant identity; use it for counting
+    /// distinct edits, never as a confluence gate.
+    Spdi,
+}
+
+impl ConfluenceRelation {
+    /// The stable name this relation is spelled with outside Rust — the Python
+    /// binding's `relation=` argument and the `relation` field of a rendered
+    /// report.
+    ///
+    /// Exhaustive on purpose: this crate's own matches on a `#[non_exhaustive]`
+    /// enum are still checked for exhaustiveness (the attribute only binds
+    /// downstream crates), so adding a relation fails the build **here**, next
+    /// to [`Self::from_name`], rather than in a binding that silently keeps
+    /// answering for the relations it already knows.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ConfluenceRelation::CrossAxisSequenceMatch => "cross_axis",
+            ConfluenceRelation::Spdi => "spdi",
+        }
+    }
+
+    /// The inverse of [`Self::as_str`], or `None` for an unknown name.
+    ///
+    /// Deliberately co-located with `as_str`: this direction matches on a
+    /// `&str`, so no compiler check can force a new relation to gain an arm.
+    /// The pairing is pinned by `every_relation_round_trips_through_its_name`.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "cross_axis" => Some(ConfluenceRelation::CrossAxisSequenceMatch),
+            "spdi" => Some(ConfluenceRelation::Spdi),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ConfluenceRelation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One equivalence class whose members normalized to more than one distinct
+/// output — a non-confluence witness.
+///
+/// A confluent class produces no `ConfluenceGroup`; see
+/// [`ConfluenceGroup::from_class`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ConfluenceGroup {
+    /// The class members' rendered input descriptions, in input order.
+    pub inputs: Vec<String>,
+    /// The **distinct** normalized outputs the class reached, sorted. Length is
+    /// always at least two — a class with one output is confluent and yields no
+    /// group.
+    pub outputs: Vec<String>,
+}
+
+impl ConfluenceGroup {
+    /// Build a violation from one equivalence class's `(input, normalized_output)`
+    /// members, or `None` when the class is **confluent** — its members reach at
+    /// most one distinct normalized output.
+    ///
+    /// This is the flagging rule in isolation: it deduplicates and sorts the
+    /// outputs and returns `Some` exactly when more than one survives. The inputs
+    /// are recorded in the order given so a consumer can see which descriptions
+    /// collided.
+    pub(crate) fn from_class(members: impl IntoIterator<Item = (String, String)>) -> Option<Self> {
+        let mut inputs = Vec::new();
+        let mut outputs = BTreeSet::new();
+        for (input, output) in members {
+            inputs.push(input);
+            outputs.insert(output);
+        }
+        if outputs.len() > 1 {
+            Some(ConfluenceGroup {
+                inputs,
+                outputs: outputs.into_iter().collect(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Which stage of a [`check_confluence`] run dropped an input, for a consumer
+/// that needs to account for coverage rather than read a message.
+///
+/// The two are **not** interchangeable, and reading them as one is how a
+/// coverage figure goes wrong — see [`ConfluenceReport::classes_checked`].
+///
+/// [`check_confluence`]: crate::equivalence::EquivalenceChecker::check_confluence
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ConfluenceSkipKind {
+    /// The chosen relation could not place the input at all, so it is in **no**
+    /// class and is not counted in
+    /// [`classes_checked`](ConfluenceReport::classes_checked).
+    Unplaceable,
+    /// The input *was* placed in a class — so its class **is** counted in
+    /// [`classes_checked`](ConfluenceReport::classes_checked) — but the
+    /// normalizer declined it, so it contributed no output to that class's
+    /// output set.
+    NormalizationDeclined,
+}
+
+impl ConfluenceSkipKind {
+    /// The stable name this kind is spelled with outside Rust.
+    ///
+    /// Exhaustive for the reason given on [`ConfluenceRelation::as_str`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ConfluenceSkipKind::Unplaceable => "unplaceable",
+            ConfluenceSkipKind::NormalizationDeclined => "normalization_declined",
+        }
+    }
+}
+
+impl std::fmt::Display for ConfluenceSkipKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// An input the confluence analysis could not fully cover, with why.
+///
+/// A skip is **not** a pass. It is surfaced as a first-class part of the report
+/// so a consumer knows exactly how much of its call set the analysis does not
+/// cover — a silent drop that read as confluence is the failure this check
+/// exists to prevent. Two things land here, kept apart by
+/// [`kind`](Self::kind): an input the chosen relation cannot place
+/// ([`ConfluenceSkipKind::Unplaceable`] — no computable denotation on this
+/// reference, so no [`SpdiKey`](crate::equivalence::SpdiKey) under
+/// [`ConfluenceRelation::Spdi`] and no comparable triples under
+/// [`ConfluenceRelation::CrossAxisSequenceMatch`]), and an input the normalizer
+/// declined ([`ConfluenceSkipKind::NormalizationDeclined`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ConfluenceSkip {
+    /// The rendered input description that was skipped.
+    pub input: String,
+    /// Which stage dropped it.
+    pub kind: ConfluenceSkipKind,
+    /// The refusal, **typed**, when one was produced: which class it is in
+    /// ([`TripleDecline`]) and which site it came from
+    /// ([`DeclineSite`](crate::equivalence::DeclineSite)).
+    ///
+    /// This is the field to act on. It separates "this description denotes no
+    /// sequence to anyone" from "this reference could not serve the bases" —
+    /// which read very differently to a consumer with a partly-provisioned
+    /// reference — as data rather than as English, so a consumer never has to
+    /// sniff [`reason`](Self::reason) for a keyword that a rewording silently
+    /// removes.
+    ///
+    /// `None` only where there is no such refusal to report: a
+    /// [`NormalizationDeclined`](ConfluenceSkipKind::NormalizationDeclined) skip,
+    /// which is the normalizer's refusal rather than the projection's, and the
+    /// [`Spdi`](ConfluenceRelation::Spdi) first-pass mismatch described on
+    /// `group_by_spdi`.
+    pub decline: Option<TripleDecline>,
+    /// Why it could not be analyzed, rendered for a human. A presentation of
+    /// [`decline`](Self::decline) where there is one — never the authority on it.
+    pub reason: String,
+}
+
+/// The result of a [`check_confluence`] run.
+///
+/// A **diagnostic**: it reports the non-confluence witnesses it found, how many
+/// classes it examined, and what it could not place. It carries no pass/fail
+/// release verdict; [`is_confluent`](Self::is_confluent) is an observation about
+/// *this corpus under this relation*, not a gate.
+///
+/// [`check_confluence`]: crate::equivalence::EquivalenceChecker::check_confluence
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ConfluenceReport {
+    relation: ConfluenceRelation,
+    violations: Vec<ConfluenceGroup>,
+    classes_checked: usize,
+    skipped: Vec<ConfluenceSkip>,
+    undecided_pairs: usize,
+}
+
+impl ConfluenceReport {
+    /// Construct a report. Crate-internal: a report is only meaningful when its
+    /// parts come from one [`check_confluence`] run.
+    ///
+    /// [`check_confluence`]: crate::equivalence::EquivalenceChecker::check_confluence
+    pub(crate) fn new(
+        relation: ConfluenceRelation,
+        violations: Vec<ConfluenceGroup>,
+        classes_checked: usize,
+        skipped: Vec<ConfluenceSkip>,
+        undecided_pairs: usize,
+    ) -> Self {
+        Self {
+            relation,
+            violations,
+            classes_checked,
+            skipped,
+            undecided_pairs,
+        }
+    }
+
+    /// The relation the run grouped by.
+    pub fn relation(&self) -> ConfluenceRelation {
+        self.relation
+    }
+
+    /// The non-confluence witnesses: every examined class that reached more than
+    /// one distinct normalized output.
+    pub fn violations(&self) -> &[ConfluenceGroup] {
+        &self.violations
+    }
+
+    /// How many equivalence classes the run examined, singletons included.
+    ///
+    /// The denominator a violation count is read against.
+    ///
+    /// **It is not `inputs - skipped`, and computing coverage as
+    /// `classes_checked + skipped.len()` double-counts.** The two
+    /// [`ConfluenceSkipKind`]s are excluded differently, which is the whole
+    /// reason that enum exists:
+    ///
+    /// * [`Unplaceable`](ConfluenceSkipKind::Unplaceable) inputs were never
+    ///   placed, so they are in no class and contribute nothing here;
+    /// * [`NormalizationDeclined`](ConfluenceSkipKind::NormalizationDeclined)
+    ///   inputs **were** placed — their class is counted here — and then
+    ///   contributed no output to it. A class of two whose only two members both
+    ///   decline still counts as one examined class, over an empty output set.
+    ///
+    /// So the inputs this run actually placed is
+    /// `inputs - skipped.filter(kind == Unplaceable).count()`, and the classes
+    /// among them is `classes_checked`.
+    ///
+    /// This paragraph replaces a claim that skips "were never placed in a
+    /// class", which was true of one kind and false of the other.
+    pub fn classes_checked(&self) -> usize {
+        self.classes_checked
+    }
+
+    /// The inputs that could not be analyzed, each with a kind and a reason.
+    ///
+    /// Read this alongside [`is_confluent`](Self::is_confluent): "no violation"
+    /// over a corpus that was mostly skipped is not evidence of confluence.
+    pub fn skipped(&self) -> &[ConfluenceSkip] {
+        &self.skipped
+    }
+
+    /// How many pairwise comparisons came back **undecidable** rather than
+    /// deciding the pair apart — always `0` under
+    /// [`ConfluenceRelation::Spdi`], which compares keys and never a pair.
+    ///
+    /// This is the *second* way coverage is lost, and it is invisible in
+    /// [`skipped`](Self::skipped) because nothing was dropped: both inputs were
+    /// placed, they merely failed to merge. Under
+    /// [`ConfluenceRelation::CrossAxisSequenceMatch`] a pair whose comparison
+    /// declined — the union reference window exceeds the checker's cap, or the
+    /// relation errored on a shape it cannot decide — does not merge, exactly as
+    /// a pair that was compared and found different does not merge. Grouping
+    /// therefore **splits a class it could not examine into singletons**, and
+    /// every non-confluence inside that class becomes invisible.
+    ///
+    /// So a non-zero count means the class structure is a *lower bound* on how
+    /// coarse the true classes are, and [`is_confluent`](Self::is_confluent) is
+    /// a *lower bound* on the non-confluence present. Zero is what makes
+    /// "no violations" a statement about the corpus rather than about the
+    /// reference.
+    pub fn undecided_pairs(&self) -> usize {
+        self.undecided_pairs
+    }
+
+    /// Whether **this corpus** showed no non-confluence under **this relation**.
+    ///
+    /// A diagnostic observation, never a release verdict — and vacuously `true`
+    /// for a corpus with no examined classes, which is why
+    /// [`skipped`](Self::skipped), [`classes_checked`](Self::classes_checked)
+    /// and [`undecided_pairs`](Self::undecided_pairs) must all be read with it.
+    /// `true` with a non-empty `skipped` or a non-zero `undecided_pairs` means
+    /// "no non-confluence *among the pairs I could examine*", which is a weaker
+    /// claim and the one the report is actually entitled to make.
+    pub fn is_confluent(&self) -> bool {
+        self.violations.is_empty()
+    }
+
+    /// Whether the run examined everything it was given: nothing skipped and no
+    /// comparison undecidable.
+    ///
+    /// [`is_confluent`](Self::is_confluent) is only a statement about the whole
+    /// corpus when this is `true`. It says nothing about whether violations were
+    /// found — a complete run can still report plenty.
+    pub fn is_complete(&self) -> bool {
+        self.skipped.is_empty() && self.undecided_pairs == 0
+    }
+
+    /// The violations and the skips, for a caller that wants to own them.
+    pub fn into_parts(self) -> (Vec<ConfluenceGroup>, Vec<ConfluenceSkip>) {
+        (self.violations, self.skipped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn members(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(i, o)| (i.to_string(), o.to_string()))
+            .collect()
+    }
+
+    /// A class whose members all reach one output is confluent, so no group is
+    /// produced — whatever the member count.
+    #[test]
+    fn a_class_with_one_distinct_output_is_confluent() {
+        assert_eq!(
+            ConfluenceGroup::from_class(members(&[("g.2A>G", "g.2A>G")])),
+            None,
+            "a singleton is confluent"
+        );
+        assert_eq!(
+            ConfluenceGroup::from_class(members(&[
+                ("g.2A>G", "g.2A>G"),
+                ("g.2delinsG", "g.2A>G"),
+                ("g.2_2delinsG", "g.2A>G"),
+            ])),
+            None,
+            "three spellings, one output"
+        );
+    }
+
+    /// A class whose members reach two distinct outputs is a violation, and the
+    /// outputs are deduplicated and sorted while the inputs keep their order.
+    #[test]
+    fn a_class_with_two_distinct_outputs_is_a_violation() {
+        let group = ConfluenceGroup::from_class(members(&[
+            ("input-b", "g.2_7delinsGGCTA"),
+            ("input-a", "g.[2A>G;7C>A]"),
+            ("input-c", "g.2_7delinsGGCTA"),
+        ]))
+        .expect("two distinct outputs is non-confluent");
+
+        assert_eq!(
+            group.inputs,
+            vec!["input-b", "input-a", "input-c"],
+            "inputs are recorded in the order given"
+        );
+        assert_eq!(
+            group.outputs,
+            // Lexicographic: '2' (0x32) sorts before '[' (0x5B).
+            vec!["g.2_7delinsGGCTA", "g.[2A>G;7C>A]"],
+            "outputs are the distinct set, sorted"
+        );
+    }
+
+    /// The boundary: exactly two members, two outputs, is the smallest witness.
+    #[test]
+    fn two_members_two_outputs_is_the_minimal_witness() {
+        let group =
+            ConfluenceGroup::from_class(members(&[("a", "x"), ("b", "y")])).expect("two outputs");
+        assert_eq!(group.outputs, vec!["x", "y"]);
+    }
+
+    /// An empty class produces nothing rather than a spurious violation.
+    #[test]
+    fn an_empty_class_is_not_a_violation() {
+        assert_eq!(ConfluenceGroup::from_class(std::iter::empty()), None);
+    }
+
+    /// A report exposes its parts through the accessors, and `into_parts` hands
+    /// back exactly the violations and skips it was built from.
+    #[test]
+    fn a_report_exposes_its_parts() {
+        let violation = ConfluenceGroup {
+            inputs: vec!["a".to_string(), "b".to_string()],
+            outputs: vec!["x".to_string(), "y".to_string()],
+        };
+        let skip = ConfluenceSkip {
+            input: "c".to_string(),
+            kind: ConfluenceSkipKind::Unplaceable,
+            reason: "no SPDI key".to_string(),
+            decline: None,
+        };
+        let report = ConfluenceReport::new(
+            ConfluenceRelation::Spdi,
+            vec![violation.clone()],
+            3,
+            vec![skip.clone()],
+            7,
+        );
+
+        assert_eq!(report.relation(), ConfluenceRelation::Spdi);
+        assert_eq!(report.classes_checked(), 3);
+        assert_eq!(report.violations(), std::slice::from_ref(&violation));
+        assert_eq!(report.skipped(), std::slice::from_ref(&skip));
+        assert_eq!(report.undecided_pairs(), 7);
+        assert!(!report.is_confluent(), "one violation means not confluent");
+        assert!(!report.is_complete(), "a skip and undecided pairs are gaps");
+
+        let (violations, skipped) = report.into_parts();
+        assert_eq!(violations, [violation]);
+        assert_eq!(skipped, [skip]);
+    }
+
+    /// A run with nothing skipped and nothing undecidable is complete, whatever
+    /// it found — completeness is about coverage, not about the verdict.
+    #[test]
+    fn completeness_is_about_coverage_not_about_the_verdict() {
+        let clean = ConfluenceReport::new(
+            ConfluenceRelation::CrossAxisSequenceMatch,
+            Vec::new(),
+            2,
+            Vec::new(),
+            0,
+        );
+        assert!(clean.is_complete() && clean.is_confluent());
+
+        let found = ConfluenceReport::new(
+            ConfluenceRelation::CrossAxisSequenceMatch,
+            vec![ConfluenceGroup {
+                inputs: vec!["a".to_string(), "b".to_string()],
+                outputs: vec!["x".to_string(), "y".to_string()],
+            }],
+            2,
+            Vec::new(),
+            0,
+        );
+        assert!(
+            found.is_complete() && !found.is_confluent(),
+            "a complete run can still report violations"
+        );
+
+        let blind = ConfluenceReport::new(
+            ConfluenceRelation::CrossAxisSequenceMatch,
+            Vec::new(),
+            2,
+            Vec::new(),
+            1,
+        );
+        assert!(
+            !blind.is_complete() && blind.is_confluent(),
+            "one undecidable comparison and no skip is still an incomplete run"
+        );
+    }
+
+    /// Every relation's external name round-trips. The rendering direction is
+    /// compiler-checked (an exhaustive match on the enum), the parsing
+    /// direction cannot be, so the pairing is pinned here — a relation added to
+    /// `as_str` without an arm in `from_name` fails this test.
+    #[test]
+    fn every_relation_round_trips_through_its_name() {
+        for relation in [
+            ConfluenceRelation::CrossAxisSequenceMatch,
+            ConfluenceRelation::Spdi,
+        ] {
+            let name = relation.as_str();
+            assert!(!name.is_empty(), "{relation:?} must have a name");
+            assert_eq!(
+                ConfluenceRelation::from_name(name),
+                Some(relation),
+                "{name:?} must parse back to {relation:?}"
+            );
+            assert_eq!(relation.to_string(), name, "Display matches as_str");
+        }
+        assert_eq!(ConfluenceRelation::from_name("cross-axis"), None);
+        assert_eq!(ConfluenceRelation::from_name(""), None);
+    }
+
+    /// The two skip kinds have distinct names, and they round-trip through
+    /// `Display` — a consumer reading a rendered report must be able to tell
+    /// "never placed" from "placed, then declined".
+    #[test]
+    fn the_two_skip_kinds_are_distinguishable() {
+        let unplaceable = ConfluenceSkipKind::Unplaceable;
+        let declined = ConfluenceSkipKind::NormalizationDeclined;
+        assert_ne!(unplaceable.as_str(), declined.as_str());
+        assert_eq!(unplaceable.to_string(), unplaceable.as_str());
+        assert_eq!(declined.to_string(), declined.as_str());
+    }
+}

--- a/src/equivalence/mod.rs
+++ b/src/equivalence/mod.rs
@@ -120,7 +120,13 @@
 //! - [Variant Normalization](https://www.ncbi.nlm.nih.gov/variation/notation/)
 
 mod checker;
+mod confluence;
 mod key;
 
-pub use checker::{EquivalenceChecker, EquivalenceLevel, EquivalenceResult};
+pub use checker::{
+    DeclineSite, EquivalenceChecker, EquivalenceLevel, EquivalenceResult, TripleDecline,
+};
+pub use confluence::{
+    ConfluenceGroup, ConfluenceRelation, ConfluenceReport, ConfluenceSkip, ConfluenceSkipKind,
+};
 pub use key::{group_by_spdi_key, spdi_key, SpdiKey, SpdiKeyGrouping};

--- a/src/python.rs
+++ b/src/python.rs
@@ -5,7 +5,7 @@
 
 use pyo3::exceptions::{PyDeprecationWarning, PyRuntimeError, PyUserWarning, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyList};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
@@ -17,7 +17,9 @@ use crate::batch::{BatchProcessor, BatchProgress, BatchResult, ItemResult, BATCH
 use crate::convert::CoordinateMapper;
 use crate::coords::{OneBasedPos, ZeroBasedPos};
 use crate::effect::{Consequence, EffectPredictor, Impact, ProteinEffect};
-use crate::equivalence::{EquivalenceChecker, EquivalenceLevel, EquivalenceResult};
+use crate::equivalence::{
+    ConfluenceRelation, EquivalenceChecker, EquivalenceLevel, EquivalenceResult,
+};
 use crate::error_handling::{
     ferro_to_mutalyzer, CorrectionWarning, ErrorConfig, ErrorMode, ErrorOverride, ErrorType,
 };
@@ -3962,6 +3964,109 @@ impl PyEquivalenceChecker {
                     &e,
                 )
             })
+    }
+
+    /// Run the opt-in confluence self-check over a corpus of variants (#1892).
+    ///
+    /// Groups the inputs into equivalence classes under `relation` and reports
+    /// every class whose members normalize to more than one distinct output — a
+    /// non-confluence witness. This is a diagnostic; it reports, and never emits
+    /// a pass/fail release verdict.
+    ///
+    /// Args:
+    ///     variants: The variants to check.
+    ///     relation: The equivalence relation to group by. ``"cross_axis"``
+    ///         (default) is apply-equality on every determined axis — the
+    ///         relation that establishes variant identity. ``"spdi"`` groups by
+    ///         same denoted bases on the description's own axis; it is weaker and
+    ///         insufficient for identity, offered for counting distinct edits.
+    ///
+    /// Returns:
+    ///     A dict with keys ``relation`` (str), ``is_confluent`` (bool),
+    ///     ``is_complete`` (bool), ``classes_checked`` (int),
+    ///     ``undecided_pairs`` (int), ``violations`` (list of
+    ///     ``{"inputs": [...], "outputs": [...]}``), and ``skipped`` (list of
+    ///     ``{"input": str, "kind": str, "reason": str, "decline_class": str |
+    ///     None, "decline_site": str | None}``).
+    ///
+    ///     ``decline_class`` and ``decline_site`` are the skip's refusal as
+    ///     machine-readable names rather than prose — compare these instead of
+    ///     searching ``reason`` for a keyword, whose wording is not API. Both
+    ///     are ``None`` where there is no such refusal to report. See
+    ///     `TripleDecline` for the two classes and the six sites.
+    ///
+    ///     ``is_confluent`` is an observation about this corpus under this
+    ///     relation, not a release gate, and it is only a statement about the
+    ///     *whole* corpus when ``is_complete`` is true — that is, when nothing
+    ///     was skipped and no comparison came back undecidable. A skip's
+    ///     ``kind`` is ``"unplaceable"`` (never placed in a class) or
+    ///     ``"normalization_declined"`` (placed, then contributed no output), so
+    ///     coverage is ``classes_checked`` plus the ``"unplaceable"`` skips and
+    ///     never ``classes_checked + len(skipped)``.
+    ///
+    ///     ``undecided_pairs`` is always 0 for ``"spdi"``, which compares keys
+    ///     rather than pairs.
+    ///
+    /// Raises:
+    ///     ValueError: If ``relation`` is not ``"cross_axis"`` or ``"spdi"``.
+    #[pyo3(signature = (variants, relation="cross_axis"))]
+    fn check_confluence<'py>(
+        &self,
+        py: Python<'py>,
+        variants: Vec<PyRef<PyHgvsVariant>>,
+        relation: &str,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        // Both directions of the name mapping live on `ConfluenceRelation`, so
+        // a relation added to the enum cannot be half-wired here.
+        let chosen = ConfluenceRelation::from_name(relation).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "unknown relation {relation:?}: expected \"cross_axis\" or \"spdi\""
+            ))
+        })?;
+        let rust_variants: Vec<HgvsVariant> = variants.iter().map(|v| v.inner.clone()).collect();
+        // Detached like the sibling entry points (#1455): grouping and
+        // normalizing a whole corpus reads reference windows.
+        let report = py.detach(|| self.checker.check_confluence(&rust_variants, chosen));
+
+        let dict = PyDict::new(py);
+        dict.set_item("relation", report.relation().as_str())?;
+        dict.set_item("is_confluent", report.is_confluent())?;
+        dict.set_item("is_complete", report.is_complete())?;
+        dict.set_item("classes_checked", report.classes_checked())?;
+        dict.set_item("undecided_pairs", report.undecided_pairs())?;
+
+        let violations = PyList::empty(py);
+        for group in report.violations() {
+            let entry = PyDict::new(py);
+            entry.set_item("inputs", group.inputs.clone())?;
+            entry.set_item("outputs", group.outputs.clone())?;
+            violations.append(entry)?;
+        }
+        dict.set_item("violations", violations)?;
+
+        let skipped = PyList::empty(py);
+        for skip in report.skipped() {
+            let entry = PyDict::new(py);
+            entry.set_item("input", &skip.input)?;
+            entry.set_item("kind", skip.kind.as_str())?;
+            entry.set_item("reason", &skip.reason)?;
+            // The typed refusal, as two stable names. `reason` renders these for
+            // a human; these are what a caller compares, so a partly-provisioned
+            // reference is told apart from an unrepresentable description without
+            // sniffing the sentence for a keyword.
+            entry.set_item(
+                "decline_class",
+                skip.decline.as_ref().map(|d| d.class_str()),
+            )?;
+            entry.set_item(
+                "decline_site",
+                skip.decline.as_ref().map(|d| d.site().as_str()),
+            )?;
+            skipped.append(entry)?;
+        }
+        dict.set_item("skipped", skipped)?;
+
+        Ok(dict)
     }
 }
 

--- a/tests/it/confluence_self_check_tests.rs
+++ b/tests/it/confluence_self_check_tests.rs
@@ -1,0 +1,539 @@
+//! End-to-end tests for the opt-in confluence self-check (#1892).
+//!
+//! The self-check answers the question a consumer actually asks — *will my
+//! variants change, and are any of them non-confluent on my data?* — by
+//! composing two decided pieces of machinery: the equivalence relation
+//! (`EquivalenceChecker`) and the normalizer. It groups the inputs into
+//! equivalence classes under a caller-chosen relation and flags any class whose
+//! members reach more than one distinct normalized output. It reports; it never
+//! decides which relation gates a release (that is the deferred adjudication in
+//! #1890), and it emits no pass/fail verdict.
+//!
+//! # The hermetic violation witnesses
+//!
+//! This file used to say there could be no hermetic "real violation" test —
+//! that the decided non-confluences all need a real reference window. That was
+//! wrong, and it left the feature's headline behaviour (*report the
+//! non-confluence*) with no end-to-end guard at all: replacing
+//! `violations.push(group)` in `check_confluence` with a no-op left every test
+//! in the repository green, because every one of them asserted
+//! `violations == []`.
+//!
+//! Two witnesses close it, and both are `MockProvider`-only. Each is a pair that
+//! the cross-axis relation groups into **one** class — apply-equal on every
+//! determined axis, established by `compare_denotations`, which never
+//! normalizes — whose members the normalizer carries to **two** distinct
+//! strings. See `a_class_that_normalizes_apart_is_reported` and
+//! `two_no_ops_at_different_positions_are_a_witness`. If either pair ever
+//! converges, that is a representation change and the test must be re-pointed at
+//! another divergent pair, not deleted: what it guards is that the report
+//! *fires*, and a green run over a corpus with nothing to find does not guard
+//! that.
+
+use ferro_hgvs::equivalence::{
+    ConfluenceRelation, ConfluenceSkipKind, DeclineSite, EquivalenceChecker, TripleDecline,
+};
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, HgvsVariant, MockProvider};
+
+/// The 40-base contig `spdi::apply`'s own tests use.
+fn genomic_provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_KEY.1", "GGATTACAGGCATTAGCCTGAGGATTACAGGCATTAGCCT");
+    provider
+}
+
+fn variants(descriptors: &[&str]) -> Vec<HgvsVariant> {
+    descriptors
+        .iter()
+        .map(|d| parse_hgvs(d).expect("fixture must parse"))
+        .collect()
+}
+
+/// A two-exon transcript whose junction splits a two-base `T` run, so
+/// duplicating either base yields one transcript sequence and two different
+/// genomic sequences — the `c.3921dup`/`c.3922dup` shape, reduced. This is the
+/// only geometry where the cross-axis relation and the (own-axis) SPDI relation
+/// group differently.
+fn two_exon_provider() -> MockProvider {
+    const TX: &str = "NM_TWOEXON.1";
+    const EXON1_TX: &str = "ACGCACGCAT";
+    const EXON2_TX: &str = "TATGCACCAGTCACCAGTCTGATGCGGATCACGTGCAATTGCACGTGCAATTGGATCCGATCGTACGTA";
+    let tx_sequence = format!("{EXON1_TX}{EXON2_TX}");
+    let exon2_end_tx = 11 + EXON2_TX.len() as u64 - 1;
+    let exon2_end_genomic = 2001 + EXON2_TX.len() as u64 - 1;
+    let mut genomic = String::new();
+    genomic.push_str(&"A".repeat(1000));
+    genomic.push_str(EXON1_TX);
+    genomic.push_str(&"G".repeat(990));
+    genomic.push_str(EXON2_TX);
+    genomic.push_str(&"A".repeat(91));
+    let transcript = Transcript::new(
+        TX.to_string(),
+        Some("TWOEXON".to_string()),
+        Strand::Plus,
+        tx_sequence,
+        Some(1),
+        Some(78),
+        vec![
+            Exon::with_genomic(1, 1, 10, 1001, 1010),
+            Exon::with_genomic(2, 11, exon2_end_tx, 2001, exon2_end_genomic),
+        ],
+        Some("chr_two_exon".to_string()),
+        Some(1001),
+        Some(exon2_end_genomic),
+        GenomeBuild::GRCh38,
+        ManeStatus::None,
+        None,
+        None,
+    );
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("chr_two_exon", genomic);
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// Several spellings of one variant that all normalize to one string form a
+/// single equivalence class with a single output, so the corpus is confluent
+/// and no violation is reported.
+#[test]
+fn a_confluent_corpus_reports_no_violations() {
+    let checker = EquivalenceChecker::new(genomic_provider());
+    // A literal insertion and the same bases named by reference range: cross-axis
+    // apply-equal, and the normalizer converges both.
+    let corpus = variants(&["NC_KEY.1:g.5_6insGGCATTAGCCT", "NC_KEY.1:g.5_6ins9_19"]);
+
+    let report = checker.check_confluence(&corpus, ConfluenceRelation::CrossAxisSequenceMatch);
+
+    assert!(report.is_confluent(), "one variant, one output: {report:?}");
+    assert!(report.violations().is_empty());
+    assert!(report.skipped().is_empty());
+    assert_eq!(
+        report.classes_checked(),
+        1,
+        "the two spellings are one equivalence class"
+    );
+    assert_eq!(report.undecided_pairs(), 0, "the pair was decided");
+    assert!(
+        report.is_complete(),
+        "nothing was skipped and nothing was undecidable"
+    );
+    assert_eq!(
+        report.relation(),
+        ConfluenceRelation::CrossAxisSequenceMatch
+    );
+}
+
+/// Two genuinely different variants land in separate classes, and two spellings
+/// of one variant land together.
+///
+/// The corpus is deliberately three inputs reducing to **two** classes rather
+/// than two inputs reducing to two. The earlier two-input form asserted
+/// `classes_checked == 2`, which is also exactly what a grouping that never
+/// merges anything produces — so it pinned the count without pinning the
+/// grouping, and survived "make `group_by_cross_axis` never merge" untouched.
+/// Three inputs and two classes is a number only a working grouping can reach.
+#[test]
+fn distinct_variants_form_separate_classes() {
+    let checker = EquivalenceChecker::new(genomic_provider());
+    // `g.3delinsG` is `g.3A>G` respelled: apply-equal, so it must join it.
+    // `g.3A>C` denotes a different base, so it must not.
+    let corpus = variants(&["NC_KEY.1:g.3A>G", "NC_KEY.1:g.3A>C", "NC_KEY.1:g.3delinsG"]);
+
+    let report = checker.check_confluence(&corpus, ConfluenceRelation::CrossAxisSequenceMatch);
+
+    assert!(report.is_confluent());
+    assert!(report.violations().is_empty());
+    assert_eq!(
+        report.classes_checked(),
+        2,
+        "three inputs, two variants — a grouping that never merges would say 3: {report:?}"
+    );
+    assert!(report.is_complete(), "{report:?}");
+}
+
+/// An input the chosen relation cannot place — a non-literal `insN[5]` payload
+/// has no SPDI key — is reported as skipped, with a reason, rather than silently
+/// dropped or falsely grouped. A skip that read as a pass is the failure this
+/// self-check exists to avoid.
+#[test]
+fn inputs_the_relation_cannot_place_are_reported_as_skipped() {
+    let checker = EquivalenceChecker::new(genomic_provider());
+    // An unspecified inserted length denotes no resolvable sequence, so it has
+    // no SPDI key (`spdi_key`'s documented refusals).
+    let corpus = variants(&["NC_KEY.1:g.10_11ins(10)", "NC_KEY.1:g.5_6ins(6)"]);
+
+    for relation in [
+        ConfluenceRelation::Spdi,
+        ConfluenceRelation::CrossAxisSequenceMatch,
+    ] {
+        let report = checker.check_confluence(&corpus, relation);
+
+        assert!(report.violations().is_empty());
+        assert_eq!(
+            report.skipped().len(),
+            2,
+            "neither non-literal payload denotes a sequence under {relation:?}: {report:?}"
+        );
+        assert!(
+            report
+                .skipped()
+                .iter()
+                .all(|s| s.kind == ConfluenceSkipKind::Unplaceable),
+            "the relation never placed either: {report:?}"
+        );
+        assert!(
+            report.skipped().iter().all(|s| !s.reason.is_empty()),
+            "every skip must carry a reason"
+        );
+        assert_eq!(
+            report.classes_checked(),
+            0,
+            "an unplaceable input forms no class, under either relation: {report:?}"
+        );
+        assert!(
+            !report.is_complete(),
+            "a corpus that was entirely skipped is not a complete run: {report:?}"
+        );
+    }
+}
+
+/// The chosen relation changes the grouping. Two junction-straddling
+/// duplications denote the same transcript bases (one SPDI key) but different
+/// genomic bases, so the SPDI relation groups them into one class while the
+/// cross-axis relation keeps them in two. Both are confluent here; what is being
+/// pinned is that the relation parameter is honored.
+///
+/// The corpus carries a **third** input, `c.11delinsTT`, which is `c.11dup`
+/// respelled and which the cross-axis relation therefore must merge with it.
+/// Without it the cross-axis assertion read `classes_checked == 2` over a
+/// two-input corpus — the same number a grouping that never merges anything
+/// produces — so only the SPDI half of this test was load-bearing and the
+/// mutation "make `group_by_cross_axis` never merge" left it green. Three inputs
+/// and two cross-axis classes cannot be reached without merging.
+#[test]
+fn the_relation_parameter_changes_the_grouping() {
+    let checker = EquivalenceChecker::new(two_exon_provider());
+    let corpus = variants(&[
+        "NM_TWOEXON.1:c.10dup",
+        "NM_TWOEXON.1:c.11dup",
+        "NM_TWOEXON.1:c.11delinsTT",
+    ]);
+
+    let spdi = checker.check_confluence(&corpus, ConfluenceRelation::Spdi);
+    assert_eq!(
+        spdi.classes_checked(),
+        1,
+        "same transcript bases: one SPDI class over all three: {spdi:?}"
+    );
+
+    let cross = checker.check_confluence(&corpus, ConfluenceRelation::CrossAxisSequenceMatch);
+    assert_eq!(
+        cross.classes_checked(),
+        2,
+        "`c.11dup` and `c.11delinsTT` share a genomic denotation and must merge; \
+         `c.10dup` must not join them — a grouping that never merges would say 3: {cross:?}"
+    );
+
+    assert!(spdi.is_confluent() && cross.is_confluent());
+    assert!(spdi.is_complete() && cross.is_complete());
+}
+
+/// An empty corpus is vacuously confluent.
+#[test]
+fn an_empty_corpus_is_confluent() {
+    let checker = EquivalenceChecker::new(genomic_provider());
+    let report = checker.check_confluence(&[], ConfluenceRelation::CrossAxisSequenceMatch);
+    assert!(report.is_confluent());
+    assert_eq!(report.classes_checked(), 0);
+    assert!(report.skipped().is_empty());
+    assert_eq!(report.undecided_pairs(), 0);
+    assert!(report.is_complete(), "nothing was handed over to miss");
+}
+
+/// **The headline behaviour, end to end.** A class the relation groups whose
+/// members the normalizer carries to two distinct strings is reported as a
+/// violation, carrying both inputs and both outputs.
+///
+/// The witness is one variant spelled two ways: `g.[3A>G;10=]` states an
+/// unchanged base alongside the substitution, `g.3A>G` does not. Applying either
+/// to the reference produces the same bases — an `=` member changes nothing — so
+/// `compare_denotations` reaches `CrossAxisSequenceMatch` and the two are one
+/// class. The normalizer preserves the `=` member, so the class reaches two
+/// outputs.
+///
+/// This is a real non-confluence in ferro, not a contrivance: a caller that
+/// records the bases it checked is spelling the same variant. If it is ever
+/// converged, re-point this test at another divergent pair — see the module
+/// docs.
+#[test]
+fn a_class_that_normalizes_apart_is_reported() {
+    let checker = EquivalenceChecker::new(genomic_provider());
+    let corpus = variants(&["NC_KEY.1:g.[3A>G;10=]", "NC_KEY.1:g.3A>G"]);
+
+    let report = checker.check_confluence(&corpus, ConfluenceRelation::CrossAxisSequenceMatch);
+
+    assert_eq!(
+        report.classes_checked(),
+        1,
+        "apply-equal on every determined axis, so one class: {report:?}"
+    );
+    assert!(
+        report.is_complete(),
+        "nothing here is skipped or undecidable, so the finding is about the corpus: {report:?}"
+    );
+    assert!(
+        !report.is_confluent(),
+        "one class, two outputs, is a non-confluence witness: {report:?}"
+    );
+
+    let violations = report.violations();
+    assert_eq!(violations.len(), 1, "{report:?}");
+    assert_eq!(
+        violations[0].inputs,
+        vec![
+            "NC_KEY.1:g.[3A>G;10=]".to_string(),
+            "NC_KEY.1:g.3A>G".to_string()
+        ],
+        "the inputs are recorded in input order so a consumer sees which collided"
+    );
+    assert_eq!(
+        violations[0].outputs,
+        vec![
+            "NC_KEY.1:g.3A>G".to_string(),
+            "NC_KEY.1:g.[3A>G;10=]".to_string()
+        ],
+        "the distinct outputs the class reached, sorted"
+    );
+}
+
+/// A second, independent violation witness, on the shape `spdi_key`'s own docs
+/// single out: two descriptions that change nothing.
+///
+/// `g.10=` and `g.20=` both denote the unchanged reference, so they are
+/// apply-equal on every determined axis and the cross-axis relation groups them;
+/// the normalizer keeps each at its own position, so the class reaches two
+/// outputs. This one is deliberately stable — `src/equivalence/key.rs` records
+/// that giving two no-ops one answer "means choosing one, and nothing here needs
+/// it", so converging them is a decision nobody has made rather than a defect
+/// waiting to be fixed. Under `Spdi` they key at their own positions and do not
+/// group, which is the same fact seen from the weaker relation.
+#[test]
+fn two_no_ops_at_different_positions_are_a_witness() {
+    let checker = EquivalenceChecker::new(genomic_provider());
+    let corpus = variants(&["NC_KEY.1:g.10=", "NC_KEY.1:g.20="]);
+
+    let cross = checker.check_confluence(&corpus, ConfluenceRelation::CrossAxisSequenceMatch);
+    assert_eq!(cross.classes_checked(), 1, "{cross:?}");
+    assert!(cross.is_complete(), "{cross:?}");
+    assert!(!cross.is_confluent(), "{cross:?}");
+    assert_eq!(
+        cross.violations()[0].outputs,
+        vec!["NC_KEY.1:g.10=".to_string(), "NC_KEY.1:g.20=".to_string()],
+        "{cross:?}"
+    );
+
+    let spdi = checker.check_confluence(&corpus, ConfluenceRelation::Spdi);
+    assert_eq!(
+        spdi.classes_checked(),
+        2,
+        "the weaker relation keys each at its own position, so it finds nothing: {spdi:?}"
+    );
+    assert!(spdi.is_confluent(), "{spdi:?}");
+}
+
+/// A pair the checker could not examine must not be reported as a clean corpus.
+///
+/// The two spellings are one cis allele written in two member orders, 150 kb
+/// apart — past `MAX_SEQUENCE_COMPARE_WINDOW`, so `compare_denotations` answers
+/// `Indeterminate`. That does not merge, which is byte-identical to what a pair
+/// decided *apart* does, so before this was counted the run reported
+/// `is_confluent: true`, `classes_checked: 2`, `skipped: []` — indistinguishable
+/// from a corpus that was read and found clean.
+#[test]
+fn a_pair_the_checker_could_not_examine_is_counted_not_assumed() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_WIDE.1", "ACGT".repeat(50_000));
+    let checker = EquivalenceChecker::new(provider);
+    let corpus = variants(&[
+        "NC_WIDE.1:g.[10del;150010del]",
+        "NC_WIDE.1:g.[150010del;10del]",
+    ]);
+
+    let report = checker.check_confluence(&corpus, ConfluenceRelation::CrossAxisSequenceMatch);
+
+    assert!(
+        report.skipped().is_empty(),
+        "both inputs denote a sequence — nothing was dropped: {report:?}"
+    );
+    assert_eq!(
+        report.classes_checked(),
+        2,
+        "the undecidable pair split a class it could not examine: {report:?}"
+    );
+    assert_eq!(
+        report.undecided_pairs(),
+        1,
+        "the one comparison came back undecidable: {report:?}"
+    );
+    assert!(
+        !report.is_complete(),
+        "a run that could not examine a pair has not covered its corpus: {report:?}"
+    );
+}
+
+/// A reference that cannot serve the bases is reported as *that*, and never as
+/// a clean corpus.
+///
+/// This is the consumer failure the report exists to prevent: a partly
+/// provisioned reference — one contig absent — over which every unreadable
+/// description was split into a singleton and every non-confluence among them
+/// made invisible, while the report read `is_confluent: true`, `skipped: []`.
+/// Both spellings here are well formed and denote one variant, and both
+/// normalize to `g.2del`.
+#[test]
+fn an_unreadable_reference_is_named_rather_than_read_as_clean() {
+    // Serves no bases at all: `NC_ABSENT.1` is not in it.
+    let checker = EquivalenceChecker::new(MockProvider::new());
+    let corpus = variants(&["NC_ABSENT.1:g.2del", "NC_ABSENT.1:g.2delC"]);
+
+    for relation in [
+        ConfluenceRelation::CrossAxisSequenceMatch,
+        ConfluenceRelation::Spdi,
+    ] {
+        let report = checker.check_confluence(&corpus, relation);
+
+        assert!(
+            !report.is_complete(),
+            "the reference could not be read, so the run covered nothing it claims: {report:?}"
+        );
+        assert!(
+            !report.skipped().is_empty(),
+            "at least one input has no computable denotation here: {report:?}"
+        );
+        assert!(
+            report
+                .skipped()
+                .iter()
+                .all(|s| s.kind == ConfluenceSkipKind::Unplaceable),
+            "{report:?}"
+        );
+        // Fix the misdiagnosis: the descriptions are well formed and it is the
+        // provider that declined, so the skip must say so.
+        //
+        // **This keys on the classifier, never on the sentence.** Asserting
+        // `reason.contains("reference")` — which this test did until the typed
+        // decline existed — passes whenever that word happens to appear and
+        // breaks silently the moment someone rewords the message, so it tests
+        // the prose rather than the classification. Matching the variant makes
+        // the assertion immune to any rewording and sensitive to exactly the
+        // thing it is about: which class `edit_triples` put the refusal in.
+        assert!(
+            report
+                .skipped()
+                .iter()
+                .any(|s| matches!(s.decline, Some(TripleDecline::ReferenceUnavailable(_)))),
+            "the refusal must be classified against the reference, not the description: {report:?}"
+        );
+    }
+}
+
+/// Every reachable `(class, site)` pair renders a **distinct** sentence, and the
+/// count is what it is rather than what is convenient to claim.
+///
+/// Six refusal sites exist in `edit_triples`. Only `MemberConversion` can be
+/// either class — it is the only site holding a `ConversionError`, and only a
+/// conversion error can be "want of reference data" — so the reachable pairs
+/// number **seven**, not twelve and not six. Enumerated here so that a site
+/// added without its own wording (or two sites whose prose collapses together)
+/// fails rather than quietly reducing what a report can tell a consumer apart.
+#[test]
+fn every_reachable_decline_renders_a_distinct_message() {
+    use ferro_hgvs::spdi::ConversionError;
+
+    let subject = parse_hgvs("NC_KEY.1:g.3A>G").unwrap();
+    let conversion = || ConversionError::MissingReferenceData {
+        description: "probe".to_string(),
+    };
+
+    // The five sites that only ever classify as `Unrepresentable`, plus the one
+    // site that reaches both classes — once under each.
+    let reachable = [
+        TripleDecline::Unrepresentable(DeclineSite::MultiMoleculeAllele {
+            phase: ferro_hgvs::hgvs::variant::AllelePhase::Trans,
+        }),
+        TripleDecline::Unrepresentable(DeclineSite::NullOrUnknownAllele),
+        TripleDecline::Unrepresentable(DeclineSite::EmptyAllele),
+        TripleDecline::Unrepresentable(DeclineSite::MemberConversion {
+            error: conversion(),
+        }),
+        TripleDecline::Unrepresentable(DeclineSite::CrossAccession {
+            first: "NC_A.1".to_string(),
+            second: "NC_B.1".to_string(),
+        }),
+        TripleDecline::Unrepresentable(DeclineSite::UnresolvedAccession),
+        TripleDecline::ReferenceUnavailable(DeclineSite::MemberConversion {
+            error: conversion(),
+        }),
+    ];
+
+    // The counts below are the *properties*, not a restated literal: a seventh
+    // pair that renders like an existing one, or two sites sharing a name, fails
+    // here. What guarantees a newly *added* site reaches this list at all is not
+    // a count but the wildcard-free matches in `into_reason` and
+    // `DeclineSite::as_str`, which make an unhandled site a compile error.
+    let rendered: std::collections::BTreeSet<String> = reachable
+        .iter()
+        .map(|d| d.clone().into_reason(&subject))
+        .collect();
+    assert_eq!(
+        rendered.len(),
+        7,
+        "two decline pairs render the same sentence, so a report cannot tell them apart: {rendered:#?}"
+    );
+
+    // The six site names are distinct too — that is the machine-readable half,
+    // and it is what a consumer matches on.
+    let sites: std::collections::BTreeSet<&str> =
+        reachable.iter().map(|d| d.site().as_str()).collect();
+    assert_eq!(sites.len(), 6, "{sites:?}");
+}
+
+/// A skip is a skip because the relation could not place the input — never
+/// because the input is malformed or the normalizer refused it.
+///
+/// `g.pterdel` is the sharpest form of that: it normalizes perfectly well (to
+/// `g.2del`), and it still has no computable denotation, because `pter` is a
+/// landmark of the assembled chromosome rather than a coordinate on the
+/// sequence. So it is `Unplaceable`, forms no class, and is excluded from
+/// `classes_checked` — which is the half of the accounting the two
+/// `ConfluenceSkipKind`s exist to keep apart. A
+/// `NormalizationDeclined` skip is excluded the *other* way: its class is
+/// formed and counted, and only its output is missing. That arm is stated as
+/// contract on `ConfluenceReport::classes_checked` rather than reproduced here,
+/// because no description this provider can place also fails to normalize.
+#[test]
+fn an_unplaceable_input_forms_no_class_even_when_it_normalizes() {
+    let checker = EquivalenceChecker::new(genomic_provider());
+    let corpus = variants(&["NC_KEY.1:g.3A>G", "NC_KEY.1:g.pterdel"]);
+
+    let report = checker.check_confluence(&corpus, ConfluenceRelation::CrossAxisSequenceMatch);
+
+    assert_eq!(report.skipped().len(), 1, "{report:?}");
+    assert_eq!(
+        report.skipped()[0].input,
+        "NC_KEY.1:g.pterdel",
+        "{report:?}"
+    );
+    assert_eq!(
+        report.skipped()[0].kind,
+        ConfluenceSkipKind::Unplaceable,
+        "it was never placed — this is not a normalization failure: {report:?}"
+    );
+    assert_eq!(
+        report.classes_checked(),
+        1,
+        "only the placeable input formed a class: {report:?}"
+    );
+    assert!(!report.is_complete(), "{report:?}");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -114,6 +114,7 @@ mod compound_cross_reference;
 mod comprehensive_edge_case_tests;
 mod comprehensive_external_tests;
 mod con_conversion_audit;
+mod confluence_self_check_tests;
 mod conformance_census_instrument;
 mod conformance_summary_generated;
 mod convert_gff_library_parity;

--- a/tests/python/test_issue_1892_confluence_self_check.py
+++ b/tests/python/test_issue_1892_confluence_self_check.py
@@ -1,0 +1,166 @@
+"""Issue #1892: the opt-in confluence self-check, via the Python API.
+
+``EquivalenceChecker.check_confluence`` groups a corpus of variants into
+equivalence classes under a chosen relation and reports every class whose
+members normalize to more than one distinct output — a non-confluence witness.
+It is a diagnostic: it reports offending groups and never emits a pass/fail
+release verdict.
+
+The reference is fully synthetic: the 21-base ``NC_KEY.1`` contig that
+``spdi::apply``'s own tests use, so the grouping can be checked by hand.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+CONTIG = "NC_KEY.1"
+SEQUENCE = "GGATTACAGGCATTAGCCTGA"  # 1-based: GGCATTAGCCT sits at 9..=19
+
+
+def _checker(tmp_path: Path) -> "ferro_hgvs.EquivalenceChecker":
+    ref = {"transcripts": [], "genomic_sequences": {CONTIG: SEQUENCE}}
+    path = tmp_path / "reference.json"
+    path.write_text(json.dumps(ref))
+    return ferro_hgvs.EquivalenceChecker(reference_json=str(path))
+
+
+def _variants(descriptors):
+    return [ferro_hgvs.parse(d) for d in descriptors]
+
+
+def test_confluent_corpus_reports_no_violations(tmp_path: Path) -> None:
+    checker = _checker(tmp_path)
+    # A literal insertion and the same bases named by reference range: apply-equal
+    # and converged by the normalizer.
+    corpus = _variants([f"{CONTIG}:g.5_6insGGCATTAGCCT", f"{CONTIG}:g.5_6ins9_19"])
+
+    report = checker.check_confluence(corpus)
+
+    assert report["relation"] == "cross_axis"
+    assert report["is_confluent"] is True
+    assert report["is_complete"] is True
+    assert report["violations"] == []
+    assert report["skipped"] == []
+    assert report["classes_checked"] == 1
+    assert report["undecided_pairs"] == 0
+
+
+def test_distinct_variants_form_separate_classes(tmp_path: Path) -> None:
+    checker = _checker(tmp_path)
+    # Three inputs, two variants: `g.3delinsG` is `g.3A>G` respelled and must
+    # join it. Two inputs and two classes would also be what a grouping that
+    # never merges produces, so the count would pin nothing.
+    corpus = _variants([f"{CONTIG}:g.3A>G", f"{CONTIG}:g.3A>C", f"{CONTIG}:g.3delinsG"])
+
+    report = checker.check_confluence(corpus, relation="cross_axis")
+
+    assert report["is_confluent"] is True
+    assert report["is_complete"] is True
+    assert report["classes_checked"] == 2
+
+
+def test_spdi_relation_is_selectable(tmp_path: Path) -> None:
+    checker = _checker(tmp_path)
+    corpus = _variants([f"{CONTIG}:g.13_14insT", f"{CONTIG}:g.14dup"])
+
+    report = checker.check_confluence(corpus, relation="spdi")
+
+    assert report["relation"] == "spdi"
+    assert report["is_confluent"] is True
+    assert report["classes_checked"] == 1
+
+
+def test_inputs_the_relation_cannot_place_are_skipped(tmp_path: Path) -> None:
+    checker = _checker(tmp_path)
+    # An unspecified inserted length denotes no resolvable sequence, so it has no
+    # SPDI key and cannot be placed.
+    corpus = _variants([f"{CONTIG}:g.10_11ins(10)", f"{CONTIG}:g.5_6ins(6)"])
+
+    report = checker.check_confluence(corpus, relation="spdi")
+
+    assert report["violations"] == []
+    assert len(report["skipped"]) == 2
+    assert all(entry["reason"] for entry in report["skipped"])
+    assert all("input" in entry for entry in report["skipped"])
+    assert all(entry["kind"] == "unplaceable" for entry in report["skipped"])
+    assert report["is_complete"] is False
+
+
+def test_unknown_relation_raises_value_error(tmp_path: Path) -> None:
+    checker = _checker(tmp_path)
+    with pytest.raises(ValueError):
+        checker.check_confluence(_variants([f"{CONTIG}:g.3A>G"]), relation="bogus")
+
+
+def test_empty_corpus_is_confluent(tmp_path: Path) -> None:
+    checker = _checker(tmp_path)
+    report = checker.check_confluence([])
+    assert report["is_confluent"] is True
+    assert report["is_complete"] is True
+    assert report["classes_checked"] == 0
+    assert report["undecided_pairs"] == 0
+
+
+def test_a_class_that_normalizes_apart_is_reported(tmp_path: Path) -> None:
+    """The headline behaviour: a violation is reported, with its inputs and outputs.
+
+    `g.[3A>G;10=]` states an unchanged base alongside the substitution and
+    `g.3A>G` does not; applying either produces the same bases, so they are one
+    class, and the normalizer keeps the `=` member, so the class reaches two
+    outputs. Every other test in this file asserts `violations == []`, which
+    cannot observe the reporting path at all.
+    """
+    checker = _checker(tmp_path)
+    corpus = _variants([f"{CONTIG}:g.[3A>G;10=]", f"{CONTIG}:g.3A>G"])
+
+    report = checker.check_confluence(corpus)
+
+    assert report["classes_checked"] == 1
+    assert report["is_complete"] is True, "the finding is about the corpus, not the reference"
+    assert report["is_confluent"] is False
+    assert len(report["violations"]) == 1
+    assert report["violations"][0]["inputs"] == [
+        f"{CONTIG}:g.[3A>G;10=]",
+        f"{CONTIG}:g.3A>G",
+    ]
+    assert report["violations"][0]["outputs"] == [
+        f"{CONTIG}:g.3A>G",
+        f"{CONTIG}:g.[3A>G;10=]",
+    ]
+
+
+def test_an_unreadable_reference_is_named_rather_than_read_as_clean(
+    tmp_path: Path,
+) -> None:
+    """A reference that cannot serve the bases must not read as a clean corpus.
+
+    Both descriptions are well formed and denote one variant; the contig is
+    simply not in the reference. Before this was reported, the run answered
+    `is_confluent: True`, `skipped: []` — byte-identical to a corpus that was
+    read and found confluent.
+    """
+    checker = _checker(tmp_path)
+    corpus = _variants(["NC_ABSENT.1:g.2del", "NC_ABSENT.1:g.2delC"])
+
+    for relation in ("cross_axis", "spdi"):
+        report = checker.check_confluence(corpus, relation=relation)
+
+        assert report["is_complete"] is False, relation
+        assert report["skipped"], relation
+        assert all(e["kind"] == "unplaceable" for e in report["skipped"]), relation
+        # The refusal must be classified against the reference rather than
+        # blamed on the description. Keyed on `decline_class`, not on the
+        # sentence: sniffing `reason` for "reference" passes whenever that word
+        # happens to appear and breaks silently on any rewording, so it tests
+        # the prose instead of the classification.
+        assert any(e["decline_class"] == "reference_unavailable" for e in report["skipped"]), (
+            relation
+        )
+        # The site is machine-readable too, so a consumer never parses English.
+        assert all(e["decline_site"] in (None, "member_conversion") for e in report["skipped"]), (
+            relation
+        )


### PR DESCRIPTION
Closes #1892.

Representation-Change: none. Additive diagnostic API; no watched directory (`src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`, `src/reference/`, `src/error_handling/`) is touched, and the check only reads normalization output — it never changes it.

## What this adds

`EquivalenceChecker::check_confluence(variants, relation)` — an **opt-in, diagnostic** confluence self-check a consumer can run over *their own* corpus. The designed cis corpus is enriched for multi-member shapes, so its non-confluence rate says nothing about a consumer's real data; this answers the question they can only answer for themselves: *are any two apply-equal descriptions in my call set normalized apart?*

It **composes decided machinery** rather than deciding anything new:

- Group the inputs into equivalence classes under a caller-chosen relation.
- Normalize each member.
- Report every class whose members reach more than one distinct normalized output — a non-confluence witness.

The grouping is derived from `apply` (`compare_denotations` / `spdi_key`), **never from the normalizer**, so it cannot collapse into the outputs it is checking — the non-circularity the `confluence-gate-is-apply-equality-on-every-determined-axis` ruling requires.

## The relation is the caller's parameter (this is not an adjudication)

Per the scope boundary in #1892, this does **not** decide which relation gates a release (that is the deferred adjudication in #1890). The relation is a parameter, and both options are already-decided, documented relations in this crate:

- `ConfluenceRelation::CrossAxisSequenceMatch` — apply-equality on every determined axis (`EquivalenceLevel::CrossAxisSequenceMatch`), the rung that establishes variant identity. The right default for "are two descriptions of one variant normalized apart?".
- `ConfluenceRelation::Spdi` — same denoted bases on the description's own axis (`SpdiKey`). Weaker and insufficient for identity (it buckets `c.3921dup` with `c.3922dup`); offered for counting distinct edits, per the issue naming it.

The result is a diagnostic report (`violations`, `classes_checked`, `skipped`, `relation`, `is_confluent`). `is_confluent()` is an observation about *this corpus under this relation*, never a pass/fail release verdict. Inputs the relation cannot place, and members the normalizer declines, are surfaced as **skips** — never silently dropped.

## API surface

Rust (`src/equivalence/`):
- `EquivalenceChecker::check_confluence(&[HgvsVariant], ConfluenceRelation) -> ConfluenceReport`
- `ConfluenceRelation` (`#[non_exhaustive]`), `ConfluenceGroup { inputs, outputs }`, `ConfluenceSkip { input, reason }`, `ConfluenceReport` (accessors + `into_parts`).

Python (`src/python.rs`, stub in `__init__.pyi`):
- `EquivalenceChecker.check_confluence(variants, relation="cross_axis"|"spdi") -> dict`, GIL released via `py.detach`; unknown relation raises `ValueError`.

## Testing

- Flag logic pinned deterministically as a unit test on `ConfluenceGroup::from_class` (confluent class -> no group; two distinct outputs -> a violation with deduped, sorted outputs; empty/singleton -> none).
- End-to-end integration (`tests/it/confluence_self_check_tests.rs`): confluent corpus reports clean, distinct variants form separate classes, unplaceable inputs are reported as skips, and the relation parameter changes the grouping (junction-straddling dups: one SPDI class vs two cross-axis classes).
- Python parity (`tests/python/test_issue_1892_confluence_self_check.py`).

**The headline behaviour has an end-to-end guard.** An earlier revision of this PR argued no hermetic "real violation" test was possible, and that was wrong: replacing `violations.push(group)` with a no-op left every test in the repository green. Two `MockProvider`-only witnesses now close it, each a pair the cross-axis relation groups into one class whose members normalize to two distinct strings — `g.[3A>G;10=]` vs `g.3A>G` (an `=` member changes nothing, so both apply-equal; the normalizer preserves it), and `g.10=` vs `g.20=` (two no-ops, which `src/equivalence/key.rs` records as a deliberate non-choice rather than a defect). The `violations.push` no-op now turns both red.

Each guard is verified by mutation rather than assumed: `violations.push` → no-op turns 2 tests red; `group_by_cross_axis` never merging turns 5 red (it turned 1 red before this revision — `the_relation_parameter_changes_the_grouping` and `distinct_variants_form_separate_classes` asserted a class count that a disabled grouping also produces, and both now use a three-input corpus reducing to two classes); removing the denotability screen turns 3 red; removing the undecided-pair count turns 1 red.

## What the run could not cover is never silence

A skip that reads as a pass is the failure this check exists to prevent, and there are two ways to lose coverage, accounted for separately.

Under either relation, an input with no computable denotation **on this reference** is reported as an `Unplaceable` skip carrying the underlying refusal — so a consumer with a partly-provisioned reference is told the *reference* declined, not that its own well-formed description denotes nothing. Under `cross_axis`, a *pair* whose comparison came back undecidable (over the checker's window cap, or a shape the relation errors on) fails to merge exactly as a decided-apart pair does; each is counted in `undecided_pairs`, because otherwise a class the checker could not examine is split into singletons and reported identically to a clean corpus.

`is_confluent` is a statement about the whole corpus only when `is_complete` is true. Coverage is `classes_checked` plus the `Unplaceable` skips: a `NormalizationDeclined` input **was** placed and its class **is** counted, so `classes_checked + len(skipped)` double-counts.

## Cost

`spdi` keys each input once (`O(n)`); `cross_axis` has no key and compares every pair (`O(n²)` `compare_denotations` calls, each doing its own SPDI conversion and reference fetches). Documented on the module. Deliberately no cap and no automatic downgrade: a cap must choose which pairs to stop comparing, and that shrinks the classes — reporting *fewer violations*, not more skips, which is the failure above. Batch by accession (classes never span accessions under either relation) or sample.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `FERRO_ASSERT_IDEMPOTENT=1 FERRO_ASSERT_REPARSE=1 FERRO_ASSERT_IN_BOUNDS=1 FERRO_SWEEP_SEEDS=full cargo nextest run --features dev --no-fail-fast` -> 11262 passed, 154 skipped
- `ruff check` / `mypy python/ferro_hgvs/` clean
- `pytest tests/python/` -> 1086 passed, 8 skipped
