### PR TITLE
fix(equivalence): apply_triples fetch failure is Indeterminate, not decided NotEquivalent

### DIFF
--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -13,6 +13,7 @@ use crate::normalize::{NormalizeConfig, Normalizer};
 use crate::reference::transcript::Strand;
 use crate::reference::ReferenceProvider;
 use crate::sequence::reverse_complement;
+use crate::spdi::apply::{apply_triples_classified, ApplyDecline};
 use crate::spdi::{hgvs_to_spdi, ConversionError, SpdiVariant};
 
 /// Largest reference window (in bases) a sequence-level equivalence rung will
@@ -526,7 +527,8 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
         // (unsupported edit, missing reference, mixed accessions, or a
         // multi-molecule allele) simply declines, so the rung only ever
         // upgrades a `NotEquivalent` verdict.
-        match self.same_resulting_sequence(v1, v2) {
+        let verdict = self.same_resulting_sequence(v1, v2);
+        match verdict {
             SequenceVerdict::Same => {
                 let (level, note) = self.strengthen_across_axes(v1, v2);
                 return Ok(EquivalenceResult::new(level)
@@ -545,17 +547,20 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                     )));
             }
             // The reference needed to compare the pair could not be read, from
-            // either of two points: the window fetch, after both sides converted
-            // to SPDI on a shared accession (#1989/#2053), or a member's own
+            // one of three points: the window fetch, after both sides converted
+            // to SPDI on a shared accession (#1989/#2053); a member's own
             // HGVS→SPDI conversion, which the ordinary short forms must run
-            // against the provider (#2056). Either way — as with `WindowTooWide`
-            // — nothing was reconstructed and nothing was compared. This is the
-            // "want of reference data" decline, and it must report
-            // `Indeterminate` for the same reason its sibling does: falling
-            // through to the `NotEquivalent` tail would assert a decided negative
-            // about a pair that was never examined. Pinned by
-            // `issue_1989_declined_is_indeterminate` and
-            // `issue_2056_edit_triples_reference_failure`.
+            // against the provider (#2056); or the apply itself, when the fetch
+            // succeeded but a stated reference base contradicts the served
+            // reference so the edit could not be reconstructed (#2075). Either
+            // way — as with `WindowTooWide` — nothing was reconstructed and
+            // nothing was compared. This is the "want of reference data"
+            // decline, and it must report `Indeterminate` for the same reason
+            // its sibling does: falling through to the `NotEquivalent` tail
+            // would assert a decided negative about a pair that was never
+            // examined. Pinned by `issue_1989_declined_is_indeterminate`,
+            // `issue_2056_edit_triples_reference_failure` and
+            // `issue_2075_apply_triples_reference_mismatch`.
             SequenceVerdict::ReferenceUnavailable => {
                 return Ok(EquivalenceResult::new(EquivalenceLevel::Indeterminate)
                     .with_normalized(str1, str2)
@@ -570,20 +575,52 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
             // checker routes to `NotEquivalent` *deliberately* are an edit SPDI
             // cannot carry (`issue_1578_followup_equivalence_rungs` for a
             // fusion), a cross-accession pair (the mixed-accession arm of
-            // `same_resulting_sequence`) and an un-appliable overlapping allele
-            // (`issue_1244_equivalence_overlap_panic`), each pinned there.
+            // `same_resulting_sequence`) and an allele whose members overlap, so
+            // that it denotes no single sequence of its own accord (pinned by
+            // `issue_2075_apply_triples_reference_mismatch`'s #2104 case — *not*
+            // by `issue_1244_equivalence_overlap_panic`, whose tests normalize
+            // first and so never reach this route; see that module's docs).
             //
-            // The reference-level declines both reach `ReferenceUnavailable`
-            // above and are handled there: the window fetch (#1989/#2053) and,
-            // as of #2056, a member's own HGVS→SPDI conversion failing for want
-            // of reference data (`edit_triples` now classifies that as
-            // `TripleDecline::ReferenceUnavailable` rather than swallowing it).
-            // So `NC_ABSENT.1:g.2del` vs `g.2delC` — `NotEquivalent` before, and
-            // `CrossAxisSequenceMatch` against a served contig — reaches the
-            // `Indeterminate` arm above and never falls through here. These two
-            // fall through.
+            // The reference-level declines all reach `ReferenceUnavailable`
+            // above and are handled there: the window fetch (#1989/#2053); as of
+            // #2056, a member's own HGVS→SPDI conversion failing for want of
+            // reference data (`edit_triples` now classifies that as
+            // `TripleDecline::ReferenceUnavailable` rather than swallowing it);
+            // and as of #2075, a stated reference base contradicting the served
+            // reference after a successful fetch (`compare_triples` now maps
+            // `apply_triples`'s `ApplyDecline::ReferenceMismatch` there rather
+            // than to `Declined`). So `NC_ABSENT.1:g.2del` vs `g.2delC` —
+            // `NotEquivalent` before, and `CrossAxisSequenceMatch` against a
+            // served contig — reaches the `Indeterminate` arm above and never
+            // falls through here. These two fall through.
+            // The applier was handed a triple outside the window built from that
+            // very triple. Nothing was reconstructed, and the fault is ours, not
+            // either description's — so this is undecided and gets its own note
+            // rather than borrowing the arm above, whose wording ("could not be
+            // read from the provider") would be false here (#2104).
+            SequenceVerdict::ApplyContractViolated => {
+                return Ok(EquivalenceResult::new(EquivalenceLevel::Indeterminate)
+                    .with_normalized(str1, str2)
+                    .with_note(
+                        "The resulting sequences could not be reconstructed because the reference \
+                         window did not cover the edits it was built from, so nothing was compared"
+                            .to_string(),
+                    ));
+            }
             SequenceVerdict::Different | SequenceVerdict::Declined => {}
         }
+
+        // Everything reaching here fell through the match above, i.e. it is a
+        // verdict the ladder is entitled to read as a negative. Stated on
+        // `SequenceVerdict` and asserted here rather than left implicit in which
+        // arms happen to `return`, so a verdict that reports no comparison
+        // cannot acquire a decided negative by being added without an arm
+        // (#2104).
+        debug_assert!(
+            verdict.may_be_read_as_a_negative(),
+            "{verdict:?} reports that nothing was compared, so it must not fall through to \
+             NotEquivalent",
+        );
 
         // #1578 follow-up: `NotEquivalent` is a *positive claim* that two
         // descriptions denote different variants, and it is only sound if
@@ -697,6 +734,7 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                     // `a_second_axis_that_cannot_be_computed_stops_at_the_single_axis_rung`.
                     SequenceVerdict::WindowTooWide
                     | SequenceVerdict::ReferenceUnavailable
+                    | SequenceVerdict::ApplyContractViolated
                     | SequenceVerdict::Declined => (
                         EquivalenceLevel::SequenceMatch,
                         format!(
@@ -928,7 +966,7 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
     ///
     /// Best-effort and side-effect free. [`SequenceVerdict::Declined`] covers
     /// every variant that cannot be projected to SPDI triples on a single
-    /// shared accession. Three declines are split out of it because they must
+    /// shared accession. Five declines are split out of it because they must
     /// not be read as a negative and instead resolve to
     /// [`EquivalenceLevel::Indeterminate`] at the caller:
     ///
@@ -940,7 +978,16 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
     /// * [`SequenceVerdict::ReferenceUnavailable`] from a **member's
     ///   HGVS→SPDI conversion** — a short form (`g.2del`, `g.2dup`) whose SPDI
     ///   had to read the reference and could not, surfaced via
-    ///   [`TripleDecline::ReferenceUnavailable`] rather than swallowed (#2056).
+    ///   [`TripleDecline::ReferenceUnavailable`] rather than swallowed (#2056);
+    /// * [`SequenceVerdict::ReferenceUnavailable`] from the **apply** — the
+    ///   fetch succeeds and both sides convert, but a stated reference base
+    ///   contradicts the served reference, surfaced via
+    ///   [`ApplyDecline::ReferenceMismatch`](crate::spdi::apply::ApplyDecline::ReferenceMismatch)
+    ///   rather than collapsed into the catch-all (#2075);
+    /// * [`SequenceVerdict::ApplyContractViolated`] from the **apply** again —
+    ///   the applier was handed a triple the window built from that very triple
+    ///   does not cover, which is an internal inconsistency and so must not be
+    ///   argued into a verdict about the two descriptions (#2104).
     ///
     /// So `NC_ABSENT.1:g.2del` vs `g.2delC` — one edit, two spellings — now
     /// answers `Indeterminate` on a provider serving no bases, matching its
@@ -1520,22 +1567,29 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
 
 /// What a sequence-level comparison concluded.
 ///
-/// Three of the four variants mean "nothing was compared", and they are kept
-/// apart because they are not read the same way. `WindowTooWide` and
-/// `ReferenceUnavailable` both report `Indeterminate`, because arguing either
-/// into a decided negative claims a comparison that never ran (#1989).
+/// Four of the six variants mean "nothing was compared", and they are kept
+/// apart because they are not read the same way. `WindowTooWide`,
+/// `ReferenceUnavailable` and `ApplyContractViolated` all report
+/// `Indeterminate`, because arguing any of them into a decided negative claims a
+/// comparison that never ran (#1989).
 /// `WindowTooWide` is a window that exceeds the cap. `ReferenceUnavailable` is
-/// "want of reference data", and it now has **two** sources, both routed here by
+/// "want of reference data", and it now has **three** sources, all routed here by
 /// [`Self::same_resulting_sequence`]: the window fetch failing after both sides
-/// convert ([`compare_triples`], #1989/#2053), and — as of #2056 — a member's
-/// own HGVS→SPDI conversion failing for want of reference, surfaced by
+/// convert ([`compare_triples`], #1989/#2053); as of #2056, a member's own
+/// HGVS→SPDI conversion failing for want of reference, surfaced by
 /// [`edit_triples`](EquivalenceChecker::edit_triples) as
-/// [`TripleDecline::ReferenceUnavailable`] instead of being swallowed. `Declined`
-/// is the catch-all; the checker deliberately routes it to `NotEquivalent`, and
-/// the shapes it carries — an edit SPDI cannot carry, a cross-accession pair, an
-/// un-appliable overlapping allele — are pinned elsewhere. `Different` is the one
-/// decided negative that was actually measured: both sides reconstructed, and
-/// they disagree.
+/// [`TripleDecline::ReferenceUnavailable`] instead of being swallowed; and as of
+/// #2075, a stated reference base contradicting the served reference after a
+/// successful fetch, surfaced by `apply_triples` as
+/// [`ApplyDecline::ReferenceMismatch`](crate::spdi::apply::ApplyDecline::ReferenceMismatch).
+/// `Declined` is the catch-all; the checker deliberately routes it to
+/// `NotEquivalent`, and the shapes it carries — an edit SPDI cannot carry, a
+/// cross-accession pair, an allele whose members overlap — are pinned
+/// elsewhere. `Different` is the one decided negative that was actually measured:
+/// both sides reconstructed, and they disagree. `ApplyContractViolated` is the
+/// fourth undecided one and the newest: as of #2104, a broken precondition of the
+/// applier reports its own verdict instead of sharing `Declined`'s, because an
+/// internal inconsistency is not a statement about two descriptions.
 ///
 /// The short forms are why the `edit_triples` source matters most in practice:
 /// `g.2del`, `g.2dup`, `c.10_12del` omit their deleted / duplicated bases, so
@@ -1546,7 +1600,10 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
 /// `issue_2056_edit_triples_reference_failure`. Note an **out-of-bounds
 /// substitution on a served contig** does *not* take this route — its SPDI
 /// converts (a substitution states its own bases), so it is the window fetch's
-/// concern, not `edit_triples`'.
+/// concern, not `edit_triples`'. A substitution **in bounds** whose stated base
+/// contradicts the served one is a third route again: the fetch succeeds and the
+/// apply declines, which is #2075's `ApplyDecline::ReferenceMismatch`, pinned by
+/// `issue_2075_apply_triples_reference_mismatch`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SequenceVerdict {
     /// Both sides were reconstructed and the resulting sequences are equal.
@@ -1556,14 +1613,18 @@ enum SequenceVerdict {
     /// Nothing was reconstructed: the union window exceeds
     /// [`MAX_SEQUENCE_COMPARE_WINDOW`].
     WindowTooWide,
-    /// Nothing was reconstructed for want of reference data. Raised from two
+    /// Nothing was reconstructed for want of reference data. Raised from three
     /// sources: the union window is bounded and both sides convert to SPDI on a
     /// shared accession, but the provider could not serve the window's bases
-    /// (#1989/#2053); or a member's own HGVS→SPDI conversion needed the reference
+    /// (#1989/#2053); a member's own HGVS→SPDI conversion needed the reference
     /// and could not read it, mapped from [`TripleDecline::ReferenceUnavailable`]
-    /// (#2056). The "want of reference data" decline — the sibling of
-    /// [`Self::WindowTooWide`], and like it a decline that must **not** be read
-    /// as a negative.
+    /// (#2056); or — as of #2075 — the fetch **succeeded** but a stated reference
+    /// base contradicts the base the reference carries, so `apply_triples`
+    /// declined with [`ApplyDecline::ReferenceMismatch`]. The "want of reference
+    /// data" decline — the sibling of [`Self::WindowTooWide`], and like it a
+    /// decline that must **not** be read as a negative.
+    ///
+    /// [`ApplyDecline::ReferenceMismatch`]: crate::spdi::apply::ApplyDecline::ReferenceMismatch
     ReferenceUnavailable,
     /// Nothing was reconstructed, for any other reason. The shapes it carries
     /// are representation-level — an edit SPDI cannot carry, a cross-accession
@@ -1572,13 +1633,86 @@ enum SequenceVerdict {
     /// *before* the fetch, inside `edit_triples`, no longer lands here: it is
     /// [`Self::ReferenceUnavailable`] as of #2056 (see [`TripleDecline`]).
     ///
-    /// One reference-level obstacle still does land here, knowingly: a fetch
-    /// that **succeeds** followed by an `apply_triples` that returns `None` —
-    /// typically a description whose stated reference base contradicts the base
-    /// the reference carries. That is [`compare_triples`]'s catch-all arm, it is
-    /// the last route by which a reference-level obstacle is read as a decided
-    /// negative, and it is tracked as **#2075** rather than fixed here.
+    /// Neither does a reference base contradicting the served reference *after* a
+    /// successful fetch: as of #2075 `apply_triples` distinguishes that
+    /// ([`ApplyDecline::ReferenceMismatch`]) from a set of triples that cannot be
+    /// spliced whatever the reference holds, and as of #2104 only the
+    /// **description-level** half of the latter — an allele whose members
+    /// overlap, [`ApplyDecline::MembersOverlap`] — reaches here. A broken
+    /// precondition of the applier is [`Self::ApplyContractViolated`].
+    ///
+    /// [`ApplyDecline::ReferenceMismatch`]: crate::spdi::apply::ApplyDecline::ReferenceMismatch
+    /// [`ApplyDecline::MembersOverlap`]: crate::spdi::apply::ApplyDecline::MembersOverlap
     Declined,
+    /// Nothing was reconstructed because a precondition of the **applier** was
+    /// broken: it was handed a triple the window it was also handed does not
+    /// cover ([`ApplyDecline::ContractViolated`], #2104).
+    ///
+    /// Reports [`EquivalenceLevel::Indeterminate`], and its own note rather than
+    /// [`Self::ReferenceUnavailable`]'s, because the reference was read
+    /// perfectly well — the inconsistency is ours. Routing it to
+    /// [`Self::Declined`] would turn an internal bug into a decided
+    /// `NotEquivalent`, which is the class #2053/#2069/#2075 spent three PRs
+    /// removing; it was the residual arm inside the last of them.
+    ///
+    /// **Unreachable from [`compare_triples`] by construction** — the window is
+    /// the union of both triple sets' footprints — so that function asserts
+    /// against it in debug rather than only reporting it. The verdict exists so
+    /// that if it ever *is* raised, it is undecided rather than negative.
+    ///
+    /// [`ApplyDecline::ContractViolated`]: crate::spdi::apply::ApplyDecline::ContractViolated
+    ApplyContractViolated,
+}
+
+impl SequenceVerdict {
+    /// Whether the ladder may fall through to its `NotEquivalent` tail on this
+    /// verdict.
+    ///
+    /// Stated once, wildcard-free, rather than left implicit in which arms of
+    /// [`EquivalenceChecker::denotational_verdict`] happen to `return` — and
+    /// asserted at that fall-through, so a verdict added without an arm is a
+    /// compile error there and a loud assertion here rather than a silent
+    /// decided negative (#2104).
+    ///
+    /// [`Self::Same`] is `false`: it reports a positive and must not fall
+    /// through either. [`Self::Declined`] is `true` because the checker
+    /// deliberately reads it as a negative — the description itself is what said
+    /// it denotes no single sequence.
+    const fn may_be_read_as_a_negative(self) -> bool {
+        match self {
+            Self::Different | Self::Declined => true,
+            Self::Same
+            | Self::WindowTooWide
+            | Self::ReferenceUnavailable
+            | Self::ApplyContractViolated => false,
+        }
+    }
+}
+
+impl ApplyDecline {
+    /// The [`SequenceVerdict`] this decline reports at the sequence rung.
+    ///
+    /// Lives here rather than beside the enum because `SequenceVerdict` is this
+    /// module's private type and `spdi` must not depend on `equivalence`. The
+    /// counterpart for the rung one step earlier is
+    /// [`TripleDecline::into_sequence_verdict`].
+    ///
+    /// **Wildcard-free, and tested over the enum** as well as end-to-end.
+    /// Measured: with this mapping carried by ordered match arms, over-mapping
+    /// one decline onto another's verdict left the whole suite green (#2104), and
+    /// [`ApplyDecline::ContractViolated`] is unreachable from either caller by
+    /// construction — so for it the enum is the only place the mapping can be
+    /// asserted at all. Pinned by
+    /// `every_apply_decline_maps_to_its_own_verdict`; the two reachable declines
+    /// are additionally pinned through the ladder by
+    /// `issue_2075_apply_triples_reference_mismatch`.
+    fn into_sequence_verdict(self) -> SequenceVerdict {
+        match self {
+            Self::ReferenceMismatch => SequenceVerdict::ReferenceUnavailable,
+            Self::MembersOverlap => SequenceVerdict::Declined,
+            Self::ContractViolated => SequenceVerdict::ApplyContractViolated,
+        }
+    }
 }
 
 /// Why [`EquivalenceChecker::edit_triples`] could not project a variant to its
@@ -1876,24 +2010,40 @@ where
         return SequenceVerdict::ReferenceUnavailable;
     };
 
-    match (
-        crate::spdi::apply::apply_triples(&reference, win_start, triples1),
-        crate::spdi::apply::apply_triples(&reference, win_start, triples2),
+    // The fetch succeeded, so a side that still will not apply says so for one
+    // of three reasons, and they are *not* read the same way — see
+    // [`ApplyDecline`]. Which verdict each reports, and which of two governs
+    // when both sides decline, are pure total functions over that enum rather
+    // than an ordering of arms here. That is #2104: with the precedence carried
+    // by arm order, swapping the arms reversed the rule #2075 states in words
+    // and left the whole suite green, because no input in it reaches the second
+    // arm at all.
+    let verdict = match (
+        apply_triples_classified(&reference, win_start, triples1),
+        apply_triples_classified(&reference, win_start, triples2),
     ) {
         // Case-insensitive, like the deletion check in `apply_triples`:
         // reference FASTAs are often soft-masked (repeats lower-cased), so
         // case carries no biological meaning here and must not split two
         // otherwise-identical resulting sequences.
-        (Some(a), Some(b)) if a.eq_ignore_ascii_case(&b) => SequenceVerdict::Same,
-        (Some(_), Some(_)) => SequenceVerdict::Different,
-        // The fetch succeeded and a side still would not apply — most often
-        // because its stated reference base contradicts the base the reference
-        // carries. That is a reference-level obstacle read as a decided
-        // negative, i.e. the same class #2053 and #2056 each closed at their own
-        // rung, surviving at this one. Tracked as #2075; deliberately unchanged
-        // here so this PR moves one rung only.
-        _ => SequenceVerdict::Declined,
-    }
+        (Ok(a), Ok(b)) if a.eq_ignore_ascii_case(&b) => SequenceVerdict::Same,
+        (Ok(_), Ok(_)) => SequenceVerdict::Different,
+        (Err(first), Err(second)) => first.governing(second).into_sequence_verdict(),
+        (Err(only), Ok(_)) | (Ok(_), Err(only)) => only.into_sequence_verdict(),
+    };
+
+    // The window above is the union of both triple sets' own footprints, so
+    // neither set can contain a triple the applier was not given bases for. A
+    // contract violation here is therefore a bug in this function and not a fact
+    // about either description: loud in debug, and `Indeterminate` rather than a
+    // decided negative in release (#2104).
+    debug_assert_ne!(
+        verdict,
+        SequenceVerdict::ApplyContractViolated,
+        "compare_triples built the window from these very triples, so the applier \
+         cannot have been handed one outside it",
+    );
+    verdict
 }
 
 /// Why `variant` has no computable denotation, or `None` when it has one.
@@ -2115,7 +2265,13 @@ mod tests {
     #[test]
     fn test_different_variants() {
         let checker = checker();
-        let v1 = parse_hgvs("NM_000088.3:c.10A>G").unwrap();
+        // The stated reference bases must match what the provider serves for
+        // `NM_000088.3` (…AAGG**T**G…, so c.10 is `G` and c.20 is `A`). A
+        // substitution whose stated base contradicts the served one no longer
+        // reconstructs — the sequence rung reports `Indeterminate`, not a decided
+        // negative (#2075) — so two *faithful* different substitutions are used
+        // to keep this a `NotEquivalent` test.
+        let v1 = parse_hgvs("NM_000088.3:c.10G>A").unwrap();
         let v2 = parse_hgvs("NM_000088.3:c.20A>G").unwrap();
 
         let result = checker.check(&v1, &v2).unwrap();
@@ -2152,8 +2308,12 @@ mod tests {
         // the normalizer treats an unknown accession. The members differ in
         // coordinates, so the alleles are not identical.
         let checker = checker();
-        let v1 = parse_hgvs("NM_000088.3:c.[10A>G;20C>T]").unwrap();
-        let v2 = parse_hgvs("NM_000088.3:c.[11A>G;21C>T]").unwrap();
+        // Faithful reference bases for `NM_000088.3` (c.10=G, c.11=T, c.20=A,
+        // c.21=G) so both alleles reconstruct and the sequence rung genuinely
+        // compares them; a stated-base contradiction would report `Indeterminate`
+        // rather than the `NotEquivalent` this asserts (#2075).
+        let v1 = parse_hgvs("NM_000088.3:c.[10G>A;20A>T]").unwrap();
+        let v2 = parse_hgvs("NM_000088.3:c.[11T>A;21G>T]").unwrap();
         assert!(matches!(v1, HgvsVariant::Allele(_)));
         assert!(matches!(v2, HgvsVariant::Allele(_)));
 
@@ -2255,8 +2415,10 @@ mod tests {
     #[test]
     fn test_substitution_at_different_positions() {
         let checker = checker();
-        let v1 = parse_hgvs("NM_000088.3:c.10A>G").unwrap();
-        let v2 = parse_hgvs("NM_000088.3:c.11A>G").unwrap();
+        // Faithful bases for `NM_000088.3` (c.10=G, c.11=T); a contradicting base
+        // would now report `Indeterminate` instead of a decided negative (#2075).
+        let v1 = parse_hgvs("NM_000088.3:c.10G>A").unwrap();
+        let v2 = parse_hgvs("NM_000088.3:c.11T>A").unwrap();
 
         let result = checker.check(&v1, &v2).unwrap();
         assert_eq!(result.level, EquivalenceLevel::NotEquivalent);
@@ -2921,5 +3083,85 @@ mod tests {
             checker.compare_denotations(&v1, &v2).unwrap().level,
             EquivalenceLevel::AccessionVersionDifference
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // #2104: `ApplyDecline` -> `SequenceVerdict` is pinned over the enum, and
+    // not only through the pipeline.
+    //
+    // Measured on this branch: a `panic!()` in the old ordered `Unappliable`
+    // arm, and in all five of `apply_triples_classified`'s contract guards,
+    // left `11405 tests run: 11405 passed` — so both mutations that matter
+    // (over-mapping a decline, reversing the precedence) were green. The
+    // reachable half is now driven end-to-end from
+    // `issue_2075_apply_triples_reference_mismatch`; `ContractViolated` cannot
+    // be reached from either caller by construction, so the enum is the only
+    // place its mapping can be asserted at all. See `ApplyDecline`'s own docs
+    // for the per-variant reachability measurement.
+    // -----------------------------------------------------------------------
+
+    /// Each decline's verdict, asserted by constructing the decline directly.
+    #[test]
+    fn every_apply_decline_maps_to_its_own_verdict() {
+        assert_eq!(
+            ApplyDecline::ReferenceMismatch.into_sequence_verdict(),
+            SequenceVerdict::ReferenceUnavailable,
+        );
+        assert_eq!(
+            ApplyDecline::MembersOverlap.into_sequence_verdict(),
+            SequenceVerdict::Declined,
+        );
+        assert_eq!(
+            ApplyDecline::ContractViolated.into_sequence_verdict(),
+            SequenceVerdict::ApplyContractViolated,
+        );
+
+        // And no two may share a verdict. Over-mapping one decline onto
+        // another's is the mutation #2104 measured green, so it has to be
+        // observable somewhere, and this is where.
+        for (index, first) in ApplyDecline::ALL.iter().enumerate() {
+            for second in &ApplyDecline::ALL[index + 1..] {
+                assert_ne!(
+                    first.into_sequence_verdict(),
+                    second.into_sequence_verdict(),
+                    "{first:?} and {second:?} must not report the same verdict",
+                );
+            }
+        }
+    }
+
+    /// Only a **description-level** decline may reach a decided negative.
+    ///
+    /// This is the property the split exists for: an allele whose members
+    /// overlap says of itself that it denotes no single sequence, so
+    /// `NotEquivalent` is honest. A reference obstacle and a broken precondition
+    /// of the applier say nothing about the descriptions at all.
+    #[test]
+    fn only_a_description_level_decline_reaches_a_decided_negative() {
+        for decline in ApplyDecline::ALL {
+            let negative = decline.into_sequence_verdict().may_be_read_as_a_negative();
+            assert_eq!(
+                negative,
+                decline == ApplyDecline::MembersOverlap,
+                "{decline:?} reaching a decided negative: {negative}",
+            );
+        }
+    }
+
+    /// Which verdicts the ladder may fall through to `NotEquivalent` on, over
+    /// every variant. `denotational_verdict` asserts against this at the
+    /// fall-through, so the table and the arms cannot drift apart silently.
+    #[test]
+    fn only_a_measured_or_stated_verdict_may_be_read_as_a_negative() {
+        for (verdict, expected) in [
+            (SequenceVerdict::Same, false),
+            (SequenceVerdict::Different, true),
+            (SequenceVerdict::Declined, true),
+            (SequenceVerdict::WindowTooWide, false),
+            (SequenceVerdict::ReferenceUnavailable, false),
+            (SequenceVerdict::ApplyContractViolated, false),
+        ] {
+            assert_eq!(verdict.may_be_read_as_a_negative(), expected, "{verdict:?}",);
+        }
     }
 }

--- a/src/spdi/apply.rs
+++ b/src/spdi/apply.rs
@@ -450,14 +450,159 @@ fn trim_common_flanks<'a>(reference: &'a [u8], resulting: &'a [u8]) -> (usize, &
 /// if they disagree (a ref-mismatched input — e.g. `c.5A>G` where the reference
 /// base is not `A`), we cannot faithfully reconstruct the edit, so we decline
 /// (`None`) rather than assert a sequence equivalence we cannot trust. Also
-/// returns `None` if any triple falls outside the window (a defensive guard;
-/// callers build the window to cover every triple), or if two triples overlap
-/// (see [`triples_are_disjoint`]).
+/// returns `None` if two triples overlap (see [`triples_are_disjoint`]), or if
+/// the window the caller handed over does not cover the triples it handed over
+/// with it — which is a broken precondition of this function rather than a fact
+/// about any description. [`ApplyDecline`] keeps the three apart for the caller
+/// that needs to tell them apart; this wrapper flattens all three.
 pub(crate) fn apply_triples(
     reference: &str,
     win_start: u64,
     triples: &[SpdiVariant],
 ) -> Option<String> {
+    apply_triples_classified(reference, win_start, triples).ok()
+}
+
+/// Why [`apply_triples`] could not reconstruct the edited sequence.
+///
+/// The split exists so a consumer can tell a **reference-level** obstacle from a
+/// **description-level** one, and both of those from a **broken precondition of
+/// the applier** — three things that must never be one, which is the whole point
+/// of #1989/#2053/#2069, made here at the apply step. [`apply_triples`] itself
+/// flattens all three to `None` for the callers that do not care.
+///
+/// # The classification is a total function, tested over the enum (#2104)
+///
+/// Which sequence verdict a decline reports is `into_sequence_verdict` in
+/// `src/equivalence/checker.rs` — there rather than here, because the verdict is
+/// the checker's own private type and `spdi` must not depend on `equivalence` —
+/// and which of two declines governs when both sides declined is
+/// [`Self::governing`]. Both are wildcard-free matches over this enum, so a
+/// fourth variant is a compile error at every place that has to decide what it
+/// means rather than a silent catch-all.
+///
+/// Both are also tested by **constructing each variant directly**, not only by
+/// driving the pipeline, because for two of the three the pipeline cannot pin
+/// them at all. Measured on this branch, over the whole suite: a `panic!()` in
+/// the checker's decline arm *and* in all five of this function's contract
+/// guards survived `11405 tests run: 11405 passed`, and with the classification
+/// carried by ordered match arms both mutations that matter were invisible —
+/// over-mapping a decline onto another's verdict, and reversing the precedence,
+/// each left `11405 passed` (#2104).
+///
+/// Where each variant can and cannot be reached, measured rather than assumed:
+///
+/// * [`Self::ReferenceMismatch`] is reached end-to-end and pinned by
+///   `issue_2075_apply_triples_reference_mismatch`.
+/// * [`Self::MembersOverlap`] is reachable, but **only through
+///   `EquivalenceChecker::compare_denotations`**, which compares the pair as
+///   written. `EquivalenceChecker::check` normalizes first, and normalization
+///   *repairs* the overlap: measured, `NC_TEST.1:g.[267_270AT[4];270_276del]`
+///   normalizes to the single-member `NC_TEST.1:g.270_272del`, and one member
+///   cannot overlap anything. That is why #1244's five tests — all of which use
+///   `check` — never reach this arm, and why the claim that they pinned it was
+///   withdrawn. It is now pinned end-to-end by the `compare_denotations` test in
+///   the same file.
+/// * [`Self::ContractViolated`] is unreachable from either caller by
+///   construction, so the enum is the *only* place its mapping can be asserted.
+///   `compare_triples` additionally asserts against it in debug.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApplyDecline {
+    /// A triple's stated deleted bases contradict the bases the reference
+    /// actually carries at that span — a ref-mismatched input (e.g. `g.5A>G`
+    /// where the served base is not `A`). The fetch succeeded, so this is not a
+    /// missing-window failure; it is still "want of usable reference data",
+    /// because the edit could not be faithfully reconstructed and nothing was
+    /// compared. Must **not** be read as a decided negative (#2075).
+    ReferenceMismatch,
+    /// Two triples claim the same reference base, so the set cannot be spliced
+    /// in one 3'->5' walk whatever the reference holds
+    /// ([`triples_are_disjoint`], #1244).
+    ///
+    /// **The only decline here that is a fact about the description**, and so
+    /// the only one a caller may read as a decided negative: an allele whose
+    /// members overlap denotes no single resulting sequence, so there is nothing
+    /// to compare and the description itself is what says so.
+    MembersOverlap,
+    /// A precondition of [`apply_triples_classified`] was broken by its caller:
+    /// a triple lies outside `[win_start, win_start + reference.len())`, its
+    /// coordinate arithmetic overflows, or the splice produced bytes that are
+    /// not UTF-8.
+    ///
+    /// **Never a fact about the description, and so never a decided negative.**
+    /// Both callers build the window as the union of the very triples they then
+    /// hand over — `compare_triples` over both sides' triples,
+    /// [`apply_to_reference_padded`] over one variant's — so a triple outside it
+    /// means the *caller* mis-computed, and answering a decided negative would
+    /// turn an internal inconsistency into a verdict about two descriptions.
+    /// That is the class #2053/#2069/#2075 spent three PRs removing, which is
+    /// why it is split out of #2075's own residual arm rather than left sitting
+    /// inside it (#2104). It governs every other decline for the same reason:
+    /// an internal inconsistency must not be masked by a decline about the
+    /// descriptions.
+    ContractViolated,
+}
+
+impl ApplyDecline {
+    /// Every variant, exactly once — the corpus the classification tests walk.
+    ///
+    /// Kept honest by [`Self::precedence`], whose match is wildcard-free: a new
+    /// variant is a compile error there, and
+    /// `all_declines_are_listed_exactly_once` then fails until this array
+    /// carries it too. Without both halves an "exhaustive over the enum" test
+    /// would quietly stop being exhaustive — which is #2104's own failure, one
+    /// level up.
+    ///
+    /// Test-only: it is a corpus, not part of the classification. The
+    /// classification's own totality is carried by the wildcard-free matches,
+    /// which are compiled in every configuration.
+    #[cfg(test)]
+    pub(crate) const ALL: [Self; 3] = [
+        Self::ReferenceMismatch,
+        Self::MembersOverlap,
+        Self::ContractViolated,
+    ];
+
+    /// Which of two declines governs when **both** sides of a comparison
+    /// declined.
+    ///
+    /// A `min` over [`Self::precedence`], so it is symmetric, idempotent and
+    /// associative, and the precedence rule is a property of a pure function
+    /// over the enum rather than of the order in which a caller's match arms
+    /// happen to be written. Before #2104 it *was* that ordering, and reversing
+    /// it was a mutation the entire suite could not see.
+    pub(crate) fn governing(self, other: Self) -> Self {
+        if other.precedence() < self.precedence() {
+            other
+        } else {
+            self
+        }
+    }
+
+    /// Rank in the governing order — **lower governs**, and the ranks are
+    /// distinct, which is what makes [`Self::governing`] deterministic and
+    /// `ALL` checkable.
+    ///
+    /// [`Self::ContractViolated`] is first so a broken precondition of this
+    /// function is never masked by a decline about the descriptions.
+    /// [`Self::ReferenceMismatch`] outranks [`Self::MembersOverlap`] because a
+    /// difference cannot be asserted against a sequence that could not be built
+    /// — the rule #2075 states in words and #2104 found unpinned.
+    const fn precedence(self) -> u8 {
+        match self {
+            Self::ContractViolated => 0,
+            Self::ReferenceMismatch => 1,
+            Self::MembersOverlap => 2,
+        }
+    }
+}
+
+/// [`apply_triples`], but classifying *why* it declined — see [`ApplyDecline`].
+pub(crate) fn apply_triples_classified(
+    reference: &str,
+    win_start: u64,
+    triples: &[SpdiVariant],
+) -> Result<String, ApplyDecline> {
     let ref_bytes = reference.as_bytes();
     let mut bytes = ref_bytes.to_vec();
     let mut ordered: Vec<&SpdiVariant> = triples.iter().collect();
@@ -480,32 +625,52 @@ pub(crate) fn apply_triples(
         )
     });
     if !triples_are_disjoint(&ordered) {
-        return None;
+        return Err(ApplyDecline::MembersOverlap);
     }
     for t in ordered {
-        let rel = t.position.checked_sub(win_start)? as usize;
-        let end = rel.checked_add(t.deletion.len())?;
+        // The three guards below are the caller's contract, not the
+        // description's: the window is built from these very triples, so a
+        // position 5' of it, a span that overflows, or a span running past its
+        // 3' edge all mean the caller mis-computed. Classified as such so no
+        // consumer can read an internal inconsistency as a decided verdict
+        // (#2104).
+        let rel = t
+            .position
+            .checked_sub(win_start)
+            .ok_or(ApplyDecline::ContractViolated)? as usize;
+        let end = rel
+            .checked_add(t.deletion.len())
+            .ok_or(ApplyDecline::ContractViolated)?;
         if end > ref_bytes.len() {
-            return None;
+            return Err(ApplyDecline::ContractViolated);
         }
         // Validate the stated deletion against the original reference span.
         // (Checked against `ref_bytes`, not the mutated `bytes`: descending
         // order means every already-applied splice sits strictly 3' of `rel`,
         // so this span is untouched either way.)
+        //
+        // A disagreement is a reference-level obstacle, not a representation
+        // one: the served reference is not the reference the description
+        // asserts, so the edit cannot be faithfully reconstructed (#2075).
         if !ref_bytes[rel..end].eq_ignore_ascii_case(t.deletion.as_bytes()) {
-            return None;
+            return Err(ApplyDecline::ReferenceMismatch);
         }
         // The splice targets the mutated buffer, whose length no longer matches
         // the reference once a length-changing edit has been applied. The
         // disjointness guard above already makes `end <= bytes.len()` hold;
         // bound it explicitly anyway so a future change cannot turn a logic
-        // slip back into an out-of-bounds panic (#1244).
+        // slip back into an out-of-bounds panic (#1244). A logic slip is this
+        // function's own fault, hence `ContractViolated` and not a decline about
+        // the description.
         if end > bytes.len() {
-            return None;
+            return Err(ApplyDecline::ContractViolated);
         }
         bytes.splice(rel..end, t.insertion.bytes());
     }
-    String::from_utf8(bytes).ok()
+    // `reference` arrived as a `&str` and every insertion came from a `String`,
+    // so this can only fail if a splice cut a multi-byte character — again an
+    // invariant of ours, not a statement about the description.
+    String::from_utf8(bytes).map_err(|_| ApplyDecline::ContractViolated)
 }
 
 /// Whether `ordered` can be spliced in one 3' -> 5' walk.
@@ -1786,6 +1951,91 @@ mod tests {
                 "disjointness of {span:?} and {zero_width:?} changed with member \
                  order: {forward} vs {reverse}",
             );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // #2104: the decline classification, tested over the enum.
+    //
+    // These construct each `ApplyDecline` directly rather than driving an input
+    // through the applier, because no input is known that reaches
+    // `MembersOverlap` through `EquivalenceChecker::compare_triples` and
+    // `ContractViolated` is unreachable from either caller by construction —
+    // measured, see the enum's own docs. A pipeline test would therefore pin
+    // nothing, which is exactly what #2104 found.
+    // -----------------------------------------------------------------------
+
+    /// `ALL` cannot silently fall behind the enum.
+    ///
+    /// A new variant is a compile error in `precedence`; this then fails until
+    /// `ALL` carries it too, because the ranks of `ALL`'s members must be
+    /// exactly `0..ALL.len()`. That also pins the ranks as *distinct*, which is
+    /// what makes `governing` deterministic.
+    #[test]
+    fn all_declines_are_listed_exactly_once() {
+        let mut ranks: Vec<u8> = ApplyDecline::ALL.iter().map(|d| d.precedence()).collect();
+        ranks.sort_unstable();
+        let expected: Vec<u8> = (0..ApplyDecline::ALL.len() as u8).collect();
+        assert_eq!(
+            ranks,
+            expected,
+            "ApplyDecline::ALL must hold every variant exactly once, with distinct \
+             precedences; got {ranks:?} for {:?}",
+            ApplyDecline::ALL,
+        );
+    }
+
+    /// The rule #2075's PR body states in words — a reference obstacle governs
+    /// an overlap, because a difference cannot be asserted against a sequence
+    /// that could not be built.
+    ///
+    /// Asserted in **both** argument orders. Reversing this used to be a
+    /// mutation the whole suite could not see (#2104).
+    #[test]
+    fn a_reference_mismatch_governs_a_member_overlap() {
+        assert_eq!(
+            ApplyDecline::ReferenceMismatch.governing(ApplyDecline::MembersOverlap),
+            ApplyDecline::ReferenceMismatch,
+        );
+        assert_eq!(
+            ApplyDecline::MembersOverlap.governing(ApplyDecline::ReferenceMismatch),
+            ApplyDecline::ReferenceMismatch,
+        );
+    }
+
+    /// A broken precondition of the applier governs everything, in both orders,
+    /// so an internal inconsistency can never be masked by a decline about the
+    /// descriptions.
+    #[test]
+    fn a_contract_violation_governs_every_other_decline() {
+        for other in ApplyDecline::ALL {
+            assert_eq!(
+                ApplyDecline::ContractViolated.governing(other),
+                ApplyDecline::ContractViolated,
+                "ContractViolated must govern {other:?}",
+            );
+            assert_eq!(
+                other.governing(ApplyDecline::ContractViolated),
+                ApplyDecline::ContractViolated,
+                "ContractViolated must govern {other:?} from the other side too",
+            );
+        }
+    }
+
+    /// `governing` is symmetric and idempotent over the whole enum — the two
+    /// properties that make "which decline wins" independent of which side of a
+    /// comparison declined.
+    #[test]
+    fn governing_is_symmetric_and_idempotent() {
+        for first in ApplyDecline::ALL {
+            assert_eq!(first.governing(first), first, "{first:?} is not idempotent");
+            for second in ApplyDecline::ALL {
+                assert_eq!(
+                    first.governing(second),
+                    second.governing(first),
+                    "governing is not symmetric for {first:?} and {second:?}",
+                );
+            }
         }
     }
 }

--- a/tests/it/issue_2075_apply_triples_reference_mismatch.rs
+++ b/tests/it/issue_2075_apply_triples_reference_mismatch.rs
@@ -1,0 +1,210 @@
+//! #2075: an `apply_triples` failing **after a successful fetch** must report
+//! [`EquivalenceLevel::Indeterminate`], not a decided negative.
+//!
+//! This is the last of the three reference-level obstacles that used to reach a
+//! decided `NotEquivalent`. Its two siblings are closed:
+//!
+//! * #1989/#2053 — the sequence rung's **window fetch** failing after both sides
+//!   convert to SPDI ([`compare_triples`]'s missing reference bases);
+//! * #2056/#2069 — a member's own **HGVS→SPDI conversion** needing the reference
+//!   and failing (`edit_triples`).
+//!
+//! This one is one step further in: the window fetch **succeeds** and both sides
+//! convert, but `apply_triples` still declines — most commonly because a stated
+//! reference base contradicts the base the reference actually carries. That is
+//! `compare_triples`'s catch-all arm, and before this fix it fell through to the
+//! ladder's `NotEquivalent` tail: a decided negative asserted for a pair whose
+//! resulting sequences were never reconstructed.
+//!
+//! # The measured wrong answer
+//!
+//! `SyntheticBuilder::genomic` pads its core with 256 `ACGT` bases on each side,
+//! so `NC_TEST.1` is **524** bases and positions 20 and 21 are *served*, not
+//! out-of-bounds. Position 20 reads `T` and position 21 reads `A`, so
+//! `g.20A>G` and `g.21C>T` each state a reference base the reference contradicts.
+//! Both SPDIs convert without consulting the provider (a substitution states its
+//! own bases), so neither takes the `edit_triples` route (#2056) — the fetch
+//! succeeds and the only thing left to decline is the apply. Before this fix the
+//! checker answered `NotEquivalent`; the honest verdict is `Indeterminate`.
+//!
+//! # Scope
+//!
+//! This moves **only** the reference-mismatch decline. A genuinely different
+//! served pair, and a genuinely equivalent served pair, both keep their decided
+//! verdicts, and so does the one decline `apply_triples` raises that really is a
+//! fact about the description — an allele whose members overlap.
+//!
+//! # #2104: the other half of the split, and why it was unpinned
+//!
+//! `ApplyDecline` began as a two-way split, with everything that is not a
+//! reference mismatch collapsed into one `Unappliable`. Measured over the whole
+//! suite, a `panic!()` in the arm that routed it was never reached
+//! (`11405 tests run: 11405 passed`), so both mutations that matter were green:
+//! over-mapping it onto the reference-obstacle verdict, and reversing the
+//! precedence between the two.
+//!
+//! The reason is not that the shape is unreachable — it is that only one entry
+//! point was ever driven with it. `EquivalenceChecker::check` **normalizes
+//! before the sequence rung**, and normalization repairs the overlap: measured,
+//! `NC_TEST.1:g.[267_270AT[4];270_276del]` normalizes to the single-member
+//! `NC_TEST.1:g.270_272del`, and one member cannot overlap anything. Every one
+//! of `issue_1244_equivalence_overlap_panic`'s tests uses `check`, which is why
+//! this PR's original claim that they preserved the route was wrong — they pass
+//! with the arm over-mapped, and they never reach it.
+//!
+//! `compare_denotations` compares the pair **as written**, so it does reach it.
+//! `an_overlapping_cis_allele_is_a_decided_negative_not_a_reference_obstacle`
+//! below is that pin, verified by the same `panic!()` probe: with the arm armed,
+//! exactly one test in the suite fires, and it is that one.
+
+use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+use ferro_hgvs::parse_hgvs;
+
+use crate::common::synthetic::SyntheticBuilder;
+
+/// The core `SyntheticBuilder::genomic` wraps in 256 `ACGT` pad bases per side,
+/// so `NC_TEST.1` is 524 bases long. All positions probed below are served.
+const CORE: &str = "ACGTACGTACGT";
+
+fn checker() -> EquivalenceChecker<ferro_hgvs::JsonProvider> {
+    EquivalenceChecker::new(SyntheticBuilder::genomic(CORE).build())
+}
+
+/// The primary reproducer. Both variants state a reference base the served
+/// reference contradicts, so `apply_triples` declines both after the fetch
+/// succeeds. Nothing was reconstructed, so the verdict must not be decided.
+#[test]
+fn both_sides_contradict_the_served_reference_and_are_indeterminate() {
+    let checker = checker();
+
+    // g.20 reads T (stated A) and g.21 reads A (stated C): both contradicted.
+    let a = parse_hgvs("NC_TEST.1:g.20A>G").unwrap();
+    let b = parse_hgvs("NC_TEST.1:g.21C>T").unwrap();
+
+    for (label, result) in [
+        (
+            "compare_denotations",
+            checker.compare_denotations(&a, &b).unwrap(),
+        ),
+        ("check", checker.check(&a, &b).unwrap()),
+    ] {
+        assert_eq!(
+            result.level,
+            EquivalenceLevel::Indeterminate,
+            "{label}: a stated-ref-base contradiction is 'could not tell', not a decided \
+             negative; got {:?}",
+            result.level,
+        );
+        assert!(
+            !result.level.is_decided(),
+            "{label}: an unreconstructable comparison is not a decided verdict",
+        );
+        assert!(
+            !result.is_equivalent(),
+            "{label}: and it is not a positive one either",
+        );
+    }
+}
+
+/// One side contradicts the reference while the other applies cleanly — a
+/// different fact from neither applying, but still one where a resulting
+/// sequence could not be built, so still `Indeterminate`.
+#[test]
+fn one_side_contradicting_the_reference_is_indeterminate() {
+    let checker = checker();
+
+    // g.20A>G contradicts (g.20 reads T); g.21A>G is faithful (g.21 reads A).
+    let contradicts = parse_hgvs("NC_TEST.1:g.20A>G").unwrap();
+    let faithful = parse_hgvs("NC_TEST.1:g.21A>G").unwrap();
+
+    let result = checker
+        .compare_denotations(&contradicts, &faithful)
+        .unwrap();
+    assert_eq!(
+        result.level,
+        EquivalenceLevel::Indeterminate,
+        "one side could not be reconstructed, so the verdict is not decided; got {:?}",
+        result.level,
+    );
+    assert!(!result.level.is_decided());
+}
+
+/// The discriminating control, and why this fix does not over-map: when both
+/// stated reference bases are faithful, two variants that produce genuinely
+/// different sequences are reconstructed and compared, and that decided negative
+/// must survive unchanged.
+#[test]
+fn a_faithful_genuinely_different_pair_stays_a_decided_negative() {
+    let checker = checker();
+
+    // g.21 reads A, g.22 reads C — both faithful, and the two edits differ.
+    let a = parse_hgvs("NC_TEST.1:g.21A>G").unwrap();
+    let b = parse_hgvs("NC_TEST.1:g.22C>G").unwrap();
+
+    assert_eq!(
+        checker.compare_denotations(&a, &b).unwrap().level,
+        EquivalenceLevel::NotEquivalent,
+        "a reconstructed, genuinely different pair is still `NotEquivalent`",
+    );
+    assert_eq!(
+        checker.check(&a, &b).unwrap().level,
+        EquivalenceLevel::NotEquivalent,
+    );
+}
+
+/// The other half of the control: two faithful spellings of one edit still reach
+/// a decided **positive**. The fix moves only the case the reference could not
+/// carry, never a case it could.
+#[test]
+fn a_faithful_equivalent_pair_stays_a_decided_positive() {
+    let checker = checker();
+
+    // g.21 reads A: both spellings are the same faithful edit A->G.
+    let a = parse_hgvs("NC_TEST.1:g.21A>G").unwrap();
+    let b = parse_hgvs("NC_TEST.1:g.21delAinsG").unwrap();
+
+    let result = checker.compare_denotations(&a, &b).unwrap();
+    assert!(
+        result.is_equivalent(),
+        "a reconstructed, equivalent pair still reaches a decided positive; got {:?}",
+        result.level,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #2104: the other half of the same split.
+// ---------------------------------------------------------------------------
+
+/// The 30-base core #1244 uses, whose core positions 11..=20 are an `(AT)`
+/// tandem repeat. Under `SyntheticBuilder::genomic` core `n` sits at HGVS
+/// `256 + n`, so the repeat spans `g.267`..=`g.276`.
+const OVERLAP_CORE: &str = "CAGCTAGCTGATATATATATGCGCGCGCGC";
+
+/// A repeat expansion over core 11..=14 followed by a deletion over core
+/// 14..=20: both members claim core position 14, so the allele's resulting
+/// sequence is undefined. #1244's own reproducer.
+const OVERLAPPING_ALLELE: &str = "NC_TEST.1:g.[267_270AT[4];270_276del]";
+
+/// The description-level decline, driven through the ladder.
+///
+/// `compare_denotations` is load-bearing here and `check` cannot substitute for
+/// it: `check` normalizes first and normalization collapses this allele to one
+/// member (see the module docs), which is why the arm had never been reached.
+#[test]
+fn an_overlapping_cis_allele_is_a_decided_negative_not_a_reference_obstacle() {
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic(OVERLAP_CORE).build());
+    let overlapping = parse_hgvs(OVERLAPPING_ALLELE).unwrap();
+    let elsewhere = parse_hgvs("NC_TEST.1:g.257C>A").unwrap();
+
+    let result = checker
+        .compare_denotations(&overlapping, &elsewhere)
+        .unwrap();
+    assert_eq!(
+        result.level,
+        EquivalenceLevel::NotEquivalent,
+        "an allele whose members overlap denotes no single sequence, which the \
+         description itself says — so this stays a decided negative and must not be \
+         swept up with the reference-level declines this PR moves; got {:?}",
+        result.level,
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -52,6 +52,7 @@ mod issue_1989_declined_is_indeterminate;
 mod issue_2018_past_cds_end_mode_dependent;
 mod issue_2037_cis_allele_at_transcript_start;
 mod issue_2056_edit_triples_reference_failure;
+mod issue_2075_apply_triples_reference_mismatch;
 mod issue_2092_explain_normalizer_codes;
 mod recommended_form_pins;
 mod repeat_input_idempotency;


### PR DESCRIPTION
Closes #2075

Representation-Change: none. `src/spdi/apply.rs` changes are behaviour-preserving — `apply_triples` still returns `None` for exactly the same inputs (it is now a `.ok()` wrapper over the new classified function), so no normalized output moves. The `src/equivalence/` change only reclassifies an equivalence verdict, which is not a normalization output.

`compare_triples` fetches the union window, applies both SPDI triple sets, and matches on the pair. Its catch-all arm — reached when the fetch **succeeded** but `apply_triples` still returned `None`, most commonly because a description's stated reference base contradicts the base the reference actually carries — fell through to the ladder's `NotEquivalent` tail. That asserted a decided negative about a pair whose resulting sequences were never reconstructed: a reference-level obstacle read as a decided verdict.

This is the last of the three reference-level routes that reached a decided negative; its two siblings are already closed — #2053 (#1989: the window fetch failing) and #2069 (#2056: a member's own HGVS→SPDI conversion failing) — and this mirrors both.

The fix distinguishes *why* `apply_triples` declined. `src/spdi/apply.rs` gains `ApplyDecline { ReferenceMismatch, Unappliable }` and an `apply_triples_classified` returning `Result<String, ApplyDecline>`; `apply_triples` becomes a thin `.ok()` wrapper so its existing callers are unchanged. `compare_triples` then routes a `ReferenceMismatch` on either side to `SequenceVerdict::ReferenceUnavailable` → `Indeterminate`, while a genuinely un-spliceable set of triples (`Unappliable` — an overlapping cis allele, or the defensive out-of-window guard) stays `Declined` → `NotEquivalent`, preserving the deliberate negative pinned by `issue_1244_equivalence_overlap_panic`. `ReferenceMismatch` takes precedence over `Unappliable` because a difference cannot be asserted against a sequence that could not be built.

Pinned by the new `tests/it/issue_2075_apply_triples_reference_mismatch.rs` (the measured `g.20A>G` vs `g.21C>T` reproducer on the served-but-contradicting `NC_TEST.1` contig, plus a one-sided-contradiction case and both discriminating controls). Three in-source unit tests (`test_different_variants`, `test_substitution_at_different_positions`, `test_differing_alleles_do_not_error`) stated reference bases that contradicted the served `NM_000088.3` sequence and only passed via the old buggy route; they are updated to faithful bases so they genuinely reconstruct and compare — the same correction #2053 made to `test_genomic_variants_different`.

Refs #1989, #2053, #2056, #2069.