### PR TITLE
ci: run benchmark::hgvs_rs's Rust tests (the #2046 gap, one feature over)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2054,6 +2054,69 @@ jobs:
             --extract-to . --extract-overwrite --no-tests=fail \
             -E "test(spec_conformance_axis)"
 
+  # src/benchmark/hgvs_rs.rs carries 3 pure-Rust `#[cfg(test)]` tests
+  # (`benchmark::hgvs_rs::tests::*`) that only compile under the `hgvs-rs`
+  # feature — and, before #2080, ran NOWHERE. `dev` does not include `hgvs-rs`,
+  # so the sharded `test` jobs never compiled them, and the only two `hgvs-rs`
+  # invocations anywhere in CI are build-only: `clippy-all-features`'s
+  # `--all-features --all-targets` compiles the `#[cfg(test)]` module but does
+  # not execute it (its own comment names `hgvs-rs` as a feature it exists to
+  # keep compiling), and `deploy-local.yml` builds the `ferro-web` binary. A
+  # break in any of the three passed every check — the #1505 / #1372 / #2046
+  # dead-coverage family, one feature over.
+  #
+  # The tests are hermetic — URL parsing and a default-config constructor, with
+  # no UTA database or SeqRepo checkout — so this job only has to compile and run
+  # them. No spec submodule is needed: the scoped selection touches nothing that
+  # reads `assets/hgvs-nomenclature` at runtime, and no `include_str!`/
+  # `include_bytes!` under `src/` names it, so `submodules` is left at its
+  # checkout default (off).
+  #
+  # SCOPED with `-E 'test(benchmark::hgvs_rs::)'`, and run under nextest rather
+  # than `cargo test`, for the same reason #2046's `python::tests` step is:
+  # `--features hgvs-rs` pulls in `benchmark`, so a bare `--lib` run would
+  # execute the whole lib suite (4000+ tests) in one process, which is not safe
+  # — e.g. `normalize::merge::tests::a_declined_sequence_first_partition_is_counted`
+  # asserts deltas on process-global `AtomicU64` counters that any concurrent
+  # test reaching `partition_block_for_rule` corrupts. nextest is
+  # process-per-test, and the selection keeps the job to the three tests it
+  # exists to run.
+  #
+  # `--no-tests=fail` is the non-vacuity guard, and the other reason this is
+  # nextest (same reasoning as #2046's `python::tests` step and the `soak` job).
+  # If the module is renamed or the tests are deleted, an empty selection exits 4
+  # here (`error: no tests to run`) rather than reporting `0 passed` and exiting
+  # 0 — so the coverage this job exists to provide cannot silently stop running.
+  #
+  # This job's name is NOT one of the repository-required contexts (the ruleset
+  # names a fixed set — see the `test-required` comment below), so it is wired
+  # into the `Test` rollup's `needs` to gate the merge. The compile cost it buys
+  # is real and deliberate: `hgvs-rs` pulls `hgvs`, `postgres`, `seqrepo`,
+  # `biocommons-bioutils` and `indexmap`, a dependency tree no other test job
+  # builds — which is why #2080 was split out of #2072 rather than folded in.
+  hgvs-rs-tests:
+    name: hgvs-rs Rust tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          # Save only from `main` — see the note on the first
+          # `rust-cache` block in this file.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          key: hgvs-rs-tests
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      - name: Run src/benchmark/hgvs_rs.rs unit tests
+        run: |
+          cargo nextest run --features hgvs-rs --lib --no-tests=fail \
+            -E 'test(benchmark::hgvs_rs::)'
+
   # The generated-doc `--check` gates. Split out of the old monolithic Test job
   # so they no longer sit behind the whole suite on the critical path.
   # Aggregator that reports the `Test` status context.
@@ -2072,7 +2135,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [test, test-oracle, soak, sweeps, censuses]
+    needs: [test, test-oracle, soak, sweeps, censuses, hgvs-rs-tests]
     # `always()` so a failed or cancelled dependency still reports a conclusion
     # rather than leaving the required context pending forever.
     if: always()
@@ -2084,11 +2147,13 @@ jobs:
           echo "soak            = ${{ needs.soak.result }}"
           echo "sweeps          = ${{ needs.sweeps.result }}"
           echo "censuses        = ${{ needs.censuses.result }}"
+          echo "hgvs-rs-tests   = ${{ needs.hgvs-rs-tests.result }}"
           if [ "${{ needs.test.result }}" != "success" ] \
             || [ "${{ needs.test-oracle.result }}" != "success" ] \
             || [ "${{ needs.soak.result }}" != "success" ] \
             || [ "${{ needs.sweeps.result }}" != "success" ] \
-            || [ "${{ needs.censuses.result }}" != "success" ]; then
+            || [ "${{ needs.censuses.result }}" != "success" ] \
+            || [ "${{ needs.hgvs-rs-tests.result }}" != "success" ]; then
             echo "::error::one or more test jobs did not succeed"
             exit 1
           fi


### PR DESCRIPTION
Closes #2080

## The defect

`src/benchmark/hgvs_rs.rs` carries 3 pure-Rust `#[cfg(test)]` tests (`benchmark::hgvs_rs::tests::{test_parse_uta_url, test_parse_uta_url_remote, test_default_config}`) that CI **compiles but never runs** — the #1505 / #1372 / #2046 dead-coverage family, one feature over. A break in any of the three passes every check.

Measured on `origin/main` at `9b6dcf87`:

```
$ cargo nextest list --features hgvs-rs --lib -E 'test(benchmark::hgvs_rs::)'
ferro-hgvs benchmark::hgvs_rs::tests::test_default_config
ferro-hgvs benchmark::hgvs_rs::tests::test_parse_uta_url
ferro-hgvs benchmark::hgvs_rs::tests::test_parse_uta_url_remote
$ cargo nextest list --features dev     --lib -E 'test(benchmark::hgvs_rs::)'
   (empty — dev does not include hgvs-rs)
```

The three tests exist only under `--features hgvs-rs`, because `src/benchmark/mod.rs` gates the module behind it. No CI command runs them:

- the sharded `test` jobs run `--features dev`, and `dev` excludes `hgvs-rs`, so they never compile the module;
- `clippy-all-features` runs `cargo clippy --all-features --all-targets` — compiles the `#[cfg(test)]` module but does not execute it (its own comment names `hgvs-rs` as a feature it exists to keep compiling);
- `deploy-local.yml` runs `cargo build --release --features "web-service hgvs-rs" --bin ferro-web` — a binary build, no tests.

## The fix

Unlike #2046, there is no linkage problem here — `hgvs-rs` needs no feature split, just a job that runs the tests. This PR adds a dedicated `hgvs-rs Rust tests` job that runs the scoped selection and wires it into the `Test` rollup's `needs` so it gates the merge (the ruleset's required-context set is fixed and does not name this job, so gating goes through the rollup rather than a settings change).

```
cargo nextest run --features hgvs-rs --lib --no-tests=fail -E 'test(benchmark::hgvs_rs::)'
```

### Scoped, and under nextest — same reasoning as #2072's `python::tests` step

`--features hgvs-rs` pulls in `benchmark`, so a bare `--lib` run would execute the whole lib suite (4000+ tests) in one process, which is not safe: e.g. `normalize::merge::tests::a_declined_sequence_first_partition_is_counted` asserts deltas on process-global `AtomicU64` counters that any concurrent test reaching `partition_block_for_rule` corrupts. nextest is process-per-test, and the selection keeps the job to the three tests it exists to run.

### The guard against silent regression

`--no-tests=fail` is the non-vacuity guard (mirroring #2072). If the module is renamed or the tests deleted, an empty selection exits **4** here (`error: no tests to run`) rather than reporting `0 passed` and exiting 0 — so this coverage cannot silently stop running again. Proven below.

### The cost, stated

`hgvs-rs` pulls `hgvs`, `postgres`, `seqrepo`, `biocommons-bioutils` and `indexmap`, a dependency tree no other test job builds. That is a real trade — three hermetic unit tests against a dep tree CI does not otherwise compile — which is exactly why #2080 was split out of #2072 rather than folded in. The tests are hermetic (URL parsing plus a default-config constructor; no UTA database or SeqRepo checkout), and the job needs no spec submodule (nothing in the scoped selection reads `assets/hgvs-nomenclature`, and no `include_str!`/`include_bytes!` under `src/` names it).

## Verification

- **Before:** 0 of the 3 `benchmark::hgvs_rs::tests::*` run in any CI job. **After:** all 3 run in the new job.
- Exact CI command green: `3 tests run: 3 passed, 4337 skipped` in 0.022s.
- Non-vacuity guard proven: a bogus selection exits **4** (`error: no tests to run`).
- `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `actionlint .github/workflows/ci.yml` — clean.
- `cargo nextest run --features dev --no-fail-fast` — **11278 passed, 152 skipped, 0 failed**.

## Out of scope

The fourth instance the issue notes — `src/service/tools/hgvs_rs.rs`'s `test_hgvs_rs_service_creation_without_feature`, whose `#[cfg(feature = "hgvs-rs")]` arm asserts nothing and needs `web-service,hgvs-rs` to compile — is left for a separate change: covering it means giving that arm a meaningful assertion (its outcome is DB-availability-dependent), not merely running it, so it is a different piece of work from wiring the three list-visible tests into CI.

Representation-Change: none