### PR TITLE
docs(normalize): the band pin's fixtures do not exercise band clipping

### DIFF
--- a/src/normalize/seqfirst/align.rs
+++ b/src/normalize/seqfirst/align.rs
@@ -1368,10 +1368,18 @@ mod tests {
             (&b"CAG"[..], &b"AGA"[..]),
             (&b"AAAC"[..], &b"ACCCAA"[..]),
             (&b"AACA"[..], &b"CCCAAC"[..]),
-            // Plus the shapes a band is most likely to get wrong, since the
-            // copy carries its own `band.contains` / `row_span` arithmetic:
-            // both blocks empty, either block empty, and a length ratio far
-            // from one so `|delta|` and not the divergence sets the band.
+            // Plus the degenerate grid shapes: both blocks empty, either block
+            // empty, and a length ratio far from one. These reach the copy's
+            // loop bounds and the `widest` computation below — NOT its band
+            // arithmetic, which at this band cannot clip at all: `band_for(n, m,
+            // n + m)` is `lo = -m, hi = n`, i.e. every diagonal of the grid, so
+            // `band.contains` is unconditionally true inside `0..=n`/`0..=m` and
+            // `row_span` returns the whole row. Measured: dropping the copy's
+            // `band.contains(i + 1, j)` guard leaves this pin GREEN and reddens
+            // only `the_brute_force_oracle_is_blind_to_a_uniformly_too_small_dag`,
+            // whose `build_confined_to_band` calls pass a narrow `k`. So a
+            // band-clipping drift is not what this pin catches; a drift in the
+            // shared post-loop body is.
             (&b""[..], &b""[..]),
             (&b""[..], &b"ACGT"[..]),
             (&b"ACGT"[..], &b""[..]),


### PR DESCRIPTION
Follow-up to #2071, which merged as `e334cc07`.

## The claim that is wrong

`the_hand_copied_band_confined_build_still_matches_build`'s doc says its fixtures cover "the shapes a band is most likely to get wrong, since the copy carries its own `band.contains` / `row_span` arithmetic."

The pin runs at `widest = n + m`, where `band_for(n, m, n + m)` gives `lo = ceil_half(-2m) = -m` and `hi = floor_half(2n) = n` — **every diagonal of the grid**. So `band.contains(i, j)` is unconditionally true inside `0..=n`/`0..=m`, and `row_span(i)` returns the whole row. The band arithmetic cannot clip at the only band this pin uses.

Verified two ways rather than one. Analytically, from `band_for`'s own definition above. And by mutation — replacing the copy's `if i < n && band.contains(i + 1, j)` with `if i < n`:

```
PASS  the_hand_copied_band_confined_build_still_matches_build
FAIL  the_brute_force_oracle_is_blind_to_a_uniformly_too_small_dag   (debug_assert at align.rs:395)
```

The pin stays green; only the narrow-`k` caller reddens.

## Why it is worth a PR

#2071's own thesis is that this pin buys **attribution** rather than coverage of a hole measured open — and it says so, honestly, two paragraphs above. The fixture comment then claims the opposite about the one thing it names. That is a fourth instance of the very pattern #2071 documents, in the sentence sitting beside it.

In a repo where the prose is the artefact people follow, a doc that overstates a guard's reach is the direction that costs most later: the next reader trims something on its authority, or trusts a drift is covered when it is not.

## What changes

Comment only. The corrected text names what the fixtures actually reach (the copy's loop bounds and the `widest` computation), states the band arithmetic cannot clip at this band, and records the mutation result so the next reader does not re-derive it.

The pin's *stated guarantee* two paragraphs above — band wide enough, so the copy reproduces `build` exactly, leaving only a shared-post-loop drift to separate them — is accurate and untouched. Only the fixture sentence overstated.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings`, and `cargo nextest run --features dev --no-fail-fast` (**11273 passed, 152 skipped**) all clean, each status read back from its log's own `EXIT=` line.

Representation-Change: none. Comment only; no test, fixture or behaviour change.