### PR TITLE
ci: run src/python.rs's Rust tests (split out extension-module feature)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2107,11 +2107,74 @@ jobs:
           # `rust-cache` block in this file.
           save-if: ${{ github.ref == 'refs/heads/main' }}
           key: python-wheel
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      # src/python.rs carries 10 pure-Rust `#[cfg(test)]` tests that only
+      # compile under the `python` feature — and, before #2046, ran NOWHERE:
+      # `dev` excludes `python` so the sharded test jobs never compiled them,
+      # `maturin build` runs no Rust test, and `cargo clippy --all-features`
+      # compiles without executing. A break in one passed every check (the
+      # #1505 / #1372 dead-coverage family, one feature over).
+      #
+      # They are pure (they never start the interpreter), so they only need the
+      # crate to LINK, which needs libpython. That is why `extension-module` is
+      # NOT part of Cargo.toml's `python` feature: with it set, PyO3 links no
+      # libpython on Linux (`is_linking_libpython_for_target` in
+      # pyo3-build-config), so this test executable would fail to link its
+      # undefined Python symbols. `cargo` never reads pyproject.toml, so this
+      # step gets `python` WITHOUT `extension-module` and links libpython; the
+      # wheel step below asks for both features BY NAME (see its comment — the
+      # `[tool.maturin] features` list does not reach a build that passes
+      # `--features` on the command line).
+      #
+      # SCOPED, and run under nextest rather than `cargo test`, because this
+      # job reports a REQUIRED status check and the lib suite is not safe to run
+      # in one process. `cargo test --features python --lib` ran all 4240 lib
+      # tests under libtest's thread pool, where
+      # `normalize::merge::tests::a_declined_sequence_first_partition_is_counted`
+      # asserts deltas on process-global `AtomicU64` counters (`SEQFIRST_*` in
+      # src/normalize/merge.rs) that any concurrent test reaching
+      # `partition_block_for_rule` corrupts, and
+      # `parallel::tests::test_stress_concurrent_throughput` is a timing test
+      # sensitive to oversubscription. Measured on this branch at
+      # `--test-threads=32`: 4 of 6 runs failed that way, i.e. a green PR's
+      # required check would flake for reasons unrelated to the PR. nextest is
+      # process-per-test, so the corruption is not expressible at any thread
+      # count, and the selection keeps the job to the tests it exists to run
+      # (10 tests in 0.02s, against 4240 in ~14s).
+      #
+      # `--no-tests=fail` is the non-vacuity guard, and is the other reason this
+      # is nextest: a selection matching nothing exits 4 here ("error: no tests
+      # to run"), where `cargo test -- python::tests` reports
+      # `ok. 0 passed; 4240 filtered out` and exits 0 — a typo in the filter
+      # would silently delete the coverage this job was added to provide. Same
+      # reasoning as the `soak` job's `--no-tests=fail`; see its comment.
+      #
+      # The test binary loads libpython at startup, so point the loader at the
+      # interpreter's shared-library dir.
+      - name: Run src/python.rs unit tests
+        run: |
+          LIBDIR="$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')"
+          echo "libpython dir: $LIBDIR"
+          LD_LIBRARY_PATH="$LIBDIR:${LD_LIBRARY_PATH:-}" \
+            cargo nextest run --features python --lib --no-tests=fail \
+              -E 'test(python::tests::)'
+      # `extension-module` is named explicitly, NOT inherited from
+      # `[tool.maturin] features`. Measured with maturin 1.13.3: a `--features`
+      # flag on the command line REPLACES that list rather than merging with it,
+      # so `maturin build --features python` hands cargo `--features python`
+      # alone and the pyproject entry is never consulted. Without the name here,
+      # the wheel's non-libpython linkage would rest solely on maturin setting
+      # `PYO3_BUILD_EXTENSION_MODULE=1` (which pyo3 honours independently of the
+      # Cargo feature) — true of every maturin in use today, but an unpinned
+      # `maturin>=1.0,<2.0` that predates it would silently build a
+      # libpython-linked wheel. Naming the feature restores exactly the cargo
+      # feature resolution this repo had before the split, and costs no version
+      # floor.
       - name: Build release wheel
         run: |
           python -m pip install --upgrade pip
           python -m pip install 'maturin>=1.0,<2.0'
-          maturin build --release --features python --out dist
+          maturin build --release --features python,extension-module --out dist
       - name: Install wheel into clean venv
         run: |
           python -m venv /tmp/wheel-venv

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -109,7 +109,13 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          args: --release --out dist --features python
+          # `extension-module` named explicitly: a `--features` flag here
+          # REPLACES `[tool.maturin] features` rather than merging with it, so
+          # without it cargo never sees the feature and the wheel's linkage
+          # would depend on the maturin version (which sets
+          # `PYO3_BUILD_EXTENSION_MODULE=1`) rather than on Cargo.toml.
+          # See pyproject.toml and #2046.
+          args: --release --out dist --features python,extension-module
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-linux-${{ matrix.target }}-${{ matrix.manylinux }}
@@ -151,7 +157,13 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macosx_deployment_target }}
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --features python
+          # `extension-module` named explicitly: a `--features` flag here
+          # REPLACES `[tool.maturin] features` rather than merging with it, so
+          # without it cargo never sees the feature and the wheel's linkage
+          # would depend on the maturin version (which sets
+          # `PYO3_BUILD_EXTENSION_MODULE=1`) rather than on Cargo.toml.
+          # See pyproject.toml and #2046.
+          args: --release --out dist --features python,extension-module
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-macos-${{ matrix.target }}
@@ -176,7 +188,13 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: x86_64-pc-windows-msvc
-          args: --release --out dist --features python
+          # `extension-module` named explicitly: a `--features` flag here
+          # REPLACES `[tool.maturin] features` rather than merging with it, so
+          # without it cargo never sees the feature and the wheel's linkage
+          # would depend on the maturin version (which sets
+          # `PYO3_BUILD_EXTENSION_MODULE=1`) rather than on Cargo.toml.
+          # See pyproject.toml and #2046.
+          args: --release --out dist --features python,extension-module
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-windows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,42 +20,71 @@ cargo build --features benchmark     # Build ferro-benchmark binary
 ```bash
 cargo check --features python        # Typecheck the bindings (fast; does NOT link)
 cargo clippy --features python       # Lint the bindings (also does NOT link)
-maturin develop --features python    # Build and install locally for development
-maturin build --features python      # Build wheel
+# Run src/python.rs's own Rust #[test]s (#2046). SCOPED, and nextest not
+# `cargo test` — see "Why the binding tests are scoped" below.
+cargo nextest run --features python --lib --no-tests=fail -E 'test(python::tests::)'
+maturin develop --features python,extension-module  # Build an importable module
+maturin build   --features python,extension-module  # Build wheel
 ```
 
-**Do not use `cargo build --features python`** — on macOS it cannot link. `pyo3` is declared with
-`features = ["abi3-py310", "extension-module"]`, and `extension-module` deliberately does *not*
-link against libpython: the CPython symbols are meant to resolve against the host interpreter
-when the module is imported. Maturin supplies the linker allowance that makes that legal
-(`-undefined dynamic_lookup`); a plain `cargo build` does not, so it compiles the whole crate and
-only then dies linking the cdylib:
+**`extension-module` is a SEPARATE Cargo feature, not part of `python` (#2046).** `pyo3` is
+declared with `features = ["abi3-py310"]`, and `pyo3/extension-module` is pulled in by the
+`extension-module` feature instead.
 
-```
-error: linking with `cc` failed: exit status: 1
-  = note: Undefined symbols for architecture arm64:
-            "_PyBaseObject_Type", referenced from: ...
-          ld: symbol(s) not found for architecture arm64
-error: could not compile `ferro-hgvs` (lib) due to 1 previous error
-```
+The split exists because `extension-module` deliberately does *not* link against libpython (the
+CPython symbols resolve against the host interpreter at import time). With it enabled, PyO3 emits
+no libpython link line on Linux/macOS (`is_linking_libpython_for_target` in `pyo3-build-config`),
+so a plain test/bin executable fails to link its undefined Python symbols — which is exactly why
+`src/python.rs`'s pure-Rust `#[cfg(test)]` tests ran nowhere in CI. Keeping `extension-module`
+out of `python` lets `cargo test/nextest --features python --lib` link libpython and actually run
+them; CI does this in the `Python Wheel Test` job (which has a shared-library Python available).
 
-Compilation had already succeeded at that point, so the failure says nothing about the code —
-it just costs a full build cycle to find out. Use `cargo check --features python` (and
-`cargo clippy --features python`) to verify the bindings compile, and `maturin develop
---features python` whenever you need a module you can actually import (e.g. to run
+**So every wheel/develop build must ask for `extension-module` BY NAME — `[tool.maturin]
+features` does not supply it for free.** That list in `pyproject.toml` is a **default**, not an
+addition: measured with maturin 1.13.3, a `--features` flag on the maturin command line
+**replaces** it rather than merging with it, so `maturin build --features python` hands cargo
+`--features python` alone and the pyproject entry is never consulted. The entry is therefore
+load-bearing only for builds that pass no `--features` of their own (the PEP 517 backend — `pip
+install .`, `python -m build`, `uv`), and every explicit invocation in this repo names the feature
+itself: `ci.yml`'s "Build release wheel", `release-wheels.yml`'s three `maturin-action` blocks,
+`pyproject.toml`'s two `build-*` tasks, and `CONTRIBUTING.md`.
+
+Do not "simplify" those call sites back to `--features python` on the grounds that the wheel
+still works without it. It does still work — maturin sets `PYO3_BUILD_EXTENSION_MODULE=1`, and
+pyo3 0.28's `is_extension_module()` honours that env var independently of the Cargo feature,
+whose doc comment there calls it *"(deprecated)"*. Measured: wheels built both ways are
+indistinguishable (no libpython link line, 99 undefined `_Py` symbols each). But that makes the
+linkage a property of **which maturin ran**, and `ci.yml` installs an unpinned
+`maturin>=1.0,<2.0` while `release-wheels.yml` takes `maturin-action`'s default — so a maturin
+predating that env var would build a libpython-linked wheel silently. Naming the feature restores
+exactly the cargo feature resolution this repo had before the split, and costs no version floor.
+
+#### Why the binding tests are scoped
+
+The `Python Wheel Test` job reports a **required** status check, and the lib suite is not safe to
+run in one process. `cargo test --features python --lib` runs all 4240 lib tests under libtest's
+thread pool, where `normalize::merge::tests::a_declined_sequence_first_partition_is_counted`
+asserts deltas on process-global `AtomicU64` counters (`SEQFIRST_*` in `src/normalize/merge.rs`)
+that any concurrent test reaching `partition_block_for_rule` corrupts, and
+`parallel::tests::test_stress_concurrent_throughput` is a timing test sensitive to
+oversubscription. Measured at `--test-threads=32`: **4 of 6 runs failed** — i.e. an unrelated PR's
+required check flaking. nextest is process-per-test, so the corruption is not expressible at any
+thread count (10/10 green at the same thread count), and the selection keeps the job to the tests
+it exists to run: 10 tests in 0.02s against 4240 in ~14s.
+
+`--no-tests=fail` is the non-vacuity guard, and the other reason this is nextest. A selection
+matching nothing exits **4** here (`error: no tests to run`); `cargo test -- python::tests`
+reports `ok. 0 passed; 4240 filtered out` and exits **0**, so a typo in the filter would silently
+delete the coverage without reddening anything.
+
+**Still use `maturin`, not `cargo build --features python`, for an importable module.** A plain
+`cargo build` produces a cdylib that is not a wheel-ready abi3 extension, and historically dies
+linking on macOS unless `-undefined dynamic_lookup` is passed — PyO3 ships those flags in
+`pyo3_build_config::add_extension_module_link_args()` (Darwin-only) but a crate must call them
+from its own `build.rs`, and this crate has none. Maturin passes them itself. Use
+`cargo check`/`cargo clippy --features python` to verify the bindings compile, and `maturin
+develop --features python` whenever you need a module you can import (e.g. to run
 `pytest tests/python/`).
-
-The hard failure above is macOS-specific: `ld` there refuses undefined symbols in a dylib unless
-`-undefined dynamic_lookup` is passed. Two things could pass it and neither does under a plain
-`cargo build`. PyO3 ships the flags in
-`pyo3_build_config::add_extension_module_link_args()` — Darwin-only, by design — but a crate has
-to call that from its own `build.rs`, and this crate has no `build.rs`. Maturin passes them
-itself, which is why the `maturin` commands above work. So `cargo build` gets them from nowhere
-and the link dies.
-
-Linkers that do permit undefined symbols in a shared object get no such error, but the advice is
-unchanged everywhere: `cargo build` still produces no importable extension module, so reach for
-`maturin` rather than treating a quiet link as success.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ failing. See [Testing](#testing) for the flag that turns that into a failure, an
 
 ```bash
 uv sync --group dev
-uv run maturin develop --features python
+uv run maturin develop --features python,extension-module
 uv run pytest
 ```
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ noodles-gtf = "0.52"
 smol_str = { version = "0.3", features = ["serde"] }
 flate2 = "1.0"
 ahash = { version = "0.8", optional = true }
-pyo3 = { version = "0.28", features = ["abi3-py310", "extension-module"], optional = true }
+pyo3 = { version = "0.28", features = ["abi3-py310"], optional = true }
 memmap2 = "0.9"
 memchr = "2.7"
 ureq = { version = "2.9", optional = true }
@@ -117,6 +117,29 @@ validation = ["dep:ahash"]
 # The Python batch API parallelizes across a rayon pool, so the `parallel`
 # (rayon) feature is pulled in whenever the bindings are built.
 python = ["dep:pyo3", "parallel"]
+# `pyo3/extension-module` makes the compiled cdylib importable as a CPython
+# extension: it SUPPRESSES linking against libpython, because the interpreter
+# supplies those symbols at import time. That is required for the wheel, and it
+# is NOT folded into `python` because doing so breaks the one thing #2046 fixes:
+# `cargo test --features python --lib` builds a plain executable, and with
+# `extension-module` set PyO3 links no libpython for non-Windows/-Android/-iOS
+# targets (`is_linking_libpython_for_target` in pyo3-build-config), so on Linux
+# CI that binary fails to link its undefined Python symbols and src/python.rs's
+# #[test]s can never run. Split out, `cargo test --features python` links
+# libpython and runs them — see ci.yml's "Run src/python.rs unit tests" step.
+#
+# EVERY WHEEL/DEVELOP BUILD MUST THEREFORE ASK FOR THIS FEATURE BY NAME, and the
+# ones in this repo do. It is tempting to believe `[tool.maturin] features` in
+# pyproject.toml supplies it for free; it does not. Measured with maturin
+# 1.13.3: a `--features` flag on the maturin command line REPLACES that list
+# rather than merging with it, so `maturin build --features python` hands cargo
+# `--features python` alone. Such a build still produces a working extension
+# module today, because maturin also sets `PYO3_BUILD_EXTENSION_MODULE=1` and
+# pyo3 0.28's `is_extension_module()` honours that env var independently of the
+# Cargo feature (whose doc comment there calls it "(deprecated)") — but that
+# makes the linkage a property of the maturin version rather than of this
+# manifest, so the feature is named at each call site instead.
+extension-module = ["dep:pyo3", "pyo3/extension-module"]
 # memmap2 is now an unconditional dependency (used by the cdot rkyv loader);
 # this feature is retained as a no-op for compatibility with callers that
 # still pass `--features mmap`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,20 @@ dev = [
 ]
 
 [tool.maturin]
-features = ["python"]
+# `extension-module` is intentionally NOT part of Cargo.toml's `python` feature
+# (it suppresses libpython linkage, which would stop `cargo test --features
+# python --lib` from linking on Linux CI — see #2046 and the Cargo.toml note).
+#
+# THIS LIST IS A DEFAULT, NOT AN ADDITION. Measured with maturin 1.13.3: a
+# `--features` flag on the maturin command line REPLACES this list rather than
+# merging with it, so `maturin build --features python` hands cargo
+# `--features python` alone and this entry is never consulted. It is therefore
+# load-bearing for exactly the builds that pass no `--features` of their own —
+# the PEP 517 backend above, i.e. `pip install .`, `python -m build`, `uv` — and
+# every invocation that does pass one must name `extension-module` itself. They
+# all do; see ci.yml's "Build release wheel" step, release-wheels.yml's three
+# `maturin-action` blocks, and the two tasks below.
+features = ["python", "extension-module"]
 python-source = "python"
 module-name = "ferro_hgvs"
 
@@ -71,8 +84,10 @@ ignore = [
 known-first-party = ["ferro_hgvs"]
 
 [tool.poe.tasks]
-build-dev          = {cmd = "bash -c 'unset CONDA_PREFIX' && maturin develop --features python", help = "build the native extension in development mode"}
-build-wheel        = {cmd = "bash -c 'unset CONDA_PREFIX' && maturin build --features python",   help = "build a distributable wheel of the native extension"}
+# `--features` on the maturin command line replaces `[tool.maturin] features`
+# rather than merging with it, so `extension-module` is named here explicitly.
+build-dev          = {cmd = "bash -c 'unset CONDA_PREFIX' && maturin develop --features python,extension-module", help = "build the native extension in development mode"}
+build-wheel        = {cmd = "bash -c 'unset CONDA_PREFIX' && maturin build --features python,extension-module",   help = "build a distributable wheel of the native extension"}
 
 check-format = {cmd = "ruff format --check --diff python/ tests/python/", help = "check Python code formatting"}
 check-lint   = {cmd = "ruff check python/ tests/python/",                 help = "lint Python sources"}


### PR DESCRIPTION
Closes #2046.

## The defect

`src/python.rs` carries 10 pure-Rust `#[cfg(test)]` tests that CI **compiles but never runs**, so a break in one passes every check — the #1505 / #1372 dead-coverage family, one feature over.

- `cargo nextest run --features dev` (every sharded test job) never compiles them: `dev` does not include `python`.
- `maturin build --features python` (the only `--features python` in CI) builds a wheel and runs no Rust test.
- `cargo clippy --all-features --all-targets` compiles the test target but does not execute it.

## Why the issue's suggested command does not work as-is

The tests are pure — they never start the interpreter — so they only need the crate to **link**, which needs libpython. But `pyo3`'s `extension-module` feature deliberately suppresses libpython linkage: `is_linking_libpython_for_target` in `pyo3-build-config` returns `false` on Linux/macOS when it is set. A plain test/bin executable then fails to link its undefined Python symbols. macOS links such a binary via its `dynamic_lookup` special case (so the naive command *passes locally on a Mac*), but **Linux CI does not**.

## The fix

Take `extension-module` out of Cargo.toml's `python` feature and make it a separate feature:

- `pyo3 = { version = "0.28", features = ["abi3-py310"], optional = true }`
- `extension-module = ["dep:pyo3", "pyo3/extension-module"]`

A new step in the `Python Wheel Test` job (which already has a shared-library Python) then links libpython and runs the tests, pointing the loader at the interpreter's lib dir.

### The step is scoped, and runs under nextest

`Python Wheel Test` reports a **required** status check, and the lib suite is not safe to run in one process. `cargo test --features python --lib` runs all 4240 lib tests under libtest's thread pool, where:

- `normalize::merge::tests::a_declined_sequence_first_partition_is_counted` asserts deltas on process-global `AtomicU64` counters (`SEQFIRST_ATTEMPTED` / `SEQFIRST_DECLINED`), which any concurrent test reaching `partition_block_for_rule` corrupts;
- `parallel::tests::test_stress_concurrent_throughput` is a timing test sensitive to CPU oversubscription.

Measured at `--test-threads=32` on this branch: **4 of 6 runs of the unscoped command failed**, always the counter test. Unfixed, every PR in the repo would inherit a flaky required check, at a rate that rises the moment GitHub's standard runner gains cores.

`cargo nextest run --features python --lib --no-tests=fail -E 'test(python::tests::)'` fixes both halves: nextest is process-per-test, so the corruption is not expressible at any thread count, and the selection keeps the job to the tests it exists to run.

`--no-tests=fail` is the non-vacuity guard, and the second reason this is nextest rather than a filtered `cargo test`. Measured: an empty selection exits **4** under nextest (`error: no tests to run`), while `cargo test -- python::tests` reports `ok. 0 passed; 4240 filtered out` and exits **0** — a typo in the filter would silently delete this coverage.

| | tests run | wall | empty selection |
|---|---|---|---|
| `cargo test --lib` | 4240 | ~14 s, 4/6 fail at `-j32` | exit 0, silent |
| scoped nextest | 10 | 0.02 s, 10/10 green at `-j32` | exit 4, loud |

### `[tool.maturin] features` is a DEFAULT, not an addition

The first revision of this PR claimed maturin "merges" that list into every build. **It does not.** Measured with maturin 1.13.3 via a `cargo` shim that records the real invocation:

| `[tool.maturin] features` | CLI `--features` | cargo receives |
|---|---|---|
| `["python","extension-module"]` | `python` | `python` |
| `["python","extension-module"]` | *(none)* | `python` + `extension-module` |
| `["python"]` | *(none)* | `python` |
| `["python"]` | `python,extension-module` | `python,extension-module` |

A CLI `--features` flag **replaces** the pyproject list. So the entry is load-bearing for builds that pass no `--features` of their own — the PEP 517 backend (`pip install .`, `python -m build`, `uv`) — and is overridden for every explicit invocation in this repo.

Such a wheel is still a working extension module today, because maturin also sets `PYO3_BUILD_EXTENSION_MODULE=1`, which pyo3 0.28's `is_extension_module()` honours independently of the Cargo feature (whose doc comment there calls it *"(deprecated)"*). But that makes the wheel's linkage a property of **which maturin ran** — `ci.yml` installs an unpinned `maturin>=1.0,<2.0`, `release-wheels.yml` takes `maturin-action`'s default — where before this PR the Cargo feature guaranteed it.

So every explicit invocation now names the feature: `ci.yml`'s wheel step, `release-wheels.yml`'s three `maturin-action` blocks, `pyproject.toml`'s two `build-*` tasks, and `CONTRIBUTING.md`. That restores exactly the cargo feature resolution `main` has today and needs no version floor or build-time assertion. Verified: wheels built with and without the explicit feature are indistinguishable — no libpython link line, 99 undefined `_Py` symbols each.

`docs`/`CLAUDE.md` are updated to state the replace-not-merge rule, since the earlier wording would have led someone to delete a load-bearing line or rely on a merge that does not happen.

## Verification

- **10/10 stress reps green** at `--test-threads=32`, exactly 10 `python::tests::*` executed each time (0.024 s), against 4/6 failures and ~14 s for the unscoped command.
- **Non-vacuity proven**: sabotaging one assertion turns the run red — `10 tests run: 9 passed, 1 failed`, exit 100. `src/python.rs` restored byte-identically.
- `cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `actionlint` — clean.
- `cargo nextest run --features dev --no-fail-fast` — **11245 passed, 0 failed**.
- `pytest tests/python/` against the built wheel — **1080 passed, 8 skipped**.

## Out of scope, filed separately

#2046's closing paragraph asked whether any other feature is in the same position. `hgvs-rs` is: three lib tests (`benchmark::hgvs_rs::tests::*`) exist only under it and no CI command runs them, plus a fourth instance at sub-test granularity in `src/service/tools/hgvs_rs.rs`. Filed as #2080 rather than folded in here — covering it means compiling `hgvs`, `postgres` and `seqrepo` in CI for three hermetic unit tests, which is its own trade. `slow-tests` is excluded deliberately and documented; `extension-module` and `dhat-heap` gate no code at all.

## Unchanged on purpose

`src/python.rs` itself is byte-identical (the sabotage was reverted).

Representation-Change: none