### PR TITLE
refactor(prepare)!: split legacy transcript metadata into sourced authority + on-disk record

### DIFF
--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -98,8 +98,8 @@ pub use parse::{parse_ferro, parse_ferro_unified};
 pub use runner::{load_existing_results, run_benchmark};
 // Re-export from the main prepare module (avoiding code duplication)
 pub use crate::prepare::{
-    check_references, prepare_references, LegacyMetadata, LegacyTranscript, PrepareConfig,
-    ReferenceManifest,
+    check_references, prepare_references, LegacyMetadata, LegacyTranscript, LegacyTranscriptRecord,
+    PrepareConfig, ReferenceManifest,
 };
 pub use report::generate_report;
 pub use sample::stratified_sample;

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -206,8 +206,18 @@ pub mod urls {
         "https://ftp.ebi.ac.uk/pub/databases/lrgex/list_LRGs_transcripts_xrefs.txt";
 }
 
-/// Metadata for a legacy transcript fetched from GenBank.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+/// Sourced (authoritative) metadata for a legacy transcript fetched from
+/// GenBank: accession, gene symbol, and CDS bounds.
+///
+/// The transcript LENGTH is deliberately **not** a field here. Its sole
+/// authority is the FASTA (`seq.len()`, recoverable from the `.fai` index), so
+/// storing it on the sourced record would make a second, drift-prone copy of a
+/// value the FASTA already owns. This type therefore *structurally* cannot carry
+/// a derived length — the compiler enforces the sourced/derived split (#2085).
+/// The on-disk row that still carries the length for byte-compatible metadata is
+/// [`LegacyTranscriptRecord`]; dropping it from disk entirely is tracked by #2064
+/// (a deliberate re-bless of the reference identity).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LegacyTranscript {
     /// Accession with version (e.g., "NM_000051.3")
     pub id: String,
@@ -217,8 +227,68 @@ pub struct LegacyTranscript {
     pub cds_start: Option<u64>,
     /// CDS end position (1-based, inclusive)
     pub cds_end: Option<u64>,
-    /// Total sequence length
+}
+
+/// On-disk row for a legacy transcript: the sourced [`LegacyTranscript`] fields
+/// plus the **derived** `sequence_length`.
+///
+/// This is the *only* type that carries the derived length across the
+/// persistence boundary. It exists so the structural sourced/derived split (the
+/// authority type has no length) is byte-for-byte identity-neutral (#905/#933):
+/// the serialized JSON is unchanged from the pre-split format, so the content
+/// stamps in [`crate::prepare::identity`] and the blessed reference identity do
+/// not move. Field order matches the pre-split `LegacyTranscript` exactly, which
+/// is what keeps the bytes identical. Dropping the field from disk (which *would*
+/// move the identity) is #2064.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LegacyTranscriptRecord {
+    /// Accession with version (e.g., "NM_000051.3")
+    pub id: String,
+    /// Gene symbol if available
+    pub gene_symbol: Option<String>,
+    /// CDS start position (1-based, inclusive)
+    pub cds_start: Option<u64>,
+    /// CDS end position (1-based, inclusive)
+    pub cds_end: Option<u64>,
+    /// Total sequence length. **Derived**: its authority is the FASTA / `.fai`;
+    /// this persisted copy equals `seq.len()` at write time and is recomputable.
     pub sequence_length: usize,
+}
+
+impl LegacyTranscript {
+    /// Pair this sourced record with the **derived** length taken from its FASTA
+    /// authority at write time, producing the on-disk [`LegacyTranscriptRecord`].
+    ///
+    /// This is the seam the split exists for, and it is load-bearing rather than
+    /// advisory: [`legacy_record_from_genbank`] — the only construction of
+    /// `LegacyTranscriptRecord` in `src/`, and the step
+    /// [`fetch_legacy_versions`] performs per GenBank record — reaches the
+    /// persisted row exclusively through here, so a derived length cannot enter
+    /// production metadata without passing this function. A writer that bypassed
+    /// it would leave that helper unused and fail the `-D warnings` build.
+    pub fn into_record(self, sequence_length: usize) -> LegacyTranscriptRecord {
+        LegacyTranscriptRecord {
+            id: self.id,
+            gene_symbol: self.gene_symbol,
+            cds_start: self.cds_start,
+            cds_end: self.cds_end,
+            sequence_length,
+        }
+    }
+}
+
+impl LegacyTranscriptRecord {
+    /// Project to the sourced authority, dropping the derived length. Callers
+    /// that need the length must consult the FASTA / `.fai` (the authority),
+    /// never this persisted copy.
+    pub fn sourced(&self) -> LegacyTranscript {
+        LegacyTranscript {
+            id: self.id.clone(),
+            gene_symbol: self.gene_symbol.clone(),
+            cds_start: self.cds_start,
+            cds_end: self.cds_end,
+        }
+    }
 }
 
 /// Metadata file for legacy transcripts.
@@ -226,8 +296,21 @@ pub struct LegacyTranscript {
 pub struct LegacyMetadata {
     /// When the metadata was generated
     pub generated_at: String,
-    /// Map from accession to transcript metadata
-    pub transcripts: HashMap<String, LegacyTranscript>,
+    /// Map from accession to the on-disk transcript row.
+    pub transcripts: HashMap<String, LegacyTranscriptRecord>,
+}
+
+impl LegacyMetadata {
+    /// The sourced authority view of every transcript, with the derived length
+    /// dropped. This is the API consumers should use to reason about legacy
+    /// transcripts so a persisted length can never be mistaken for the source of
+    /// truth (#2085); the length, when needed, comes from the FASTA / `.fai`.
+    pub fn sourced_transcripts(&self) -> HashMap<String, LegacyTranscript> {
+        self.transcripts
+            .iter()
+            .map(|(id, record)| (id.clone(), record.sourced()))
+            .collect()
+    }
 }
 
 /// Prepare reference data for normalization.
@@ -2242,6 +2325,39 @@ fn parse_genbank_record(genbank: &str) -> Option<(String, Option<u64>, Option<u6
 
 /// Fetch legacy transcript versions from NCBI and save to FASTA with metadata.
 ///
+/// Build the on-disk row for one legacy transcript from its parsed GenBank
+/// record and the bases being written to the FASTA.
+///
+/// This is the **single seam** through which a derived length enters a
+/// persisted legacy row, and it is deliberately the only construction of
+/// [`LegacyTranscriptRecord`] in `src/`: the sourced authority is built first
+/// as a [`LegacyTranscript`] — which structurally cannot hold a length — and
+/// the length is attached only by [`LegacyTranscript::into_record`], taken from
+/// `sequence`, its sole authority (#2085 move 3). It is factored out of
+/// [`fetch_legacy_versions`] because that function shells out to `curl` and so
+/// cannot be reached from a test, which would leave the seam unexercised in
+/// production; its guard is
+/// `tests::the_writer_pairs_the_sourced_authority_with_the_fasta_derived_length`.
+fn legacy_record_from_genbank(
+    accession: &str,
+    gene_name: &str,
+    cds_start: Option<u64>,
+    cds_end: Option<u64>,
+    sequence: &str,
+) -> LegacyTranscriptRecord {
+    LegacyTranscript {
+        id: accession.to_string(),
+        gene_symbol: if gene_name.is_empty() {
+            None
+        } else {
+            Some(gene_name.to_string())
+        },
+        cds_start,
+        cds_end,
+    }
+    .into_record(sequence.len())
+}
+
 /// These are older RefSeq versions that are referenced in patterns
 /// but not in the current RefSeq release. Fetches GenBank format to
 /// extract CDS coordinates and gene names.
@@ -2336,20 +2452,12 @@ pub fn fetch_legacy_versions(
                     )?;
                 }
 
-                // Add to metadata
+                // Add to metadata. The row is built through the single seam,
+                // so the derived `sequence_length` can only come from the FASTA
+                // bases written just above — its authority (#2085).
                 metadata.transcripts.insert(
                     acc.clone(),
-                    LegacyTranscript {
-                        id: acc.clone(),
-                        gene_symbol: if gene_name.is_empty() {
-                            None
-                        } else {
-                            Some(gene_name)
-                        },
-                        cds_start,
-                        cds_end,
-                        sequence_length: seq.len(),
-                    },
+                    legacy_record_from_genbank(acc, &gene_name, cds_start, cds_end, &seq),
                 );
 
                 fetched += 1;
@@ -2524,6 +2632,49 @@ mod tests {
     use super::*;
     use std::collections::BTreeMap;
     use tempfile::TempDir;
+
+    /// The writer's own record-building step, on the production path (#2085).
+    ///
+    /// `fetch_legacy_versions` shells out to `curl`, so no test can reach it;
+    /// the step it performs per GenBank record is factored into
+    /// [`legacy_record_from_genbank`], and this is the guard on *that*. What it
+    /// pins is that the derived length reaches the persisted row **only**
+    /// through [`LegacyTranscript::into_record`] — sabotage `into_record` and
+    /// this test goes red, which is what separates a load-bearing seam from a
+    /// method only tests call. The type-level half of the split (the sourced
+    /// authority has no length field at all) is pinned in
+    /// `tests/it/legacy_integration.rs::sourced_derived_split`.
+    #[test]
+    fn the_writer_pairs_the_sourced_authority_with_the_fasta_derived_length() {
+        // Stands in for the bases the same loop writes to the FASTA, which is
+        // the length's sole authority.
+        let sequence = "ACGTACGTACGT";
+        let record =
+            legacy_record_from_genbank("NM_000051.3", "ATM", Some(250), Some(9500), sequence);
+
+        assert_eq!(record.sequence_length, sequence.len());
+        // The sourced authority survives the pairing intact, and carries no
+        // length of its own to disagree with the FASTA's.
+        assert_eq!(
+            record.sourced(),
+            LegacyTranscript {
+                id: "NM_000051.3".to_string(),
+                gene_symbol: Some("ATM".to_string()),
+                cds_start: Some(250),
+                cds_end: Some(9500),
+            }
+        );
+    }
+
+    /// An absent GenBank gene name is absence, not an empty symbol. This rule
+    /// used to live inline at the insertion site; it is pinned here so the
+    /// extraction cannot quietly change it.
+    #[test]
+    fn an_empty_genbank_gene_name_becomes_no_gene_symbol() {
+        let record = legacy_record_from_genbank("NM_000001.1", "", None, None, "ACGT");
+        assert_eq!(record.gene_symbol, None);
+        assert_eq!(record.sequence_length, 4);
+    }
 
     /// Build a config with only the named cdot switches on.
     fn cfg(

--- a/tests/it/legacy_integration.rs
+++ b/tests/it/legacy_integration.rs
@@ -8,7 +8,7 @@
 
 #[cfg(feature = "benchmark")]
 mod legacy_tests {
-    use ferro_hgvs::benchmark::{LegacyMetadata, LegacyTranscript};
+    use ferro_hgvs::benchmark::{LegacyMetadata, LegacyTranscriptRecord};
     use std::io::Write;
     use tempfile::TempDir;
 
@@ -19,7 +19,7 @@ mod legacy_tests {
             generated_at: "2024-01-01T00:00:00Z".to_string(),
             transcripts: [(
                 "NM_000051.3".to_string(),
-                LegacyTranscript {
+                LegacyTranscriptRecord {
                     id: "NM_000051.3".to_string(),
                     gene_symbol: Some("ATM".to_string()),
                     cds_start: Some(250),
@@ -57,17 +57,17 @@ mod legacy_tests {
         assert_eq!(metadata.transcripts.len(), 1);
         assert!(metadata.transcripts.contains_key("NM_000051.3"));
 
-        let transcript = &metadata.transcripts["NM_000051.3"];
-        assert_eq!(transcript.gene_symbol, Some("ATM".to_string()));
-        assert_eq!(transcript.cds_start, Some(250));
-        assert_eq!(transcript.cds_end, Some(9500));
-        assert_eq!(transcript.sequence_length, 10000);
+        let record = &metadata.transcripts["NM_000051.3"];
+        assert_eq!(record.gene_symbol, Some("ATM".to_string()));
+        assert_eq!(record.cds_start, Some(250));
+        assert_eq!(record.cds_end, Some(9500));
+        assert_eq!(record.sequence_length, 10000);
     }
 
     #[test]
     fn test_legacy_transcript_optional_fields() {
-        // Test that optional fields can be None
-        let transcript = LegacyTranscript {
+        // Test that optional fields can be None on the on-disk record.
+        let record = LegacyTranscriptRecord {
             id: "NM_000001.1".to_string(),
             gene_symbol: None,
             cds_start: None,
@@ -75,8 +75,8 @@ mod legacy_tests {
             sequence_length: 5000,
         };
 
-        let json = serde_json::to_string(&transcript).unwrap();
-        let parsed: LegacyTranscript = serde_json::from_str(&json).unwrap();
+        let json = serde_json::to_string(&record).unwrap();
+        let parsed: LegacyTranscriptRecord = serde_json::from_str(&json).unwrap();
 
         assert_eq!(parsed.gene_symbol, None);
         assert_eq!(parsed.cds_start, None);
@@ -187,5 +187,129 @@ mod legacy_tests {
         // 1-based inclusive to 0-based half-open
         assert_eq!(cds_coords_to_indices(1, 100), (0, 100));
         assert_eq!(cds_coords_to_indices(251, 9500), (250, 9500));
+    }
+}
+
+/// The sourced/derived split for legacy-transcript metadata (#2085).
+///
+/// These pin the structural invariant introduced by the first increment of
+/// #2085: the *authority* type [`LegacyTranscript`] carries only sourced fields
+/// and structurally cannot hold the derived `sequence_length`, while the on-disk
+/// [`LegacyTranscriptRecord`] remains the sole carrier of the derived length so
+/// the serialized bytes — and therefore the content stamps and the blessed
+/// reference identity (`aa8b3246d83055cc`) — do not move.
+#[cfg(feature = "benchmark")]
+mod sourced_derived_split {
+    use ferro_hgvs::benchmark::{LegacyMetadata, LegacyTranscript, LegacyTranscriptRecord};
+    use ferro_hgvs::prepare::identity::fnv1a_hex;
+
+    /// The exact pre-split serialization of a single-record metadata file, so the
+    /// identity-neutrality assertions below compare against a fixed golden rather
+    /// than against the code under test. A single transcript keeps the map order
+    /// deterministic; `cds_end: null` pins that `None` still serializes as before.
+    const GOLDEN_PRETTY: &str = "{\n  \"generated_at\": \"2024-01-01T00:00:00Z\",\n  \"transcripts\": {\n    \"NM_000051.3\": {\n      \"id\": \"NM_000051.3\",\n      \"gene_symbol\": \"ATM\",\n      \"cds_start\": 250,\n      \"cds_end\": null,\n      \"sequence_length\": 10000\n    }\n  }\n}";
+
+    fn golden_metadata() -> LegacyMetadata {
+        LegacyMetadata {
+            generated_at: "2024-01-01T00:00:00Z".to_string(),
+            transcripts: [(
+                "NM_000051.3".to_string(),
+                LegacyTranscriptRecord {
+                    id: "NM_000051.3".to_string(),
+                    gene_symbol: Some("ATM".to_string()),
+                    cds_start: Some(250),
+                    cds_end: None,
+                    sequence_length: 10000,
+                },
+            )]
+            .into_iter()
+            .collect(),
+        }
+    }
+
+    /// The sourced authority type cannot carry a derived length: it has no such
+    /// field, so it never serializes one. This is the structural core of #2085 —
+    /// a persisted length can no longer masquerade as a sourced fact.
+    #[test]
+    fn sourced_authority_type_has_no_length_field() {
+        let sourced = LegacyTranscript {
+            id: "NM_000051.3".to_string(),
+            gene_symbol: Some("ATM".to_string()),
+            cds_start: Some(250),
+            cds_end: Some(9500),
+        };
+        let json = serde_json::to_string(&sourced).unwrap();
+        assert!(
+            !json.contains("sequence_length"),
+            "sourced LegacyTranscript must not serialize a derived length: {json}"
+        );
+        assert!(json.contains("\"id\":\"NM_000051.3\""));
+        assert!(json.contains("\"cds_start\":250"));
+    }
+
+    /// The on-disk bytes are byte-for-byte unchanged from the pre-split format,
+    /// so the derived-artifact content stamps and the blessed reference identity
+    /// do not move. This is what makes the increment identity-neutral (#905/#933).
+    #[test]
+    fn on_disk_bytes_are_identity_neutral() {
+        let serialized = serde_json::to_string_pretty(&golden_metadata()).unwrap();
+        assert_eq!(serialized, GOLDEN_PRETTY);
+    }
+
+    /// The FNV-1a content stamp `src/prepare/identity.rs` injects into the
+    /// reference identity, pinned as a literal digest.
+    ///
+    /// The literal is what makes this falsifiable. Comparing
+    /// `fnv1a_hex(serialized)` against `fnv1a_hex(GOLDEN_PRETTY)` — which this
+    /// test used to do — is `f(x) == f(x)` once the sibling above has asserted
+    /// `serialized == GOLDEN_PRETTY`, so it holds for *any* hash function and
+    /// any golden. The digest below was derived independently of ferro (FNV-1a
+    /// 64-bit over the golden's 228 bytes, offset basis `cbf29ce484222325`,
+    /// prime `100000001b3`), so it pins the stamp rather than restating the
+    /// assertion above it.
+    #[test]
+    fn content_stamp_is_the_pinned_digest() {
+        let serialized = serde_json::to_string_pretty(&golden_metadata()).unwrap();
+        assert_eq!(fnv1a_hex(serialized.as_bytes()), "3135b86e16384d04");
+    }
+
+    /// The persisted `sequence_length` is exactly the FASTA-derived length
+    /// (`seq.len()`), i.e. fully redundant with its authority — the very property
+    /// that makes it derived. `into_record` pairs the sourced authority with that
+    /// derived length; `sourced()` projects back, dropping it.
+    #[test]
+    fn persisted_length_is_the_fasta_derived_length() {
+        let seq = "ACGTACGTAC"; // stands in for the FASTA bases (authority)
+        let sourced = LegacyTranscript {
+            id: "NM_000001.1".to_string(),
+            gene_symbol: None,
+            cds_start: Some(1),
+            cds_end: Some(9),
+        };
+        let record = sourced.clone().into_record(seq.len());
+
+        // The persisted copy equals the authority's length, byte-for-byte.
+        assert_eq!(record.sequence_length, seq.len());
+        // Projecting back to the authority recovers exactly the sourced fields,
+        // with no length surviving the round trip.
+        assert_eq!(record.sourced(), sourced);
+    }
+
+    /// `sourced_transcripts()` is the length-free view consumers should read, so
+    /// a persisted length can never be mistaken for the source of truth (#2085).
+    #[test]
+    fn sourced_transcripts_view_drops_the_derived_length() {
+        let metadata = golden_metadata();
+        let sourced = metadata.sourced_transcripts();
+        assert_eq!(sourced.len(), 1);
+        let view = &sourced["NM_000051.3"];
+        assert_eq!(view.id, "NM_000051.3");
+        assert_eq!(view.gene_symbol, Some("ATM".to_string()));
+        assert_eq!(view.cds_start, Some(250));
+        assert_eq!(view.cds_end, None);
+        // A serialized sourced view carries no length key.
+        assert!(!serde_json::to_string(view)
+            .unwrap()
+            .contains("sequence_length"));
     }
 }


### PR DESCRIPTION
Refs #2085, #2105, #2064, #2058.

## What this is

The first, deliberately identity-neutral increment of #2085 (make the prepared-reference data model distinguish **sourced** authority from **derived**, recomputable data). It targets **move 3** of that issue — *make the sourced/derived split structural, not a doc-comment* — scoped to the legacy-transcript metadata records, with **zero** impact on the blessed reference identity.

**It does not close #2085.** #2085's principled fix is numbered 1–4 and this PR implements only move 3. Move 1 is the one #2085 itself calls the keystone ("take derived artifacts OUT of the identity"); moves 2 and 4 (read-time derivation as the sole length source; provenance-tagged cache validation) likewise have no other tracker. #2064 tracks only the field deletion. **#2105 exists to hold moves 1, 2 and 4**, so #2085 must stay open — note that #2085's own "First increment (accompanying PR)" section describes this PR and makes closing it look sanctioned; it is not.

## The change

`LegacyTranscript` conflated a sourced authority (accession, gene symbol, CDS bounds — from GenBank) with a **derived** `sequence_length` (its authority is the FASTA; the persisted value is exactly `seq.len()` and is recomputable from the `.fai` index). Nothing in `src/` ever read the persisted length.

This splits the one type into two:

- **`LegacyTranscript`** — the sourced authority. It now carries only `id`, `gene_symbol`, `cds_start`, `cds_end`, so the compiler *structurally forbids* a derived length from entering it.
- **`LegacyTranscriptRecord`** — the on-disk row: the sourced fields plus the derived `sequence_length`. It is the sole carrier of the derived length across the persistence boundary, with its field order matching the pre-split struct exactly.

**The writer goes through the seam rather than around it**, which is what makes the split load-bearing rather than a rename. The per-record step of `fetch_legacy_versions` is factored into `legacy_record_from_genbank`, which builds the sourced authority first and attaches the length only via `LegacyTranscript::into_record`. That helper is the **only** construction of `LegacyTranscriptRecord` in `src/`, so a derived length cannot reach persisted metadata without passing `into_record` — and a writer that bypassed it would leave the helper unused and fail the `-D warnings` build (verified by sabotage: `error: function legacy_record_from_genbank is never used`).

`LegacyMetadata::sourced_transcripts()` and `LegacyTranscriptRecord::sourced()` expose the length-free authority view. These two are new public surface with **no in-tree consumer yet**: they are the reader-side API move 2 of #2085 needs, and are stated here rather than left to be discovered.

## Breaking change

Declared, because both types are re-exported from the public `prepare` module (`src/lib.rs`: `pub mod prepare;`, and `pub mod benchmark;` under that feature), so this breaks downstream compilation:

- `LegacyTranscript` loses its `sequence_length` field.
- `LegacyMetadata.transcripts` is retyped to `HashMap<String, LegacyTranscriptRecord>`.

The commit is typed `refactor(prepare)!:` and carries a `BREAKING CHANGE:` footer so release-plz classifies it. **The on-disk JSON is unchanged** — this is a source-compatibility break only.

BREAKING CHANGE: `ferro_hgvs::prepare::LegacyTranscript` no longer has a `sequence_length` field, and `LegacyMetadata::transcripts` is now a `HashMap<String, LegacyTranscriptRecord>`. Downstream code reading a persisted length must move to `LegacyTranscriptRecord`.

## Identity impact: UNCHANGED

The blessed reference identity `aa8b3246d83055cc` does **not** move. `legacy_transcripts_metadata` / `legacy_genbank_metadata` are content-stamped from **on-disk bytes** (`src/prepare/identity.rs` does `fs::read(path)` → `fnv1a_hex(&bytes)`, never a re-serialized struct), and this increment keeps those bytes byte-for-byte identical: `LegacyTranscriptRecord` serializes exactly as the old `LegacyTranscript` did. No re-prepare is performed, so no artifact changes. No re-bless, no `.count` fixture change.

Actually *dropping* the field from disk (which **would** move the identity and needs an operator re-prepare + re-bless of both volumes) is #2064 and stays deferred, along with moves 1/2/4 of #2085 (see #2105). This increment establishes the type boundary those later moves build on.

## Tests

New unit tests in `src/prepare/mod.rs` on the production writer path:

- `the_writer_pairs_the_sourced_authority_with_the_fasta_derived_length` — guards `legacy_record_from_genbank`, the step `fetch_legacy_versions` performs per record. `fetch_legacy_versions` shells out to `curl` and cannot be reached from a test, which is precisely why the seam had to be factored out to be exercised at all.
- `an_empty_genbank_gene_name_becomes_no_gene_symbol` — the writer's own rule, pinned so the extraction cannot quietly change it.

New `sourced_derived_split` module in `tests/it/legacy_integration.rs` for the type-level half:

- `sourced_authority_type_has_no_length_field` — the sourced type never serializes a `sequence_length` key.
- `on_disk_bytes_are_identity_neutral` — serialized metadata equals the pre-split golden byte-for-byte.
- `content_stamp_is_the_pinned_digest` — the FNV-1a stamp against a **literal** digest (`3135b86e16384d04`), derived independently of ferro. The earlier form compared `fnv1a_hex(serialized)` against `fnv1a_hex(GOLDEN_PRETTY)`, which is `f(x) == f(x)` given the assertion above it and holds for any hash function.
- `persisted_length_is_the_fasta_derived_length` — the persisted length equals `seq.len()`, and `sourced()` drops it on the round trip.
- `sourced_transcripts_view_drops_the_derived_length` — the consumer-facing view is length-free.

The three existing legacy serialization tests are updated to the new types.

### Sabotage table

Each mutation applied to the tree, measured, reverted:

| mutation | result |
|---|---|
| `into_record` ignores its argument (`sequence_length: 0`) | **RED** — `the_writer_pairs_...` fails |
| writer's call site passes `sequence.len() + 1` | **RED** — same test fails |
| writer bypasses the helper with the pre-fix inline struct literal | **RED** — `cargo clippy --all-features --all-targets -- -D warnings` fails with `function legacy_record_from_genbank is never used` |

Before this change, `into_record` had **zero** callers in `src/`, so no mutation of it could redden anything but a test-only caller.

## Verification

- `cargo nextest run --features dev --no-fail-fast` — `EXIT=0`, 11374 passed, 0 failed.
- `cargo clippy --all-features --all-targets -- -D warnings` — `EXIT=0`.
- `cargo fmt --all --check` — `EXIT=0`.
- `python3 -m pytest tests/python/ -q` — `EXIT=0`, 1137 passed, 8 skipped.

Rebased onto `origin/main` at `0d542858`.

Representation-Change: none. Data-model type split in `src/prepare/` and `src/benchmark/` (neither a watched prefix); no `Normalizer`/`VariantProjector` path is touched and no normalized HGVS output moves.
