### PR TITLE
docs: name the real producer of the bare PositionRange variant

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -406,16 +406,39 @@ impl InsertedSequence {
     /// `(start, end, inverted)` 1-based inclusive coordinates, or `None` when
     /// this is not one.
     ///
-    /// An all-numeric same-reference range has **two** AST spellings that the
-    /// parser mints interchangeably and that [`Display`](fmt::Display) renders
-    /// identically: the bare [`PositionRange`](InsertedSequence::PositionRange) /
+    /// An all-numeric same-reference range has **two** AST spellings that
+    /// [`Display`](fmt::Display) renders identically but that reach the AST from
+    /// two different producers: the bare
+    /// [`PositionRange`](InsertedSequence::PositionRange) /
     /// [`PositionRangeInv`](InsertedSequence::PositionRangeInv) variant, and the
-    /// single-part `Complex([PositionRange | PositionRangeInv])` shape (the
-    /// parser wraps `parse_cds_position_range`'s result in `Complex` but falls
-    /// through to the bare variant for `parse_simple_count`). Both denote one
-    /// contiguous slice of the same accession, so this is the single place that
-    /// collapses them — consumers call it rather than re-deriving the match, and
-    /// so cannot disagree about which spelling they handle (#1986).
+    /// single-part `Complex([PositionRange | PositionRangeInv])` shape. Both
+    /// denote one contiguous slice of the same accession, so this is the single
+    /// place that collapses them — consumers call it rather than re-deriving the
+    /// match, and so cannot disagree about which spelling they handle (#1986).
+    ///
+    /// The **parser never mints the bare variant.** For any input reaching the
+    /// `<digits>_<digits>` dispatch arm, `parse_cds_position_range` is tried
+    /// first and accepts every plain numeric pair, returning an
+    /// [`InsertedPart`] that the arm wraps in `Complex` — so a parsed same-
+    /// reference numeric range is always the single-part `Complex` shape.
+    /// `parse_simple_count`'s own `PositionRange` / `PositionRangeInv` returns
+    /// are therefore unreachable for any parseable input, and no HGVS string
+    /// produces either bare variant. Both are minted by **normalization**, not
+    /// the parser:
+    ///
+    /// - bare [`PositionRange`](InsertedSequence::PositionRange) —
+    ///   [`canonicalize_conversion_to_delins`](crate::normalize::rules::canonicalize_conversion_to_delins)
+    ///   rewrites a same-reference `con` source (e.g.
+    ///   `NaEdit::Conversion { source: "100_200" }`) into
+    ///   `Delins { sequence: PositionRange { 100, 200 } }`;
+    /// - bare [`PositionRangeInv`](InsertedSequence::PositionRangeInv) — the
+    ///   `DNA/inversion.md:69` inverted-duplication `ins<range>inv` re-spell in
+    ///   `normalize_genome` (`crate::normalize`) mints it inside an
+    ///   `Insertion` (currently on the `g.` axis only).
+    ///
+    /// So this accessor exists to collapse those normalization-minted bare forms
+    /// with the parser's `Complex` form, not two interchangeable parser
+    /// spellings (#2035).
     ///
     /// Multi-part `Complex` payloads, [`CdsPositionRange`](InsertedPart::CdsPositionRange)
     /// (intronic-offset / UTR-marker ranges), external references,


### PR DESCRIPTION
Closes #2035.

Representation-Change: none. Doc-comment-only change under `src/hgvs/`; no watched behaviour is touched.

## The defect

`InsertedSequence::as_position_range`'s doc comment attributed the bare `PositionRange` / `PositionRangeInv` variant to the **parser** — it claimed the parser "wraps `parse_cds_position_range`'s result in `Complex` but falls through to the bare variant for `parse_simple_count`". Because this accessor is the single canonical explanation of why one payload has two spellings, a wrong attribution there propagates: someone touching `parse_simple_count` reads it and believes those returns are live.

## What is measured

The parser mints **neither** bare variant for any parseable input. The `<digits>_<digits>` dispatch arm (`src/hgvs/parser/edit.rs:368`) tries `parse_cds_position_range` first, and that parser accepts every plain numeric pair, returning an `InsertedPart` the arm wraps in `Complex` (`:370-381`). `parse_simple_count`'s own `PositionRange` / `PositionRangeInv` returns (`:992`, `:995`) are only reached when `parse_cds_position_range` fails — which for a `digits_digits` input never happens — so they are dead code and no HGVS string produces the bare variant.

The bare variants are minted by **normalization**:

- bare `PositionRange` — `normalize::rules::canonicalize_conversion_to_delins` rewrites a same-reference `con` source (`NaEdit::Conversion { source: "100_200" }`) into `Delins { sequence: PositionRange { 100, 200 } }` (`src/normalize/rules.rs:2879`).
- bare `PositionRangeInv` — the `DNA/inversion.md:69` inverted-duplication `ins<range>inv` re-spell in `normalize_genome` mints it inside an `Insertion` (`src/normalize/mod.rs:6323`), currently on the `g.` axis only.

I confirmed these are the only two live producers by enumerating every `InsertedSequence::PositionRange { … }` / `PositionRangeInv { … }` construction site in `src/`; the remainder are the dead `parse_simple_count` returns or `#[cfg(test)]` code.

## The fix

Correct the accessor doc to state the parser mints neither bare variant, and to name both normalization producers. Comment-only.

## Verification

- `cargo fmt --all --check` — clean.
- `cargo nextest run --features dev` — `11245 passed, 154 skipped` (EXIT=0). The 154 skips are the bulk/manifest-gated fixtures, unrelated to this change.
- `cargo doc --no-deps --features dev --lib` with `-D rustdoc::broken_intra_doc_links` — no new broken-link errors introduced at the edited lines (the crate carries pre-existing baseline warnings elsewhere).

Refs #1986, #2029.