### PR TITLE
fix(equivalence): route an edit_triples reference failure to Indeterminate, not NotEquivalent

### DIFF
--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -10,7 +10,7 @@ use crate::normalize::{NormalizeConfig, Normalizer};
 use crate::reference::transcript::Strand;
 use crate::reference::ReferenceProvider;
 use crate::sequence::reverse_complement;
-use crate::spdi::{hgvs_to_spdi, SpdiVariant};
+use crate::spdi::{hgvs_to_spdi, ConversionError, SpdiVariant};
 
 /// Largest reference window (in bases) a sequence-level equivalence rung will
 /// reconstruct, bounding the cost of a reference fetch.
@@ -541,19 +541,23 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                          sequence was reconstructed"
                     )));
             }
-            // The window is bounded and both sides convert to SPDI on a shared
-            // accession, but the provider could not serve its bases, so — as with
-            // `WindowTooWide` — nothing was reconstructed and nothing was
-            // compared (#1989). This is the "want of reference data" decline, and
-            // it must report `Indeterminate` for the same reason its sibling does:
-            // falling through to the `NotEquivalent` tail would assert a decided
-            // negative about a pair that was never examined. Pinned by
-            // `issue_1989_declined_is_indeterminate`.
+            // The reference needed to compare the pair could not be read, from
+            // either of two points: the window fetch, after both sides converted
+            // to SPDI on a shared accession (#1989/#2053), or a member's own
+            // HGVS→SPDI conversion, which the ordinary short forms must run
+            // against the provider (#2056). Either way — as with `WindowTooWide`
+            // — nothing was reconstructed and nothing was compared. This is the
+            // "want of reference data" decline, and it must report
+            // `Indeterminate` for the same reason its sibling does: falling
+            // through to the `NotEquivalent` tail would assert a decided negative
+            // about a pair that was never examined. Pinned by
+            // `issue_1989_declined_is_indeterminate` and
+            // `issue_2056_edit_triples_reference_failure`.
             SequenceVerdict::ReferenceUnavailable => {
                 return Ok(EquivalenceResult::new(EquivalenceLevel::Indeterminate)
                     .with_normalized(str1, str2)
                     .with_note(
-                        "The reference window covering both variants could not be read from the \
+                        "The reference needed to compare both variants could not be read from the \
                          provider, so neither resulting sequence was reconstructed"
                             .to_string(),
                     ));
@@ -566,17 +570,15 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
             // `same_resulting_sequence`) and an un-appliable overlapping allele
             // (`issue_1244_equivalence_overlap_panic`), each pinned there.
             //
-            // Those are not all of it, and the arm above does not make them so.
-            // `edit_triples` discards its conversion error —
-            // `hgvs_to_spdi(member, provider).ok()?`, `checker.rs:1114` — so a
-            // member whose conversion needed the reference and could not read it
-            // also arrives here as `Declined` and is read as a negative:
-            // `NC_ABSENT.1:g.2del` vs `g.2delC` answers `NotEquivalent` against
-            // a provider serving no bases and `CrossAxisSequenceMatch` against a
-            // served contig. So `ReferenceUnavailable` above is the
-            // reference-level decline reachable from the WINDOW FETCH, not every
-            // reference-level decline; the rest is #2056, a follow-up on
-            // `edit_triples`. These two fall through.
+            // The reference-level declines both reach `ReferenceUnavailable`
+            // above and are handled there: the window fetch (#1989/#2053) and,
+            // as of #2056, a member's own HGVS→SPDI conversion failing for want
+            // of reference data (`edit_triples` now classifies that as
+            // `TripleDecline::ReferenceUnavailable` rather than swallowing it).
+            // So `NC_ABSENT.1:g.2del` vs `g.2delC` — `NotEquivalent` before, and
+            // `CrossAxisSequenceMatch` against a served contig — reaches the
+            // `Indeterminate` arm above and never falls through here. These two
+            // fall through.
             SequenceVerdict::Different | SequenceVerdict::Declined => {}
         }
 
@@ -738,13 +740,16 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
             // it — so `edit_triples` already declined upstream.
             HgvsVariant::Cds(_) | HgvsVariant::Tx(_) | HgvsVariant::Rna(_) => {
                 match self.edit_triples(v) {
-                    Some((accession, triples)) => {
+                    Ok((accession, triples)) => {
                         match self.transcript_triples_to_genomic(&accession, &triples) {
                             Some((contig, mapped)) => SecondAxis::Genomic(contig, mapped),
                             None => SecondAxis::NotComputed,
                         }
                     }
-                    None => SecondAxis::NotComputed,
+                    // Either decline leaves the second axis uncomputed; the note
+                    // on `strengthen_across_axes`' decline arm reads it as
+                    // "could not be asked", never as a disagreement.
+                    Err(_) => SecondAxis::NotComputed,
                 }
             }
             // `edit_triples` has already established that a cis allele's
@@ -758,13 +763,13 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                     // together, rather than reporting only the first member's
                     // triples.
                     SecondAxis::Genomic(..) => match self.edit_triples(v) {
-                        Some((accession, triples)) => {
+                        Ok((accession, triples)) => {
                             match self.transcript_triples_to_genomic(&accession, &triples) {
                                 Some((contig, mapped)) => SecondAxis::Genomic(contig, mapped),
                                 None => SecondAxis::NotComputed,
                             }
                         }
-                        None => SecondAxis::NotComputed,
+                        Err(_) => SecondAxis::NotComputed,
                     },
                 },
                 None => SecondAxis::NotComputed,
@@ -920,29 +925,32 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
     ///
     /// Best-effort and side-effect free. [`SequenceVerdict::Declined`] covers
     /// every variant that cannot be projected to SPDI triples on a single
-    /// shared accession. Two declines are split out of it because they must not
-    /// be read as a negative: [`SequenceVerdict::WindowTooWide`] when the union
-    /// window exceeds [`MAX_SEQUENCE_COMPARE_WINDOW`], and
-    /// [`SequenceVerdict::ReferenceUnavailable`] when the provider cannot serve
-    /// the window's bases (#1989). Both are resolved to
-    /// [`EquivalenceLevel::Indeterminate`] by the caller.
+    /// shared accession. Three declines are split out of it because they must
+    /// not be read as a negative and instead resolve to
+    /// [`EquivalenceLevel::Indeterminate`] at the caller:
     ///
-    /// **The split covers the window fetch, and not every reference failure.**
-    /// [`Self::edit_triples`] discards its conversion error —
-    /// `hgvs_to_spdi(member, provider).ok()?`, `checker.rs:1114` — so a member
-    /// whose SPDI conversion had to read the reference and could not is `None`
-    /// there and `Declined` here, indistinguishable from an edit SPDI cannot
-    /// carry. Measured on this revision, against a provider serving no bases:
-    /// `NC_ABSENT.1:g.2del` vs `g.2delC` — one edit, two spellings — answers
-    /// `NotEquivalent`, while the same pair on a served contig answers
-    /// `CrossAxisSequenceMatch`. Narrowing that is #2056, a follow-up on
-    /// `edit_triples`, not on this function.
+    /// * [`SequenceVerdict::WindowTooWide`] — the union window exceeds
+    ///   [`MAX_SEQUENCE_COMPARE_WINDOW`];
+    /// * [`SequenceVerdict::ReferenceUnavailable`] from the **window fetch** —
+    ///   both sides convert to SPDI but the provider cannot serve the window's
+    ///   bases (#1989/#2053);
+    /// * [`SequenceVerdict::ReferenceUnavailable`] from a **member's
+    ///   HGVS→SPDI conversion** — a short form (`g.2del`, `g.2dup`) whose SPDI
+    ///   had to read the reference and could not, surfaced via
+    ///   [`TripleDecline::ReferenceUnavailable`] rather than swallowed (#2056).
+    ///
+    /// So `NC_ABSENT.1:g.2del` vs `g.2delC` — one edit, two spellings — now
+    /// answers `Indeterminate` on a provider serving no bases, matching its
+    /// `CrossAxisSequenceMatch` on a served contig; before #2056 it answered a
+    /// decided `NotEquivalent`.
     fn same_resulting_sequence(&self, v1: &HgvsVariant, v2: &HgvsVariant) -> SequenceVerdict {
-        let Some((acc1, triples1)) = self.edit_triples(v1) else {
-            return SequenceVerdict::Declined;
+        let (acc1, triples1) = match self.edit_triples(v1) {
+            Ok(t) => t,
+            Err(decline) => return decline.into_sequence_verdict(),
         };
-        let Some((acc2, triples2)) = self.edit_triples(v2) else {
-            return SequenceVerdict::Declined;
+        let (acc2, triples2) = match self.edit_triples(v2) {
+            Ok(t) => t,
+            Err(decline) => return decline.into_sequence_verdict(),
         };
         // A resulting sequence is only comparable on the same reference. Two
         // different accessions fail the relation's first conjunct outright,
@@ -994,8 +1002,10 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
     /// **A third shape now shares the SPDI blindness and is deliberately not
     /// listed either: a genomic `pter`/`qter`/`cen` description (#1643).**
     /// `hgvs_to_spdi` used to flatten those onto `base: 0` and convert; it now
-    /// refuses, so [`Self::edit_triples`]'s `.ok()?` swallows the new error and
-    /// the `SequenceMatch` rung stops firing for them. The reach is narrower
+    /// refuses. That refusal is not a reference-data error, so
+    /// [`Self::edit_triples`] classifies it as [`TripleDecline::Unrepresentable`]
+    /// and declines, and the `SequenceMatch` rung stops firing for them (#2056
+    /// changed how the error is carried, not that it declines). The reach is narrower
     /// than it looks, and the reason is worth writing down because it is not
     /// visible from this file: both rungs run on the **normalized** forms, and
     /// normalization *resolves* a marker against the provider
@@ -1054,7 +1064,7 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
         // ahead of the structural test is what makes the predicate self-retiring —
         // ring support in `hgvs_to_spdi` silently switches these pairs back to being
         // answered instead of declined.
-        if self.edit_triples(variant).is_some() {
+        if self.edit_triples(variant).is_ok() {
             return None;
         }
         // A cis allele carrying a ring is the same blindness one level down, and it
@@ -1087,39 +1097,62 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
     /// Project a variant to the SPDI primitive edits that make up its resulting
     /// sequence, together with the single accession they act on.
     ///
-    /// Returns `None` when a single resulting sequence is undefined or cannot be
-    /// derived: multi-molecule alleles (trans / mosaic / chimeric / and-or /
-    /// products / unknown phase), null/unknown alleles, edits SPDI cannot
-    /// represent, or members that span more than one accession.
-    fn edit_triples(&self, v: &HgvsVariant) -> Option<(String, Vec<SpdiVariant>)> {
+    /// Declines with [`TripleDecline::Unrepresentable`] when a single resulting
+    /// sequence is undefined or cannot be derived: multi-molecule alleles (trans
+    /// / mosaic / chimeric / and-or / products / unknown phase), null/unknown
+    /// alleles, edits SPDI cannot represent, or members that span more than one
+    /// accession.
+    ///
+    /// Declines with [`TripleDecline::ReferenceUnavailable`] when the shape
+    /// *is* representable but a member's HGVS→SPDI conversion had to read the
+    /// reference and could not — the ordinary short forms (`g.2del`, `g.2dup`,
+    /// `c.10_12del`) that omit their deleted / duplicated bases and so must
+    /// consult the provider to build their SPDI. This must not be read as a
+    /// negative: it is the [`SequenceVerdict::ReferenceUnavailable`] sibling one
+    /// step before the window fetch #2053 already guards, and it resolves to
+    /// [`EquivalenceLevel::Indeterminate`] (#2056). It used to be swallowed by
+    /// `hgvs_to_spdi(member, provider).ok()?`, collapsing "the reference could
+    /// not be read" into "unrepresentable" and answering `NotEquivalent` for a
+    /// pair the checker never compared — one that is *equivalent* when the
+    /// reference is served.
+    ///
+    /// The first member to decline decides: a `ReferenceUnavailable` behind an
+    /// earlier `Unrepresentable` member is not surfaced, because that member
+    /// already makes the whole allele's sequence uncomputable on any reference.
+    fn edit_triples(&self, v: &HgvsVariant) -> Result<(String, Vec<SpdiVariant>), TripleDecline> {
         let members: Vec<&HgvsVariant> = match v {
             HgvsVariant::Allele(allele) => {
                 // A single resulting sequence is only well-defined for a cis
                 // allele — all edits applied to the same molecule.
                 if allele.phase != AllelePhase::Cis {
-                    return None;
+                    return Err(TripleDecline::Unrepresentable);
                 }
                 allele.variants.iter().collect()
             }
-            HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => return None,
+            HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => {
+                return Err(TripleDecline::Unrepresentable)
+            }
             single => vec![single],
         };
         if members.is_empty() {
-            return None;
+            return Err(TripleDecline::Unrepresentable);
         }
 
         let mut accession: Option<String> = None;
         let mut triples = Vec::with_capacity(members.len());
         for member in members {
-            let spdi = hgvs_to_spdi(member, self.normalizer.provider()).ok()?;
+            let spdi = hgvs_to_spdi(member, self.normalizer.provider())
+                .map_err(TripleDecline::from_conversion_error)?;
             match &accession {
                 None => accession = Some(spdi.sequence.clone()),
-                Some(acc) if *acc != spdi.sequence => return None,
+                Some(acc) if *acc != spdi.sequence => return Err(TripleDecline::Unrepresentable),
                 Some(_) => {}
             }
             triples.push(spdi);
         }
-        accession.map(|acc| (acc, triples))
+        accession
+            .map(|acc| (acc, triples))
+            .ok_or(TripleDecline::Unrepresentable)
     }
 
     /// Fetch reference bases for the 0-based half-open interval
@@ -1225,30 +1258,31 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
 ///
 /// Three of the four variants mean "nothing was compared", and they are kept
 /// apart because they are not read the same way. `WindowTooWide` and
-/// `ReferenceUnavailable` are the two declines [`compare_triples`] raises before
-/// it reconstructs anything — the window that would settle the pair was not
-/// obtained, once because it exceeds the cap and once because the provider could
-/// not serve it — and both must report `Indeterminate`, because arguing either
+/// `ReferenceUnavailable` both report `Indeterminate`, because arguing either
 /// into a decided negative claims a comparison that never ran (#1989).
-/// `Declined` is the catch-all; the checker deliberately routes it to
-/// `NotEquivalent`, and the shapes it is *meant* to carry — an edit SPDI cannot
-/// carry, a cross-accession pair, an un-appliable overlapping allele — are
-/// pinned elsewhere. `Different` is the one decided negative that was actually
-/// measured: both sides reconstructed, and they disagree.
+/// `WindowTooWide` is a window that exceeds the cap. `ReferenceUnavailable` is
+/// "want of reference data", and it now has **two** sources, both routed here by
+/// [`Self::same_resulting_sequence`]: the window fetch failing after both sides
+/// convert ([`compare_triples`], #1989/#2053), and — as of #2056 — a member's
+/// own HGVS→SPDI conversion failing for want of reference, surfaced by
+/// [`edit_triples`](EquivalenceChecker::edit_triples) as
+/// [`TripleDecline::ReferenceUnavailable`] instead of being swallowed. `Declined`
+/// is the catch-all; the checker deliberately routes it to `NotEquivalent`, and
+/// the shapes it carries — an edit SPDI cannot carry, a cross-accession pair, an
+/// un-appliable overlapping allele — are pinned elsewhere. `Different` is the one
+/// decided negative that was actually measured: both sides reconstructed, and
+/// they disagree.
 ///
-/// **`Declined` is not purely representation-level.** `EquivalenceChecker::edit_triples`
-/// discards its conversion error — `hgvs_to_spdi(member, provider).ok()?`,
-/// `checker.rs:1114` — so a member whose SPDI conversion had to read the
-/// reference and could not is `None` there and `Declined` here, on the same
-/// footing as an unrepresentable edit. Measured on this revision:
-/// `NC_ABSENT.1:g.2del` vs `g.2delC` (one edit, two spellings) answers
-/// `NotEquivalent` against a provider serving no bases and
-/// `CrossAxisSequenceMatch` against a served contig; `g.2dup` vs `g.2_3insC`
-/// against the unserved provider, and two out-of-bounds substitutions on a
-/// *served* 12-base contig, answer `NotEquivalent` by the same route. Each of
-/// those declines before the fetch, which is how it is distinguishable from the
-/// `ReferenceUnavailable` arm at all. Distinguishing them is #2056, a follow-up
-/// on `edit_triples`; the split below is scoped to [`compare_triples`]'s fetch.
+/// The short forms are why the `edit_triples` source matters most in practice:
+/// `g.2del`, `g.2dup`, `c.10_12del` omit their deleted / duplicated bases, so
+/// every one must read the reference to build its SPDI. `NC_ABSENT.1:g.2del` vs
+/// `g.2delC` (one edit, two spellings) answered a decided `NotEquivalent` on a
+/// provider serving no bases before #2056, and `CrossAxisSequenceMatch` on a
+/// served contig; it now answers `Indeterminate` when unserved. Pinned by
+/// `issue_2056_edit_triples_reference_failure`. Note an **out-of-bounds
+/// substitution on a served contig** does *not* take this route — its SPDI
+/// converts (a substitution states its own bases), so it is the window fetch's
+/// concern, not `edit_triples`'.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SequenceVerdict {
     /// Both sides were reconstructed and the resulting sequences are equal.
@@ -1258,20 +1292,89 @@ enum SequenceVerdict {
     /// Nothing was reconstructed: the union window exceeds
     /// [`MAX_SEQUENCE_COMPARE_WINDOW`].
     WindowTooWide,
-    /// Nothing was reconstructed: the union window is bounded and both sides
-    /// convert to SPDI on a shared accession, but the provider could not serve
-    /// the reference bases needed to compare them (#1989). The "want of
-    /// reference data" decline — the sibling of [`Self::WindowTooWide`], and like
-    /// it a decline that must **not** be read as a negative.
+    /// Nothing was reconstructed for want of reference data. Raised from two
+    /// sources: the union window is bounded and both sides convert to SPDI on a
+    /// shared accession, but the provider could not serve the window's bases
+    /// (#1989/#2053); or a member's own HGVS→SPDI conversion needed the reference
+    /// and could not read it, mapped from [`TripleDecline::ReferenceUnavailable`]
+    /// (#2056). The "want of reference data" decline — the sibling of
+    /// [`Self::WindowTooWide`], and like it a decline that must **not** be read
+    /// as a negative.
     ReferenceUnavailable,
-    /// Nothing was reconstructed, for any other reason. The shapes it is meant
-    /// to carry are representation-level — an edit SPDI cannot carry, a
-    /// cross-accession pair, an overlapping allele that cannot be applied — and
-    /// the checker deliberately reads this as a negative. It also carries a
-    /// reference failure that happened *before* the fetch, in `edit_triples`'s
-    /// discarded conversion error (`checker.rs:1114`) — that is #2056, and the
-    /// enum-level note has the measurements.
+    /// Nothing was reconstructed, for any other reason. The shapes it carries
+    /// are representation-level — an edit SPDI cannot carry, a cross-accession
+    /// pair, an overlapping allele that cannot be applied — and the checker
+    /// deliberately reads this as a negative. A reference failure that happens
+    /// *before* the fetch, inside `edit_triples`, no longer lands here: it is
+    /// [`Self::ReferenceUnavailable`] as of #2056 (see [`TripleDecline`]).
+    ///
+    /// One reference-level obstacle still does land here, knowingly: a fetch
+    /// that **succeeds** followed by an `apply_triples` that returns `None` —
+    /// typically a description whose stated reference base contradicts the base
+    /// the reference carries. That is [`compare_triples`]'s catch-all arm, it is
+    /// the last route by which a reference-level obstacle is read as a decided
+    /// negative, and it is tracked as **#2075** rather than fixed here.
     Declined,
+}
+
+/// Why [`EquivalenceChecker::edit_triples`] could not project a variant to its
+/// SPDI triples, split so the reference-data case is not read as a negative.
+///
+/// This is the `edit_triples` counterpart of [`SequenceVerdict`]'s
+/// `ReferenceUnavailable`/`Declined` split. #1989/#2053 made that distinction at
+/// the sequence rung's **window fetch** ([`compare_triples`]); #2056 makes the
+/// same distinction one step earlier, at the per-member HGVS→SPDI conversion,
+/// which the ordinary short forms (`g.2del`, `g.2dup`) must run against the
+/// provider.
+enum TripleDecline {
+    /// A member's HGVS→SPDI conversion needed reference bases the provider could
+    /// not serve ([`ConversionError::MissingReferenceData`] or
+    /// [`ConversionError::ProviderRequired`]). "Want of reference data", not a
+    /// representation limit — resolves to [`EquivalenceLevel::Indeterminate`].
+    ReferenceUnavailable,
+    /// No single resulting sequence exists to compare: an edit SPDI cannot
+    /// carry, a position SPDI cannot address
+    /// ([`ConversionError::UnrepresentableInSpdi`] — an intronic `c.`/`n.`/`r.`
+    /// offset), a null/unknown or multi-molecule allele, an empty member list,
+    /// or members spanning more than one accession. Read as a decided negative.
+    Unrepresentable,
+}
+
+impl TripleDecline {
+    /// Classify a [`ConversionError`] raised while converting a member to SPDI.
+    /// The two reference-availability errors are the only ones that must not be
+    /// read as a negative; every other conversion failure is a representation
+    /// limit.
+    ///
+    /// **Exhaustive on purpose, with no wildcard arm.** [`ConversionError`] is
+    /// `#[non_exhaustive]`, but this module is in the *same crate*, where that
+    /// attribute has no effect — so a wildcard here would protect nothing while
+    /// silently classifying a future reference-availability variant as
+    /// `Unrepresentable`, re-introducing #2056's defect with no build error and
+    /// no failing test. Spelled out, the next variant added to
+    /// [`ConversionError`] is a compile error at exactly the site that has to
+    /// decide what it means.
+    fn from_conversion_error(err: ConversionError) -> Self {
+        match err {
+            // Answerable by a better-provisioned provider: "could not tell".
+            ConversionError::MissingReferenceData { .. }
+            | ConversionError::ProviderRequired { .. } => TripleDecline::ReferenceUnavailable,
+            // Decided by the description alone; no provider changes the answer.
+            ConversionError::UnrepresentableInSpdi { .. }
+            | ConversionError::UnsupportedVariantType { .. }
+            | ConversionError::UnsupportedEditType { .. }
+            | ConversionError::InvalidPosition { .. }
+            | ConversionError::InvalidAccession { .. } => TripleDecline::Unrepresentable,
+        }
+    }
+
+    /// The [`SequenceVerdict`] this decline maps to at the sequence rung.
+    fn into_sequence_verdict(self) -> SequenceVerdict {
+        match self {
+            TripleDecline::ReferenceUnavailable => SequenceVerdict::ReferenceUnavailable,
+            TripleDecline::Unrepresentable => SequenceVerdict::Declined,
+        }
+    }
 }
 
 /// The axis a description determines beyond the one it is written in.
@@ -1330,6 +1433,12 @@ where
         // otherwise-identical resulting sequences.
         (Some(a), Some(b)) if a.eq_ignore_ascii_case(&b) => SequenceVerdict::Same,
         (Some(_), Some(_)) => SequenceVerdict::Different,
+        // The fetch succeeded and a side still would not apply — most often
+        // because its stated reference base contradicts the base the reference
+        // carries. That is a reference-level obstacle read as a decided
+        // negative, i.e. the same class #2053 and #2056 each closed at their own
+        // rung, surviving at this one. Tracked as #2075; deliberately unchanged
+        // here so this PR moves one rung only.
         _ => SequenceVerdict::Declined,
     }
 }
@@ -1797,15 +1906,23 @@ mod tests {
     }
 
     #[test]
-    fn test_accession_version_different_variant_not_equivalent() {
+    fn test_accession_version_different_variant_is_indeterminate_when_unresolvable() {
         let checker = checker();
-        // Different versions AND different variants = not equivalent
+        // Different versions AND different variant parts, so the
+        // `AccessionVersionDifference` rung (which needs equal variant parts)
+        // does not fire and the pair reaches the sequence rung. `NM_000088.4`
+        // is not in the test provider, so its `c.` position cannot be resolved
+        // to SPDI. Before #2056 `edit_triples` swallowed that reference failure
+        // and the checker answered a decided `NotEquivalent` for a pair it never
+        // compared; it now reports `Indeterminate` — the same direction #1989
+        // established for the window-fetch route.
         let v1 = parse_hgvs("NM_000088.3:c.10A>G").unwrap();
         let v2 = parse_hgvs("NM_000088.4:c.20A>G").unwrap();
 
         let result = checker.check(&v1, &v2).unwrap();
-        assert_eq!(result.level, EquivalenceLevel::NotEquivalent);
+        assert_eq!(result.level, EquivalenceLevel::Indeterminate);
         assert!(!result.is_equivalent());
+        assert!(!result.level.is_decided());
     }
 
     #[test]
@@ -1898,16 +2015,22 @@ mod tests {
     }
 
     #[test]
-    fn test_lrg_accession_version_difference() {
+    fn test_lrg_different_transcripts_are_indeterminate_when_unresolvable() {
         let checker = checker();
-        // LRG transcripts
+        // Different LRG transcripts (t1 vs t2), not versions, so the
+        // `AccessionVersionDifference` rung does not fire and the pair reaches
+        // the sequence rung. Neither transcript is in the test provider, so
+        // neither `c.` position resolves to SPDI. Before #2056 the swallowed
+        // reference failure produced a decided `NotEquivalent`; the checker now
+        // reports `Indeterminate`, because a pair it could not build cannot be
+        // asserted a negative (had both transcripts been served they would have
+        // resolved to distinct SPDI accessions and stayed a decided negative).
         let v1 = parse_hgvs("LRG_1t1:c.10A>G").unwrap();
         let v2 = parse_hgvs("LRG_1t2:c.10A>G").unwrap();
 
         let result = checker.check(&v1, &v2).unwrap();
-        // These are different transcripts (t1 vs t2), not versions
-        // Should be NotEquivalent
-        assert_eq!(result.level, EquivalenceLevel::NotEquivalent);
+        assert_eq!(result.level, EquivalenceLevel::Indeterminate);
+        assert!(!result.level.is_decided());
     }
 
     #[test]

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -158,6 +158,31 @@ pub enum ConversionError {
         /// Why a provider is needed for this variant.
         reason: String,
     },
+    /// SPDI cannot express the description at all — a limit of the *target
+    /// representation*, decided from the description alone.
+    ///
+    /// The distinction from its two reference-flavoured siblings is what a
+    /// better-provisioned provider would buy you: [`ProviderRequired`] is
+    /// answered by supplying a provider and [`MissingReferenceData`] by
+    /// supplying one that holds the region, while **no** provider answers this
+    /// one, because nothing is missing. SPDI is positional and has no offset
+    /// notation, so an intronic transcript position (`c.10+5`, `n.10+5`,
+    /// `r.10+5`) names no coordinate on the transcript accession however
+    /// completely that accession is served.
+    ///
+    /// Consumers classifying a conversion failure as "could not tell" versus
+    /// "decided negative" must read this as the latter — see
+    /// `equivalence::checker`'s `TripleDecline::from_conversion_error`, which
+    /// is where routing these three sites through `MissingReferenceData`
+    /// turned four decided verdicts into refusals on a fully served reference
+    /// (#2056 follow-up).
+    ///
+    /// [`MissingReferenceData`]: ConversionError::MissingReferenceData
+    /// [`ProviderRequired`]: ConversionError::ProviderRequired
+    UnrepresentableInSpdi {
+        /// What cannot be expressed, and why.
+        description: String,
+    },
 }
 
 impl std::fmt::Display for ConversionError {
@@ -191,6 +216,9 @@ impl std::fmt::Display for ConversionError {
                     "reference provider required to convert {}. variant: {}",
                     variant_type, reason
                 )
+            }
+            ConversionError::UnrepresentableInSpdi { description } => {
+                write!(f, "cannot be expressed in SPDI: {}", description)
             }
         }
     }
@@ -1376,13 +1404,17 @@ fn unwrap_edit<E>(edit: &crate::hgvs::uncertainty::Mu<E>) -> Result<&E, Conversi
 /// already answers the same question for the **start** side, with `ok_or_else`
 /// and exactly that variant ("cannot convert c. variant with unknown start
 /// position"). The asymmetry between the two sides *is* the defect, so the end
-/// gets what the start has always had. The axis' other verdict,
-/// `MissingReferenceData`, would be a false statement here: it means "a
-/// well-formed position whose SPDI form needs data or a projection I do not
-/// have" (see [`resolve_cds_to_tx`], [`resolve_tx_pos`], [`require_simple_tx_pos`]),
-/// and it invites the caller to supply a provider. No provider, exon table or
-/// genomic projection can resolve `?` — the uncertainty is in the description,
-/// not in ferro's reference data.
+/// gets what the start has always had.
+///
+/// Neither of the axis' other two verdicts fits. `MissingReferenceData` means
+/// "a well-formed position whose SPDI form needs reference data I do not have",
+/// and it invites the caller to supply a provider — but no provider, exon table
+/// or genomic projection can resolve `?`, because the uncertainty is in the
+/// description rather than in ferro's reference data. `UnrepresentableInSpdi`
+/// is nearer but still wrong: it says the *representation* cannot carry an
+/// otherwise-determinate position (see [`resolve_cds_to_tx`], [`resolve_tx_pos`],
+/// [`require_simple_tx_pos`], whose intronic offsets are exactly that), whereas
+/// `?` names no position for any representation to carry.
 fn resolve_transcript_end_boundary<'a, T: std::fmt::Display>(
     interval: &'a Interval<T>,
     coord: &str,
@@ -1403,8 +1435,9 @@ fn resolve_transcript_end_boundary<'a, T: std::fmt::Display>(
 }
 
 /// Resolve the start position of a `TxInterval` for the simple (no-provider)
-/// path. Returns `MissingReferenceData` if the position requires provider
-/// data (intronic, downstream `*N`, or non-positive base).
+/// path. Returns `MissingReferenceData` if the position requires provider data
+/// (downstream `*N` or non-positive base), and `UnrepresentableInSpdi` for an
+/// intronic offset, which no provider can resolve.
 fn tx_pos_for_simple_path(interval: &Interval<TxPos>, coord: &str) -> Result<u64, ConversionError> {
     let start = interval
         .start
@@ -1427,10 +1460,16 @@ fn tx_end_for_simple_path(interval: &Interval<TxPos>, coord: &str) -> Result<u64
 // provider-backed path (`hgvs_to_spdi`) does bound; `hgvs_to_spdi_simple`
 // callers accept unbounded exonic positions by construction.
 fn require_simple_tx_pos(pos: &TxPos, coord: &str) -> Result<u64, ConversionError> {
+    // Not `MissingReferenceData`: unlike the two declines below it, this one is
+    // not answered by supplying a provider. The provider-backed path refuses an
+    // intronic position too (`resolve_tx_pos`), because SPDI has no offset
+    // notation — so promising "requires reference provider with exon data" here
+    // would send the caller after a provider that cannot help.
     if pos.is_intronic() {
-        return Err(ConversionError::MissingReferenceData {
+        return Err(ConversionError::UnrepresentableInSpdi {
             description: format!(
-                "intronic {}. position requires reference provider with exon data",
+                "intronic {}. position cannot be expressed in SPDI without genomic projection; \
+                 SPDI is positional and has no offset notation",
                 coord
             ),
         });
@@ -1482,10 +1521,12 @@ fn rna_end_for_simple_path(
 // provider-backed path (`hgvs_to_spdi`) does bound; `hgvs_to_spdi_simple`
 // callers accept unbounded exonic positions by construction.
 fn require_simple_rna_pos(pos: &RnaPos, coord: &str) -> Result<u64, ConversionError> {
+    // See `require_simple_tx_pos`: a representation limit, not a provider gap.
     if pos.is_intronic() {
-        return Err(ConversionError::MissingReferenceData {
+        return Err(ConversionError::UnrepresentableInSpdi {
             description: format!(
-                "intronic {}. position requires reference provider with exon data",
+                "intronic {}. position cannot be expressed in SPDI without genomic projection; \
+                 SPDI is positional and has no offset notation",
                 coord
             ),
         });
@@ -1529,6 +1570,12 @@ fn rna_needs_provider(interval: &Interval<RnaPos>) -> bool {
 /// on the transcript accession without first projecting to genomic coords.
 /// That projection is intentionally out of scope for this entry point —
 /// callers needing it can use the genomic conversion path explicitly.
+///
+/// That rejection is [`ConversionError::UnrepresentableInSpdi`] and is raised
+/// **before the provider is consulted at all**, which is why it must not be
+/// `MissingReferenceData`: no amount of reference data changes the answer, and
+/// a consumer classifying the error would otherwise read a decidable case as
+/// "could not tell".
 fn resolve_cds_to_tx<P: ReferenceProvider + ?Sized>(
     accession: &Accession,
     start: &CdsPos,
@@ -1536,7 +1583,7 @@ fn resolve_cds_to_tx<P: ReferenceProvider + ?Sized>(
     provider: &P,
 ) -> Result<(u64, u64), ConversionError> {
     if start.is_intronic() || end.is_intronic() {
-        return Err(ConversionError::MissingReferenceData {
+        return Err(ConversionError::UnrepresentableInSpdi {
             description: "intronic c. positions cannot be expressed in SPDI without genomic \
                           projection; SPDI is positional and has no offset notation"
                 .to_string(),
@@ -1676,9 +1723,10 @@ fn resolve_tx_pos(pos: &TxPos, transcript: &Transcript) -> Result<u64, Conversio
     // SPDI is positional and has no offset notation, so intronic n. positions
     // cannot be expressed without genomic projection. Match the sibling
     // `resolve_rna_pos` (and the simple-path helpers) by emitting
-    // `MissingReferenceData` here.
+    // `UnrepresentableInSpdi` here: the answer is decided by the position's own
+    // spelling, and no provider changes it.
     if pos.is_intronic() {
-        return Err(ConversionError::MissingReferenceData {
+        return Err(ConversionError::UnrepresentableInSpdi {
             description: format!(
                 "intronic n.{} cannot be expressed in SPDI without genomic projection; \
                  SPDI is positional and has no offset notation",
@@ -1706,8 +1754,9 @@ fn resolve_tx_pos(pos: &TxPos, transcript: &Transcript) -> Result<u64, Conversio
 }
 
 fn resolve_rna_pos(pos: &RnaPos, transcript: &Transcript) -> Result<u64, ConversionError> {
+    // As in `resolve_tx_pos`: a representation limit, read off the spelling.
     if pos.is_intronic() {
-        return Err(ConversionError::MissingReferenceData {
+        return Err(ConversionError::UnrepresentableInSpdi {
             description: format!(
                 "intronic r.{} cannot be expressed in SPDI without genomic projection; \
                  SPDI is positional and has no offset notation",
@@ -5265,16 +5314,20 @@ mod tests {
     }
 
     #[test]
-    fn test_hgvs_to_spdi_simple_tx_intronic_needs_provider() {
-        // n.100+5: intronic offset cannot be expressed as a positional SPDI;
-        // the simple path bails with MissingReferenceData (provider needed
-        // for genomic projection — out of scope for this PR).
+    fn test_hgvs_to_spdi_simple_tx_intronic_is_unrepresentable() {
+        // n.100+5: an intronic offset cannot be expressed as a positional SPDI.
+        //
+        // The simple path used to call this `MissingReferenceData` and say the
+        // position "requires reference provider with exon data", which named a
+        // remedy that does not exist — the provider-backed path refuses an
+        // intronic position too (`resolve_tx_pos`). It is a limit of SPDI, so
+        // it declines as `UnrepresentableInSpdi` on both paths.
         let hgvs = parse_hgvs("NR_046018.2:n.100+5A>G").unwrap();
         let result = hgvs_to_spdi_simple(&hgvs);
-        assert!(matches!(
-            result,
-            Err(ConversionError::MissingReferenceData { .. })
-        ));
+        assert!(
+            matches!(result, Err(ConversionError::UnrepresentableInSpdi { .. })),
+            "expected a representation limit, got {result:?}"
+        );
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("intronic"), "msg: {}", msg);
     }
@@ -5356,13 +5409,14 @@ mod tests {
     }
 
     #[test]
-    fn test_hgvs_to_spdi_simple_rna_intronic_needs_provider() {
+    fn test_hgvs_to_spdi_simple_rna_intronic_is_unrepresentable() {
+        // As on the `n.` axis above: a representation limit, not a provider gap.
         let hgvs = parse_hgvs("NR_046018.2:r.10+5a>g").unwrap();
         let result = hgvs_to_spdi_simple(&hgvs);
-        assert!(matches!(
-            result,
-            Err(ConversionError::MissingReferenceData { .. })
-        ));
+        assert!(
+            matches!(result, Err(ConversionError::UnrepresentableInSpdi { .. })),
+            "expected a representation limit, got {result:?}"
+        );
     }
 
     // ----- p. (protein) — rejected with helpful error -----------------------
@@ -5683,14 +5737,17 @@ mod tests {
     #[test]
     fn test_hgvs_to_spdi_with_provider_cds_intronic_rejected() {
         // Intronic c. cannot be expressed as a positional SPDI: SPDI has no
-        // offset notation. The provider-aware path surfaces a clear error.
+        // offset notation. The provider-aware path surfaces a clear error —
+        // and it is a *representation* error, not a reference one: this
+        // provider serves the transcript, and the decline is raised before it
+        // is asked anything.
         let provider = make_intronic_provider();
         let hgvs = parse_hgvs("NM_INTRON.1:c.10+5A>G").unwrap();
         let result = hgvs_to_spdi(&hgvs, &provider);
-        assert!(matches!(
-            result,
-            Err(ConversionError::MissingReferenceData { .. })
-        ));
+        assert!(
+            matches!(result, Err(ConversionError::UnrepresentableInSpdi { .. })),
+            "expected a representation limit, got {result:?}"
+        );
     }
 
     #[test]
@@ -6292,12 +6349,19 @@ mod tests {
     }
 
     /// The transcript axes are where a `+`/`-` offset is legitimate HGVS, and
-    /// the genomic guard must not reach them. Each still declines for its own,
-    /// unchanged reason — `MissingReferenceData`, "cannot be expressed in SPDI
-    /// without genomic projection" — which is a different verdict from the
-    /// genomic `InvalidPosition`, and the difference is the point: `c.10+5` is
-    /// a well-formed position SPDI cannot carry, `g.10+2` is not a well-formed
+    /// the genomic guard must not reach them. Each still declines for its own
+    /// reason — `UnrepresentableInSpdi`, "cannot be expressed in SPDI without
+    /// genomic projection" — which is a different verdict from the genomic
+    /// `InvalidPosition`, and the difference is the point: `c.10+5` is a
+    /// well-formed position SPDI cannot carry, `g.10+2` is not a well-formed
     /// position at all.
+    ///
+    /// The carrier used to be `MissingReferenceData`, which named the wrong
+    /// obstacle: the provider is serving this transcript — the exonic siblings
+    /// below prove it — and the `c.` arm declines before the provider is
+    /// consulted at all. Consumers classify a conversion failure on this
+    /// variant, and a downstream one read the mislabel as "could not tell"; see
+    /// `equivalence::checker`'s `TripleDecline::from_conversion_error`.
     ///
     /// Their exonic siblings on the same providers still convert, so this pins
     /// that the axes are working rather than merely erroring.
@@ -6313,8 +6377,9 @@ mod tests {
             let err = hgvs_to_spdi(&variant, &provider)
                 .expect_err("an intronic transcript position has no SPDI representation");
             assert!(
-                matches!(err, ConversionError::MissingReferenceData { .. }),
-                "`{descriptor}` must still decline as MissingReferenceData, got {err:?}"
+                matches!(err, ConversionError::UnrepresentableInSpdi { .. }),
+                "`{descriptor}` must decline as UnrepresentableInSpdi — the reference is served \
+                 and is not the obstacle, got {err:?}"
             );
             assert!(
                 err.to_string().contains("genomic projection"),
@@ -6734,7 +6799,7 @@ mod tests {
     /// which is a deliberate change of diagnostic and worth pinning as one.
     ///
     /// On `main`, `n.10+5_?delAAAA` reported the intronic start
-    /// (`MissingReferenceData`, "cannot be expressed in SPDI without genomic
+    /// (`UnrepresentableInSpdi`, "cannot be expressed in SPDI without genomic
     /// projection"); it now reports the end. Both are correct refusals, and the
     /// ordering is structural rather than a preference: `resolve_tx_to_provider_tx`
     /// takes a resolved end **by value**, so there is nothing to hand it until
@@ -6764,7 +6829,7 @@ mod tests {
         let err = hgvs_to_spdi(&intronic_only, &provider)
             .expect_err("an intronic transcript position has no SPDI representation");
         assert!(
-            matches!(err, ConversionError::MissingReferenceData { .. }),
+            matches!(err, ConversionError::UnrepresentableInSpdi { .. }),
             "a resolvable end must leave the intronic decline untouched, got {err:?}"
         );
         assert!(

--- a/tests/it/issue_2056_edit_triples_reference_failure.rs
+++ b/tests/it/issue_2056_edit_triples_reference_failure.rs
@@ -1,0 +1,266 @@
+//! #2056: a reference-data failure **inside `edit_triples`** must report
+//! [`EquivalenceLevel::Indeterminate`], not a decided negative.
+//!
+//! This is the sibling of #1989. #1989 (and its fix, #2053) split a
+//! `ReferenceUnavailable` decline out of the sequence rung's **window fetch**
+//! (`compare_triples`): the two sides convert to SPDI, but the reference window
+//! that would compare them cannot be read. #2056 is the *other* reference route,
+//! one step earlier: a member's HGVS→SPDI conversion itself needs to read the
+//! reference and cannot.
+//!
+//! The short forms are the whole point. HGVS routinely omits the deleted or
+//! duplicated bases — `g.2del`, `g.2dup`, `c.10_12del` are the ordinary
+//! spellings — and every one of those must read the reference to build its SPDI
+//! (to learn which bases it deletes / duplicates). On a provider that cannot
+//! serve them, `hgvs_to_spdi` returns [`ConversionError::MissingReferenceData`].
+//! `edit_triples` used to swallow that with `.ok()?`, turning the reference
+//! failure into `None` → `SequenceVerdict::Declined` → the ladder's
+//! `NotEquivalent` tail: a decided negative asserted for a pair that was never
+//! compared, and which is in fact *equivalent* when the reference is served.
+//!
+//! # Scope
+//!
+//! This targets exactly the swallowed HGVS→SPDI reference failure. It does
+//! **not** touch the declines the checker routes to `NotEquivalent` on purpose
+//! and pins elsewhere — an RNA fusion, a genuine cross-accession pair, an
+//! overlapping cis allele (each an *edit-level* decline where the reference was
+//! never the obstacle) — nor the window-fetch route #2053 already handles.
+
+use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+use ferro_hgvs::spdi::{hgvs_to_spdi, ConversionError};
+use ferro_hgvs::{parse_hgvs, MockProvider};
+
+use crate::common::synthetic::SyntheticBuilder;
+
+/// An accession the provider serves no bases for, so no short form's SPDI can be
+/// built.
+const ABSENT: &str = "NC_ABSENT.1";
+
+/// The primary reproducer, and the one that surfaces through **both** entry
+/// points. `g.2dup` needs the reference to name its duplicated base and
+/// `g.2_3insC` states its own; on an absent provider the two do not converge
+/// under normalization, so `check` reaches the sequence rung too. Both must
+/// report `Indeterminate`, not the decided negative the swallowed conversion
+/// error used to produce.
+#[test]
+fn a_short_form_needing_an_unavailable_reference_is_indeterminate() {
+    let checker = EquivalenceChecker::new(MockProvider::new());
+
+    let a = parse_hgvs(&format!("{ABSENT}:g.2dup")).unwrap();
+    let b = parse_hgvs(&format!("{ABSENT}:g.2_3insC")).unwrap();
+
+    for (label, result) in [
+        (
+            "compare_denotations",
+            checker.compare_denotations(&a, &b).unwrap(),
+        ),
+        ("check", checker.check(&a, &b).unwrap()),
+    ] {
+        assert_eq!(
+            result.level,
+            EquivalenceLevel::Indeterminate,
+            "{label}: a swallowed reference failure is 'could not tell', not a decided negative; \
+             got {:?}",
+            result.level,
+        );
+        assert!(
+            !result.level.is_decided(),
+            "{label}: an unreconstructable comparison is not a decided verdict",
+        );
+    }
+}
+
+/// The second short form, reached through the direct entry point. `g.2del` needs
+/// the reference to name its deleted base; `g.2delC` states it. Via `check` the
+/// two happen to converge under normalization (a different, earlier rung), so
+/// `compare_denotations` — which does not normalize — is where the swallowed
+/// failure is visible.
+#[test]
+fn a_deletion_short_form_reference_failure_is_indeterminate() {
+    let checker = EquivalenceChecker::new(MockProvider::new());
+
+    let a = parse_hgvs(&format!("{ABSENT}:g.2del")).unwrap();
+    let b = parse_hgvs(&format!("{ABSENT}:g.2delC")).unwrap();
+
+    let result = checker.compare_denotations(&a, &b).unwrap();
+    assert_eq!(
+        result.level,
+        EquivalenceLevel::Indeterminate,
+        "the deletion's base could not be read, so the verdict is not decided; got {:?}",
+        result.level,
+    );
+}
+
+/// The discriminating control, and why this fix does not over-map. When the
+/// reference **is** served, the short forms convert and the pair reconstructs to
+/// the same sequence — a decided **positive** that must survive unchanged.
+#[test]
+fn served_short_forms_still_reach_a_decided_positive() {
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic("ACGTACGTACGT").build());
+
+    for (a, b) in [
+        ("NC_TEST.1:g.2dup", "NC_TEST.1:g.2_3insC"),
+        ("NC_TEST.1:g.2del", "NC_TEST.1:g.2delC"),
+    ] {
+        let va = parse_hgvs(a).unwrap();
+        let vb = parse_hgvs(b).unwrap();
+        let result = checker.compare_denotations(&va, &vb).unwrap();
+        assert!(
+            result.level.is_equivalent(),
+            "{a} vs {b}: a reconstructed, equivalent pair still reaches a decided positive; \
+             got {:?}",
+            result.level,
+        );
+    }
+}
+
+/// The other half of the control: with a served reference, two variants that
+/// genuinely produce different sequences must still be a decided negative. The
+/// fix moves only the case where the reference could not be read, never a
+/// genuine disagreement.
+#[test]
+fn served_genuinely_different_short_forms_stay_not_equivalent() {
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic("ACGTACGTACGT").build());
+
+    // Two deletions at different positions on a served contig — a real
+    // disagreement the sequence rung reconstructs.
+    //
+    // Mind what `g.2` and `g.6` actually address. `SyntheticBuilder::genomic`
+    // wraps its core in `PAD_OFFSET` (256) bases of `ACGT…` on each side, so
+    // `NC_TEST.1` here is **524** bases and the core `ACGTACGTACGT` starts at
+    // `g.257`. Positions 2 and 6 are therefore in the 5' **pad**, not in the
+    // core; they happen to read `C` either way only because the pad repeats the
+    // same period-4 motif the core does. That padding is also why an
+    // out-of-bounds probe on this builder is not out of bounds — `g.20`/`g.21`
+    // are served bases, and a stated-ref-base contradiction there declines
+    // through a third route (`apply_triples` -> `compare_triples`'s catch-all),
+    // which is neither this route nor #2053's window fetch. That third route is
+    // #2075 and is still open.
+    let a = parse_hgvs("NC_TEST.1:g.2del").unwrap();
+    let b = parse_hgvs("NC_TEST.1:g.6del").unwrap();
+
+    assert_eq!(
+        checker.compare_denotations(&a, &b).unwrap().level,
+        EquivalenceLevel::NotEquivalent,
+        "a reconstructed, genuinely different pair is still `NotEquivalent`",
+    );
+}
+
+/// The transcript `MockProvider::with_test_data` serves completely — bases and
+/// all — so nothing on it can decline for want of reference data.
+const SERVED_TX: &str = "NM_000088.3";
+
+/// The premise every guard below rests on, asserted rather than assumed: the
+/// provider serves this accession's **bases**, not merely its metadata.
+///
+/// A short form is the instrument. `c.10del` does not state the base it
+/// deletes, so its SPDI cannot be built without reading the reference — exactly
+/// the dependency this module's reproducers exploit. If this converts, a
+/// decline anywhere below is not a reference-availability decline.
+#[test]
+fn the_probe_transcript_is_genuinely_served() {
+    let provider = MockProvider::with_test_data();
+    let short_form = parse_hgvs(&format!("{SERVED_TX}:c.10del")).unwrap();
+    assert!(
+        hgvs_to_spdi(&short_form, &provider).is_ok(),
+        "{SERVED_TX} must serve its bases for the intronic guards below to mean anything: a \
+         deletion short form has to read the reference to name what it deletes",
+    );
+}
+
+/// An intronic offset is a limit of **SPDI**, not of the reference, and the
+/// conversion error must say so.
+///
+/// `MissingReferenceData` was the wrong carrier: it is raised here *before* any
+/// provider call (`c.`) or on the position's spelling alone (`n.`, `r.`), so it
+/// asserts something false — that the reference was consulted and came up
+/// short. Consumers classify on that error, and this one classified it as
+/// "could not tell", which is what
+/// [`intronic_positions_on_a_served_reference_stay_not_equivalent`] measures the
+/// consequence of.
+#[test]
+fn an_intronic_offset_declines_as_a_representation_limit_not_a_reference_failure() {
+    let provider = MockProvider::with_test_data();
+
+    for descriptor in [
+        format!("{SERVED_TX}:c.10+5A>G"),
+        format!("{SERVED_TX}:n.10+5A>G"),
+        format!("{SERVED_TX}:r.10+5a>g"),
+    ] {
+        let variant = parse_hgvs(&descriptor).unwrap();
+        let err = hgvs_to_spdi(&variant, &provider)
+            .expect_err("SPDI has no offset notation, so an intronic position cannot convert");
+        assert!(
+            matches!(err, ConversionError::UnrepresentableInSpdi { .. }),
+            "{descriptor}: SPDI cannot address an intronic offset however completely the \
+             reference is served, so this is `UnrepresentableInSpdi` — a `MissingReferenceData` \
+             here is a false statement about the provider, got {err:?}",
+        );
+    }
+}
+
+/// The guard the classification change exists for: on a **fully served**
+/// reference, two genuinely different intronic variants stay a decided
+/// negative.
+///
+/// These are ordinary splice-region descriptions — different positions,
+/// different bases — and `c.####+/-N` is one of the largest classes in real
+/// HGVS, so the blast radius of getting this wrong is wide. Nothing here is
+/// unavailable: [`the_probe_transcript_is_genuinely_served`] pins that. The
+/// pair declines because SPDI cannot address an intronic offset, which is a
+/// representation limit and therefore a decided negative — the same treatment
+/// every other unrepresentable shape gets.
+///
+/// Both entry points are checked because both moved when the classification
+/// was wrong.
+#[test]
+fn intronic_positions_on_a_served_reference_stay_not_equivalent() {
+    let checker = EquivalenceChecker::new(MockProvider::with_test_data());
+
+    for (a, b) in [
+        // Two different splice-donor variants, one intron apart.
+        (
+            format!("{SERVED_TX}:c.10+5A>G"),
+            format!("{SERVED_TX}:c.20+5T>C"),
+        ),
+        // An intronic variant against an exonic one at the same anchor.
+        (
+            format!("{SERVED_TX}:c.10+5A>G"),
+            format!("{SERVED_TX}:c.10A>G"),
+        ),
+        // The same shape on the sibling axes the retype covers.
+        (
+            format!("{SERVED_TX}:n.10+5A>G"),
+            format!("{SERVED_TX}:n.20+5T>C"),
+        ),
+        (
+            format!("{SERVED_TX}:r.10+5a>g"),
+            format!("{SERVED_TX}:r.20+5u>c"),
+        ),
+    ] {
+        let va = parse_hgvs(&a).unwrap();
+        let vb = parse_hgvs(&b).unwrap();
+
+        for (label, result) in [
+            ("compare_denotations", checker.compare_denotations(&va, &vb)),
+            ("check", checker.check(&va, &vb)),
+        ] {
+            let result = result.unwrap();
+            assert_eq!(
+                result.level,
+                EquivalenceLevel::NotEquivalent,
+                "{label}: {a} vs {b} are different variants on a served reference; SPDI cannot \
+                 address an intronic offset, which is a representation limit and not a reference \
+                 failure, so the verdict stays decided. Got {:?} ({:?})",
+                result.level,
+                result.notes,
+            );
+            assert!(
+                !result.notes.iter().any(|n| n.contains("could not be read")),
+                "{label}: {a} vs {b}: the reference was never consulted for an intronic offset, \
+                 so no note may claim it could not be read. Got {:?}",
+                result.notes,
+            );
+        }
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -49,6 +49,7 @@ mod issue_1916_intron_distance_underflow;
 mod issue_1917_reversed_range_window;
 mod issue_1970_u16_cost_grid_bound;
 mod issue_1989_declined_is_indeterminate;
+mod issue_2056_edit_triples_reference_failure;
 mod recommended_form_pins;
 mod repeat_input_idempotency;
 mod repeat_lowering_sibling_junction;


### PR DESCRIPTION
Closes #2056.

REMOVE:

> Representation-Change: none. Touches only `src/equivalence/` (not a watched prefix) and tests; corrects an equivalence-checker verdict and feeds no normalization path, so no normalized output moves.

INSERT:

Representation-Change: none. This now also touches `src/spdi/convert.rs`, which **is** a watched prefix. Five intronic-position decline sites move from `ConversionError::MissingReferenceData` to a new `ConversionError::UnrepresentableInSpdi` — three on the provider-backed path (`resolve_cds_to_tx`, `resolve_tx_pos`, `resolve_rna_pos`) and two on the simple path (`require_simple_tx_pos`, `require_simple_rna_pos`) — and the rendered message changes from "missing reference data: …" to "cannot be expressed in SPDI: …". That is an error-surface change and nothing more: every description that converted before converts to the identical SPDI, every description that declined before still declines at the same site for the same reason, and no successful conversion's output changes. No normalized HGVS string moves, so a consumer keyed on normalized output has nothing to re-bucket.

## The defect

`EquivalenceChecker::edit_triples` discarded the error from `hgvs_to_spdi` with `.ok()?` (`src/equivalence/checker.rs`), so a member whose HGVS→SPDI conversion **needed reference bases the provider could not serve** became `None` — indistinguishable from an edit SPDI genuinely cannot represent. Both landed in `SequenceVerdict::Declined`, and the checker answered a decided `NotEquivalent` for a pair it never actually compared.

Measured on current `origin/main` (`a436b11d`), against a provider serving no bases for the accession:

| pair | unserved reference | served `NC_TEST.1` = `ACGTACGTACGT` |
|---|---|---|
| `g.2dup` vs `g.2_3insC` | **`NotEquivalent`** (both `check` and `compare_denotations`) | `CrossAxisSequenceMatch` (equivalent) |
| `g.2del` vs `g.2delC` | **`NotEquivalent`** (`compare_denotations`) | `CrossAxisSequenceMatch` (equivalent) |

Same variant either way; the only difference is whether `hgvs_to_spdi` could read the reference to build the short form's SPDI — exactly the confusion `Indeterminate` exists to prevent.

## Relationship to #1989 / #2053

This is the residual of #1989 that #2053 (already merged, `0dc68cde`) does **not** close. #2053 split a `ReferenceUnavailable` verdict out of the sequence rung's **window fetch** (`compare_triples`) and mapped it to `Indeterminate`. #2056 is the *other* reference route, one step earlier: the per-member HGVS→SPDI conversion inside `edit_triples`.

It is the larger half in practice. HGVS routinely omits the deleted/duplicated bases — `g.2del`, `g.2dup`, `c.10_12del` are the ordinary spellings — and every one of those must read the reference to build its SPDI, so every one takes the `edit_triples` route rather than the fetch route. (#2053's own reproducer had to state both bases, `g.2del` vs `g.2delC`, to land inside the band it fixes.)

The fix builds directly on #2053's machinery and does not depend on any unmerged work: it reuses the existing `SequenceVerdict::ReferenceUnavailable` → `Indeterminate` mapping.

## The fix

`edit_triples` now returns `Result<(String, Vec<SpdiVariant>), TripleDecline>`, where `TripleDecline` classifies the conversion error:

- `ConversionError::MissingReferenceData` / `ProviderRequired` → `ReferenceUnavailable` → `SequenceVerdict::ReferenceUnavailable` → `EquivalenceLevel::Indeterminate`.
- every other conversion failure (unrepresentable edit, cross-accession, multi-molecule/null/unknown allele, empty member list) → `Unrepresentable` → `SequenceVerdict::Declined` → `NotEquivalent` (unchanged).

The first member to decline decides. The other `edit_triples` callers (`second_axis`, `undecidable_reason`) are updated to the `Result` API; both treat either decline as "second axis not computed" / "not resolvable", which is behavior-preserving.


Two corrections from review, both in this PR.

**The classification had to be fixed at the source.** `ConversionError::MissingReferenceData` was not exclusively a reference-availability error: `src/spdi/convert.rs` also returned it for **intronic positions**, decided from the position's own spelling and — on the `c.` path — before the provider is consulted at all. Mapping it wholesale to `ReferenceUnavailable` turned correct answers into refusals on a **fully served** reference:

| pair (`MockProvider::with_test_data`, which serves `NM_000088.3` completely) | before | after |
|---|---|---|
| `c.10+5A>G` vs `c.20+5T>C` | `Indeterminate` | `NotEquivalent` |
| `c.10+5A>G` vs `c.10A>G` | `Indeterminate` | `NotEquivalent` |
| `n.10+5A>G` vs `n.20+5T>C` | `Indeterminate` | `NotEquivalent` |
| `r.10+5a>g` vs `r.20+5u>c` | `Indeterminate` | `NotEquivalent` |

Both entry points moved, and the attached note read "The reference needed to compare both variants could not be read from the provider" — false, since the reference was never consulted. `c.####+/-N` splice variants are one of the largest classes in real HGVS, and no existing test caught it.

Fixed at the source rather than by an exception list in the classifier, which is the shape that goes stale: a new `ConversionError::UnrepresentableInSpdi` now carries those decline sites, so `TripleDecline::from_conversion_error` is correct by construction. The invariant it establishes is that **`MissingReferenceData` means a better-provisioned provider would answer**. The two `MissingReferenceData` readers that key on it meaning "transcript unavailable" (`resolve_tx_exonic_bounded`, `resolve_rna_exonic_bounded`) are unaffected: both sit in the `else` branch of `tx_needs_provider` / `rna_needs_provider`, whose predicates return `true` for an intronic endpoint, so an intronic position could never reach either fallback.

**The wildcard arm is gone.** `ConversionError` is `#[non_exhaustive]`, but `checker.rs` is in the same crate, where that attribute has no effect — so `_ => Unrepresentable` protected nothing while guaranteeing that a future reference-availability variant would be silently misclassified, re-introducing this defect with no build error and no failing test. All arms are spelled out; adding a variant is now a compile error at the classification site.

## Unchanged on purpose (the discriminating cases)

- A genuinely-different pair on a **served** reference still reconstructs and reports `NotEquivalent` (`served_genuinely_different_short_forms_stay_not_equivalent`).
- A **served** equivalent pair still reaches a decided positive (`served_short_forms_still_reach_a_decided_positive`).
- The deliberate `NotEquivalent` declines #1989 documented are untouched: an RNA fusion, a **resolvable** cross-accession pair (`test_different_accessions_entirely_not_equivalent` still passes), and an un-appliable overlapping allele. Those never had the reference as the obstacle.
- An out-of-bounds substitution on a served contig (`g.20A>G` vs `g.21C>T`) is **not** in scope: its SPDI converts fine (a substitution states its own bases), so it takes the window-fetch route, not the `edit_triples` route, and stays `NotEquivalent`.

Two pre-existing inline unit tests (`NM_000088.3:c.10A>G` vs `NM_000088.4:c.20A>G`; `LRG_1t1` vs `LRG_1t2`) are `c.` pairs on transcripts the test provider does not serve. They fall through to the sequence rung, where the reference cannot be read, and previously relied on the swallowed error to report `NotEquivalent`. They now assert `Indeterminate` — the same direction #1989 established (`check_reports_indeterminate_when_the_reference_cannot_be_reconstructed`). Had both accessions been served they would resolve to distinct SPDI accessions and stay a decided negative.

## Verification

- `cargo fmt --all --check` — clean.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- `cargo nextest run --features dev --no-fail-fast` — **11256 passed, 0 failed, 154 skipped** (`EXIT=0`).
- New regression module `tests/it/issue_2056_edit_triples_reference_failure.rs` (all `MockProvider`/`SyntheticBuilder`-backed, so it runs on PR CI, not reference-gated): the two reproducers assert `Indeterminate`, plus served positive and served-genuinely-different controls.

## Representation stability

None. This corrects an equivalence-checker verdict; it does not touch any normalization path and moves no normalized output, so the `dump_normalized_corpus` disclosure does not apply.
