### PR TITLE
fix: catch a bare `none` decline that moves on a continuation line

### DIFF
--- a/scripts/check_representation_change.py
+++ b/scripts/check_representation_change.py
@@ -200,23 +200,41 @@ DECLINE_TERMINATORS = ".;:—–"
 
 #: A declination: one of `NONE_VALUES`, alone or followed by a reason. Built from the two
 #: constants above so the vocabulary has one definition rather than a regex restating it.
-#: `DOTALL` so a reason spanning lines does not defeat the trailing `.*`.
+#:
+#: Matched against the trailer's FIRST LINE only (see `declines`), so it carries no `DOTALL`
+#: and no `MULTILINE`: the reason it captures is the remainder of that one line, and any
+#: continuation below is the contradiction tripwire's business, not the decline verdict's.
+#: This used to carry `DOTALL` and be matched against the whole value, which made the verdict
+#: depend on terminating punctuation — a bare `none` with a continuation had nothing to feed
+#: the trailing `.*`, so `$` never reached end-of-string and the value was not read as a
+#: decline at all (#2031). git-cliff reads the verdict off the trailer's own line, so this
+#: now agrees with it by construction rather than only when a terminator happens to be
+#: present -- pinned value-by-value by `test_the_two_decline_rules_agree_value_by_value`.
 DECLINE_RE = re.compile(
     r"^(?:"
     + "|".join(re.escape(value) for value in sorted(NONE_VALUES))
     + r")[ \t]*(?:["
     + re.escape(DECLINE_TERMINATORS)
     + r"].*)?$",
-    re.IGNORECASE | re.DOTALL,
+    re.IGNORECASE,
 )
 
 
 def declines(declaration: str) -> bool:
     """Return whether `declaration` is a decline rather than a description of a move.
 
-    The verdict is the first word; anything after a terminator is the reason for it.
+    The verdict is read from the FIRST LINE of the value, which is what git-cliff's footer
+    rule reads (it is `MULTILINE`, so its `$` anchors on the trailer's own line). Reading the
+    whole value instead depended on terminating punctuation to span a continuation, so a bare
+    `none` followed by a move on the next line was not read as a decline at all and the
+    contradiction tripwire — gated on this verdict — never fired (#2031). The tripwire still
+    scans the whole value; only the *verdict* is a first-line question, and separating the two
+    is what closes the gap #2027 left.
+
+    The verdict is the first word; anything after a terminator on that line is its reason.
     """
-    return DECLINE_RE.match(declaration.strip()) is not None
+    first_line = declaration.strip().partition("\n")[0]
+    return DECLINE_RE.match(first_line) is not None
 
 
 #: A quantified movement claim -- "3 rows move", "577 rows merge", "2 rows respell",
@@ -709,10 +727,15 @@ def check(changed: list[str], declaration_text: str) -> tuple[bool, str]:
             "Measure with: cargo run --release --features dev --example dump_normalized_corpus"
         )
 
-    # The tripwire must read the WHOLE trailer value, not just its first line: a decline on
-    # line 1 can hide a `<n> rows move` on an unindented continuation line (#1854), and
-    # `declaration` above is truncated at the newline by `TRAILER_RE`. `declarations` is
-    # non-empty here, so a full value exists.
+    # Two spans, deliberately different (#2031). The decline VERDICT is a first-line question
+    # -- `declines` reads it off the trailer's own line, which is what git-cliff reads -- but
+    # the contradiction TRIPWIRE must scan the WHOLE value, because a decline on line 1 can
+    # hide a `<n> rows move` on an unindented continuation line (#1854). Reading the verdict
+    # off the whole value instead (as #2027 did) made it depend on terminating punctuation, so
+    # a BARE `none` with a move continuation was read as neither a decline nor a contradiction.
+    # `declines(full_value)` still asks the first-line question -- `full_value`'s first line is
+    # this same trailer's -- while `contradicted_decline` searches the whole value below.
+    # `declarations` is non-empty here, so a full value exists.
     full_value = full_declaration_value(declaration_text)
     assert full_value is not None
     if declines(full_value):

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -646,6 +646,50 @@ def test_a_real_multiline_disclosure_still_passes() -> None:
 
 
 # ---------------------------------------------------------------------------
+# A BARE decline may not hide a move on a continuation line either (#2031)
+#
+# #2027 (#1854) taught `check` to read the whole trailer value, but that fix
+# depends on TERMINATING PUNCTUATION: `DECLINE_RE` is not MULTILINE, so its
+# trailing `.*` (DOTALL) needs a `.;:—–` to start consuming before it can span
+# the continuation and reach `$` at end-of-string. Without a terminator there is
+# nothing to consume the continuation, so `$` never matches, `declines(full)`
+# returns False, and the contradiction tripwire — gated on `declines` — never
+# fires. A bare `none` with a `<n> rows move` continuation slips through, read as
+# a real change rather than as the contradicted decline it is. git-cliff's
+# footer rule is MULTILINE and reads the same bare decline off the trailer line,
+# so it files it under Other and the disclosure vanishes.
+#
+# The fix reads the decline verdict from the FIRST LINE (which is what git-cliff
+# sees) while the contradiction tripwire still scans the whole value.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("trailer", ["none", "no", "n/a", "na"])
+def test_a_bare_decline_that_moves_on_a_continuation_line_fails(trailer: str) -> None:
+    """A decline with NO terminating punctuation, then a move on the next line."""
+    body = f"Representation-Change: {trailer}\n150 rows of 85,642 move, all 3'-direction.\n"
+    ok, message = check(["src/normalize/merge.rs"], body)
+    assert not ok, f"bare {trailer!r} + a continuation-line move must be refused"
+    assert "declines and then describes a move" in message
+    assert "150 rows of 85,642 move" in message, "the message must quote the hidden move"
+
+
+@pytest.mark.parametrize("trailer", ["none", "no", "n/a", "na"])
+def test_a_bare_decline_with_a_reason_continuation_still_passes(trailer: str) -> None:
+    """A bare decline whose continuation is an ordinary reason stays a clean decline.
+
+    The discriminator for #2031: reading the verdict off the first line must not turn an
+    honest multi-line bare decline into a false contradiction.
+    """
+    body = (
+        f"Representation-Change: {trailer}\n"
+        "Comments and one new test module only; no watched file changes behaviour.\n"
+    )
+    ok, _ = check(["src/normalize/merge.rs"], body)
+    assert ok, f"a bare {trailer!r} whose continuation is a reason must pass"
+
+
+# ---------------------------------------------------------------------------
 # #1647: the count is the count, never the denominator
 #
 # The guard used to read "the number immediately before `rows`" as the moving
@@ -798,6 +842,18 @@ def test_the_two_decline_rules_agree_value_by_value() -> None:
         # tail, so the continuation does not change the verdict for either side.
         "none.\n  Comments and one new test module only; no watched file changes behaviour.",
         "577 rows move, 360 merge.\n  Previously-accepted inputs, so a real migration.",
+        # BARE declines with a continuation (#2031). This is the axis the parity test could
+        # not see: both multi-line values above carry a terminator, whose `[\s\S]*` tail
+        # spans the continuation for both rules. Without one, git-cliff still reads the
+        # decline off the trailer's own line (it is MULTILINE), so the verdict is a decline
+        # for it — and the checker must agree by reading the same first line. Before #2031
+        # the checker read the WHOLE value through a non-MULTILINE `DECLINE_RE`, so a bare
+        # `none` with any continuation was not a decline for it, disagreeing with git-cliff
+        # (the #1555 class) and — worse — leaving the contradiction tripwire ungated.
+        "none\n150 rows of 85,642 move, all 3'-direction.",
+        "no\nTests only; nothing under a watched directory moves.",
+        "n/a\nDocs only.",
+        "na\nGenerated artifact only.",
     ]
     for value in values:
         by_changelog = changelog_rule.search(f"Representation-Change: {value}") is not None


### PR DESCRIPTION
Closes #2031.

## The gap

#2027 (#1854) made the contradicted-decline tripwire read the whole trailer value instead of just line 1, so `none.` followed by a `<n> rows move` continuation is refused. But that fix depends on **terminating punctuation**, and a bare `none` (no terminator) slips straight through.

Measured on the branch base:

| trailer + continuation-line `150 rows … move` | `check(["src/normalize/merge.rs"], …)` |
|---|---|
| `none.` | **refuses** — "declines and then describes a move" |
| `none` | **passes** — worse, read as a real change, not even a decline |
| `no` / `n/a` / `na` | **pass** |

So the disclosure never reaches the changelog — the exact direction this mechanism exists to prevent.

## Mechanism

`DECLINE_RE` is `IGNORECASE | DOTALL` and **not** `MULTILINE`, so `$` matches only at end-of-string. With a terminator its optional `(?:[.;:—–].*)?` group's `.*` (DOTALL) swallows the continuation and reaches `$`. Without a terminator there is nothing to consume the continuation, so `$` never matches and `declines(full_value)` returns `False` — which gates the movement tripwire, so it never fires.

`release-plz.toml`'s footer rule **is** `MULTILINE`, so git-cliff reads the same bare `none`+continuation as a **decline**. The checker read it as a real change. That is the #1555 class — the checker and the changelog disagree — and `test_the_two_decline_rules_agree_value_by_value` could not see it because both of its multi-line values carried a terminator.

## The fix

Separate the two questions, which have different correct spans:

- **Decline verdict → the first line.** `declines()` now reads the trailer's first line, which is exactly what git-cliff's `MULTILINE` rule reads. `DECLINE_RE` drops the now-unneeded `DOTALL`. Parity with git-cliff is restored **by construction** rather than only when a terminator is present.
- **Contradiction tripwire → the whole value.** Unchanged: `contradicted_decline` still scans `full_declaration_value` with `MOVEMENT_CLAIM_RE`.

## Unchanged on purpose (discriminators)

- honest bare `none`, `none.`, and `none, except two rows that merge` behave exactly as `CONTRIBUTING.md` / `release-plz.toml` specify (the last is filed as a real change — comma is not a terminator);
- a bare `none` whose continuation is an ordinary **reason** (no move) still passes as a clean decline;
- `none. 0 of 950 rows move.` (the documented quantified zero) still passes;
- a real bare move (`577 rows move, …`) still passes.

## Checker ⇄ audit still agree

`test_changelog_grouping.py` (including `test_the_audit_and_the_checker_agree_on_every_documented_form`) and `test_inject_representation_disclosure.py` pass unchanged — the checker stays in agreement with `check_changelog_grouping.py` on every documented form.

## Verification

- `ruff check scripts/ tests/python/` — EXIT 0
- `ruff format --check scripts/ tests/python/` — EXIT 0
- `mypy` (strict, project flags) on `scripts/check_representation_change.py` — EXIT 0
- `pytest tests/python/test_representation_change_trailer.py` — 177 passed
- `pytest tests/python/test_changelog_grouping.py tests/python/test_inject_representation_disclosure.py` — 51 passed

Representation-Change: none. Python tooling only; no watched file changes behaviour.