### PR TITLE
fix: file declining fix: commits under Fixed in the changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,6 +666,17 @@ jobs:
         with:
           python-version: "3.12"
       - uses: taiki-e/install-action@a8fb21b85430c7a58551cf7ea87b03f355b826d9  # git-cliff
+      - name: Test the changelog grouping (renders through git-cliff)
+        # This is where `tests/python/test_changelog_grouping.py`'s end-to-end tests actually
+        # run: they render throwaway repos through the real `release-plz.toml` and assert
+        # where each commit lands (e.g. a declining `fix:` under Fixed, #1557), which needs
+        # git-cliff. The Python Wheel Test job has no git-cliff, so those tests skip there —
+        # they must not be left to skip everywhere. No wheel is needed; the tests import the
+        # script by path.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pytest tests/python/test_changelog_grouping.py -v
       - name: Require each Representation changes entry to carry its disclosure
         # The audit below asks whether the right commits are in the section. This asks
         # whether each entry in the *committed* changelog says what it moved (#1556): the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -879,10 +879,16 @@ which is filed as a real change. This was the #1555 defect: the value used to be
 declining *with a reason* was read as a disclosure. It is not a corner case — in the v0.13.1
 cycle 8 of the 14 declines gave a reason, and the section listed 10 entries of which 2 were real.
 
-**One limit of the section itself, and one that is now closed.** A declining commit is filed
-under **Other** whatever its type, so a declining `fix:` is missing from **Fixed** (#1557);
-git-cliff evaluates a parser's fields as OR, not AND, so this cannot be repaired by adding
-`message` to the exclusion rule.
+**Two limits of the section itself, both now closed.** A declining commit used to be filed
+under **Other** whatever its type, so a declining `fix:` was missing from **Fixed** (#1557).
+git-cliff evaluates a parser's fields as OR, not AND, so it could not be repaired by adding
+`message` to the exclusion rule; the fix is a `commit_preprocessor` in `release-plz.toml` that
+renames a declining trailer's key (`Representation-Change:` -> `Representation-Change-Declined:`)
+before the parsers run, so the commit falls through to its conventional-type parser. Real
+declarations keep their key and still reach the section. Setting `commit_preprocessors` replaces
+release-plz's defaults wholesale, so its default `(#N)`->PR-link rewrite is reproduced alongside;
+`check_changelog_grouping.py`'s `write_cliff_config` copies `commit_preprocessors` too, or the
+audit would render without the neutralizer and file every decline as a real change.
 
 The other — the bullet carrying the commit subject and nothing else, so the
 rejected-vs-accepted fact had to be read out of every linked PR — is #1556, and it is closed by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,12 +209,15 @@ PR — see [Changelog](#changelog) below. The release PR states the section even
 when it is empty, so that a cycle in which nothing was declared is visible rather
 than silent.
 
-Two limits of that section are worth knowing before you rely on it. It carries
-the commit **subject** only — the trailer's own text does not reach the changelog
+One limit of that section is worth knowing before you rely on it: it carries the
+commit **subject** only — the trailer's own text does not reach the changelog
 ([#1556]), so the four facts above live in your PR description and a reader has
-to follow the link for them. And a declining commit is filed under **Other**
-whatever its type, so a `fix:` that correctly declined is not listed under
-**Fixed** ([#1557]).
+to follow the link for them.
+
+A declining commit (`Representation-Change: none`) is grouped by its conventional
+type, so a `fix:` that correctly declined is listed under **Fixed** rather than
+buried in **Other** — a `commit_preprocessor` in `release-plz.toml` neutralizes
+the declining trailer so the commit falls through to its type ([#1557]).
 
 [#1556]: https://github.com/fulcrumgenomics/ferro-hgvs/issues/1556
 [#1557]: https://github.com/fulcrumgenomics/ferro-hgvs/issues/1557

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -143,69 +143,66 @@ means the trailer is missing. Fix that before releasing, not after.
 # insertion at the top) — so a released section can be amended after the fact.
 # The trailer is what gets a note in automatically, at release time.
 [changelog]
+# A commit's `Representation-Change:` trailer decides its changelog group, and there are
+# three cases to keep apart (#1424, #1557):
+#
+#   - a trailer declaring a REAL move    -> "Representation changes"
+#   - a trailer that DECLINES (`none`, ...) -> grouped by conventional type (Fixed, ...)
+#   - no trailer                         -> grouped by conventional type
+#
+# The declining case is why a preprocessor is needed rather than a second parser. git-cliff
+# matches a footer rule on the trailer's *presence*, not its value, so the inclusion parser
+# below (`^Representation-Change:`) would file a decline under "Representation changes" too
+# -- which #1526 (#1523's CI-only decline) did in v0.13.1. Every direct repair fails,
+# measured against git-cliff 2.13.1:
+#
+#   - `{ footer = <decline>, message = "^fix", group = "Fixed" }` -- git-cliff evaluates a
+#     parser's fields as OR, not AND, so this matches every `fix:` regardless of its
+#     trailer, INCLUDING the ones declaring a real move, which empties the section.
+#   - a parser routing declines to `Other` (what shipped before #1557) files a declining
+#     `fix:` under Other instead of Fixed -- the exact bug this config now fixes.
+#   - a parser that omits `group` does not fall through; the commit keeps `group = None` and
+#     git-cliff renders the raw conventional type (`fix`/`test`), losing the group ordering.
+#
+# So a `commit_preprocessor` renames the trailer KEY on DECLINING commits only, before the
+# parsers run: `Representation-Change:` becomes `Representation-Change-Declined:`, which the
+# inclusion parser's literal `:` no longer matches, so the commit falls through to its
+# conventional-type parser (a declining `fix:` -> Fixed). Real declarations keep their key
+# and are grouped into "Representation changes" as before. The rename touches the footer,
+# never the subject, so no rendered bullet changes and no strip postprocessor is needed;
+# `scripts/inject_representation_disclosure.py` reads the RAW commit message rather than the
+# preprocessed one, so a decline's own text is untouched there too.
+#
+# The decline regex is the exact one `scripts/check_changelog_grouping.py` audits with, so
+# the audit and this config agree on which commits decline by construction:
+#   - `[^\S\r\n]` is horizontal-only whitespace, so `\s` cannot span a newline into the next
+#     trailer and read a following `none` line as this trailer's value.
+#   - `(?i)` accepts `NONE`/`None`, matching the checker (whose regex is case-insensitive);
+#     without it an uppercase decline would be grouped as a real change.
+#   - `m`, because git-cliff matches against the whole footer value, which spans lines
+#     (#1573): the verdict is read off the trailer's own line, as the checker does.
+#   - the verdict is the first word and a reason may follow it (#1555): `[.;:—–]` introduces
+#     the reason, a `,` does not (a comma qualifies -- "none, except two rows" is a real
+#     change). `[\s\S]*` lets the reason span lines.
+# The decline vocabulary and terminator set are kept in step with `NONE_VALUES` and
+# `DECLINE_TERMINATORS` in `scripts/check_representation_change.py` by
+# `test_decline_vocabulary_matches_the_changelog_config` and
+# `test_the_two_decline_rules_agree_value_by_value`.
+#
+# Setting `commit_preprocessors` REPLACES release-plz's defaults wholesale, and its only
+# default is the `(#N)` -> PR-link rewrite (`release_plz_core::changelog::default_git_config`).
+# So that rewrite is reproduced as the second entry below, or the changelog loses every PR
+# link. The URL is this repo's own PR base (`RepoUrl::git_pr_link`), which is stable.
+commit_preprocessors = [
+  { pattern = "(?im)^Representation-Change:([^\\S\\r\\n]*(?:none|no|n/a|na)[^\\S\\r\\n]*(?:[.;:—–][\\s\\S]*)?)$", replace = "Representation-Change-Declined:${1}" },
+  { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/fulcrumgenomics/ferro-hgvs/pull/${1}))" },
+]
+
 commit_parsers = [
-  # `Representation-Change: none` declares that a change moves NO output, so it must not
-  # be listed as one. git-cliff matches a footer rule on the trailer's *presence*, not its
-  # value, so without this exclusion #1523 -- a CI-only change that correctly declined --
-  # rendered under "Representation changes" in v0.13.1 (#1526).
-  #
-  # That matters as much as the opposite failure. v0.13.0 under-reported (nothing declared,
-  # section empty, disclosure reconstructed by hand from a 5.7M-row corpus diff, #1522);
-  # listing non-changes is the same loss of trust from the other side, and it compounds,
-  # because declining is the COMMON case for changes under those directories.
-  #
-  # Ordering is load-bearing: git-cliff takes the FIRST matching parser, so this exclusion
-  # must precede the inclusion below. `[^\S\r\n]` is horizontal-only whitespace -- `\s`
-  # would span the newline into the next trailer and let `Representation-Change:` followed
-  # by a line reading `none` count as a decline.
-  #
-  # `(?i)` because the checker accepts `NONE`/`None` as declines (its own regex is
-  # case-insensitive); without the flag an uppercase decline is grouped as a real change,
-  # which is this bug in miniature. Verified against git-cliff 2.13.1.
-  #
-  # **The verdict is the first word; a reason may follow it** (#1555). The value used to be
-  # anchored -- `(none|no|n/a|na)$` -- so `none. No file under src/ is touched` was not a
-  # decline and rendered as a real change. That is not a corner case: in the v0.13.1 cycle
-  # 14 of 16 commits declined, 8 of them gave a reason on the same line, and all 8 landed
-  # under "Representation changes". The section listed 10 entries of which 2 were real.
-  #
-  # Explaining a decline is the behaviour to encourage, so the punctuation that introduces
-  # the explanation must not silently invert the verdict. `,` is deliberately NOT a
-  # terminator: a comma most often introduces a qualification that changes the answer
-  # ("none, except two rows"), where a full stop or a dash closes it.
-  #
-  # The decline vocabulary and this terminator set are kept in step with `NONE_VALUES` and
-  # `DECLINE_TERMINATORS` in `scripts/check_representation_change.py` by
-  # `test_decline_vocabulary_matches_the_changelog_config` and
-  # `test_the_two_decline_rules_agree_value_by_value`.
-  #
-  # **`m`, because git-cliff matches this against the whole footer value, which spans
-  # lines** (#1573). Without it `$` is end-of-*string*, so the rule only fires when the
-  # decline is the last thing in the message -- and anything appended after a BARE `none`
-  # defeats it. That is not hypothetical: CodeRabbit appends a release-notes block to the
-  # PR description, GitHub makes the description the squash body, and `3ebcdddd` (#1551)
-  # declined and was then filed under "Representation changes" in the v0.14.0 changelog.
-  # The `[.;:—–]` terminator above does not cover it, because the character following a
-  # bare decline is a newline rather than punctuation.
-  #
-  # With `m` the verdict is read off the trailer's own line, which is what the checker
-  # already does -- its `TRAILER_RE` is `re.IGNORECASE | re.MULTILINE` and takes the value
-  # from one line. The two halves now agree by construction rather than by coincidence.
-  # A reason may still span lines: `[\s\S]*` after a terminator is unchanged, and `,` is
-  # still excluded, so `none, except two rows` remains a real change.
-  { footer = "(?im)^Representation-Change:[^\\S\\r\\n]*(none|no|n/a|na)[^\\S\\r\\n]*(?:[.;:—–][\\s\\S]*)?$", group = "<!-- 7 -->Other" },
-  # A declining commit lands in `Other` whatever its type, so a `fix:` that correctly
-  # declined is not listed under `Fixed` (#1557). That is a known cost of the ordering
-  # above, not an oversight, and the obvious repair does not work: **git-cliff evaluates a
-  # parser's fields as OR, not AND** (measured against 2.13.1). Adding `message = "^fix"`
-  # to this rule matches every `fix:` commit regardless of its trailer -- including the
-  # ones declaring a real move -- which empties the section below. Omitting `group` does
-  # not fall through to a later parser either; the commit keeps `group = None` and
-  # git-cliff falls back to the raw conventional type, rendering headings as `fix`/`test`.
-  #
-  # `(?i)` here too, and not only on the exclusion above: the checker accepts any casing,
-  # so a lowercase `representation-change: 577 rows move` is a REAL disclosure that a
-  # case-sensitive rule drops silently into `Other`. Verified against git-cliff 2.13.1.
+  # `(?i)` on the inclusion rule: the checker accepts any casing, so a lowercase
+  # `representation-change: 577 rows move` is a REAL disclosure that a case-sensitive rule
+  # would drop silently into `Other`. A declining trailer never reaches this rule -- the
+  # preprocessor above has renamed its key -- so this matches only real declarations.
   { footer = "(?i)^Representation-Change:", group = "<!-- 0 -->Representation changes" },
   { message = "^feat", group = "<!-- 1 -->Added" },
   { message = "^changed", group = "<!-- 2 -->Changed" },

--- a/scripts/check_changelog_grouping.py
+++ b/scripts/check_changelog_grouping.py
@@ -142,10 +142,16 @@ def _toml_value(value: object) -> str:
 
 
 def write_cliff_config(changelog: dict[str, Any], destination: Path) -> None:
-    """Write a git-cliff config carrying the real parsers and postprocessors.
+    """Write a git-cliff config carrying the real parsers, preprocessors and postprocessors.
 
     Only the fields that decide *grouping* are copied. The body is this module's own, so
     that the rendered output is a list of commit ids rather than prose.
+
+    `commit_preprocessors` is copied because grouping now depends on it: a declining
+    `Representation-Change:` trailer is neutralized there (its key is renamed) so the commit
+    falls through to its conventional-type group instead of the "Representation changes"
+    section (#1557). Rendering without it would file every decline as a real change and the
+    audit would report a decline in the section it is meant to keep clean.
     """
     lines = ["[changelog]", 'header = ""', "trim = true", f"body = {_toml_value(BODY_TEMPLATE)}"]
     if "postprocessors" in changelog:
@@ -155,8 +161,10 @@ def write_cliff_config(changelog: dict[str, Any], destination: Path) -> None:
         "[git]",
         "conventional_commits = true",
         "filter_unconventional = false",
-        f"commit_parsers = {_toml_value(changelog['commit_parsers'])}",
     ]
+    if "commit_preprocessors" in changelog:
+        lines.append(f"commit_preprocessors = {_toml_value(changelog['commit_preprocessors'])}")
+    lines.append(f"commit_parsers = {_toml_value(changelog['commit_parsers'])}")
     destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/tests/python/test_changelog_grouping.py
+++ b/tests/python/test_changelog_grouping.py
@@ -11,24 +11,32 @@ silently agree with whatever it was handed.
 from __future__ import annotations
 
 import importlib.util
+import os
 import re
+import shutil
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
 
-_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_changelog_grouping.py"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = _REPO_ROOT / "scripts" / "check_changelog_grouping.py"
 _SPEC = importlib.util.spec_from_file_location("check_changelog_grouping", _MODULE_PATH)
 assert _SPEC is not None and _SPEC.loader is not None
 check_changelog_grouping = importlib.util.module_from_spec(_SPEC)
 sys.modules["check_changelog_grouping"] = check_changelog_grouping
 _SPEC.loader.exec_module(check_changelog_grouping)
 
+load_changelog_config = check_changelog_grouping.load_changelog_config
 opens_with_a_decline = check_changelog_grouping.opens_with_a_decline
 parse_rendered_groups = check_changelog_grouping.parse_rendered_groups
+render = check_changelog_grouping.render
 rendered_headings = check_changelog_grouping.rendered_headings
 strip_ordering_prefix = check_changelog_grouping.strip_ordering_prefix
 trailer_value = check_changelog_grouping.trailer_value
+write_cliff_config = check_changelog_grouping.write_cliff_config
 
 
 # ---------------------------------------------------------------------------
@@ -374,3 +382,176 @@ def test_ci_synthesizes_the_squash_commit_before_auditing() -> None:
         "the resolved range must be exported (AUDIT_RANGE -> $GITHUB_ENV) so the audit step "
         "uses it rather than re-deriving it from the reset HEAD"
     )
+
+
+# ---------------------------------------------------------------------------
+# The grouping of a declining `fix:` (#1557), rendered through real git-cliff
+# ---------------------------------------------------------------------------
+#
+# The bug: a commit whose `Representation-Change:` trailer DECLINES (`none`, ...) was filed
+# under **Other** whatever its conventional type, so a `fix:` that correctly declined never
+# reached **Fixed**. git-cliff evaluates a parser's fields as OR (not AND), so the naive
+# `{ footer = <decline>, message = "^fix" }` cannot express "a declining fix"; the fix is a
+# `commit_preprocessor` in `release-plz.toml` that renames a declining trailer's key so the
+# commit falls through to its conventional-type parser. These render the REAL configuration
+# through real git-cliff and assert where each commit lands — the only test that can, because
+# the grouping is git-cliff's, not this script's.
+
+
+_GIT_CLIFF = shutil.which("git-cliff")
+requires_git_cliff = pytest.mark.skipif(
+    _GIT_CLIFF is None,
+    reason="git-cliff is not installed; the grouping is rendered by git-cliff itself",
+)
+
+
+# A hermetic git environment: the throwaway repo must NOT inherit the developer's global
+# config. That config commonly enables commit signing (this repo signs via 1Password), which
+# would prompt or hang on `git commit` in a headless test, and could pull in global hooks. The
+# identity is supplied through env vars so no `git config` step is needed, and signing is
+# forced off. `os.devnull` for the config files isolates global and system config entirely.
+_GIT_ENV = {
+    **os.environ,
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+    "GIT_AUTHOR_NAME": "test",
+    "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_COMMITTER_NAME": "test",
+    "GIT_COMMITTER_EMAIL": "test@example.com",
+}
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True, env=_GIT_ENV
+    ).stdout
+
+
+def _render_real_config(commits: list[str]) -> dict[str, list[str]]:
+    """Build a throwaway repo of `commits`, render it with the real config, return groups.
+
+    Returns `{group name: [commit subject, ...]}` — subjects rather than ids, because a test
+    reads better asserting on `"declining fix"` than on a 40-hex sha. The configuration is
+    `release-plz.toml`'s own `[changelog]`, written out by the audit's `write_cliff_config`,
+    so this exercises exactly what the release will render.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        _git(repo, "init", "-q")
+        # A base commit so the audited range `<base>..HEAD` is a well-formed OID range.
+        _git(repo, "commit", "-q", "--no-gpg-sign", "--allow-empty", "-m", "chore: base")
+        base = _git(repo, "rev-parse", "HEAD").strip()
+        for message in commits:
+            _git(repo, "commit", "-q", "--no-gpg-sign", "--allow-empty", "-m", message)
+
+        config = repo / "cliff.toml"
+        write_cliff_config(load_changelog_config(_REPO_ROOT / "release-plz.toml"), config)
+        rendered = render(f"{base}..HEAD", config, repo)
+
+        subject_of = {
+            line.split(" ", 1)[0]: line.split(" ", 1)[1]
+            for line in _git(repo, "log", "--format=%H %s").strip().splitlines()
+        }
+        groups = parse_rendered_groups(rendered)
+        return {group: [subject_of[i] for i in ids] for group, ids in groups.items()}
+
+
+@requires_git_cliff
+def test_a_declining_fix_is_filed_under_fixed_not_other() -> None:
+    """The #1557 regression: a `fix:` that declined must land under **Fixed**.
+
+    Rendered through the real `release-plz.toml`. Before the fix this subject rendered under
+    **Other**; the assertion is on the group git-cliff actually assigns.
+    """
+    subject = "fix(changelog): a declining fix"
+    groups = _render_real_config(
+        [f"{subject}\n\nBody.\n\nRepresentation-Change: none. Tests only."]
+    )
+    assert subject in groups.get("Fixed", []), groups
+    assert subject not in groups.get("Other", []), groups
+    # And it must NOT be mistaken for a real representation change.
+    assert subject not in groups.get("Representation changes", []), groups
+
+
+@requires_git_cliff
+def test_declines_group_by_type_while_real_changes_group_together() -> None:
+    """The whole routing, in one render: declines by type, real changes into their section.
+
+    Covers the three cases `release-plz.toml` documents, plus the two documented edge forms
+    that read as real changes (`none, except ...` and `no rows move`) so a decline regex that
+    swallowed them — the failure this config's regex is built to avoid — would show up here.
+    """
+    groups = _render_real_config(
+        [
+            "fix(a): declining fix\n\nRepresentation-Change: none. Tests only.",
+            "feat(b): declining feature\n\nRepresentation-Change: none",
+            "fix(c): plain fix, no trailer",
+            "fix(d): a real move\n\nRepresentation-Change: 3 rows move",
+            "fix(e): none-comma is a real change\n\nRepresentation-Change: none, except two rows merge",
+            "fix(f): no-rows-move is real\n\nRepresentation-Change: no rows move",
+            "chore(g): housekeeping",
+        ]
+    )
+    assert set(groups.get("Fixed", [])) == {
+        "fix(a): declining fix",
+        "fix(c): plain fix, no trailer",
+    }, groups
+    assert groups.get("Added", []) == ["feat(b): declining feature"], groups
+    assert set(groups.get("Representation changes", [])) == {
+        "fix(d): a real move",
+        "fix(e): none-comma is a real change",
+        "fix(f): no-rows-move is real",
+    }, groups
+    assert groups.get("Other", []) == ["chore(g): housekeeping"], groups
+
+
+@requires_git_cliff
+def test_declining_commits_are_absent_from_representation_changes() -> None:
+    """A declining trailer must never be filed as a real change (the sibling of #1557).
+
+    The preprocessor and the audit share one decline regex, so this and the audit agree by
+    construction — but this asserts it against the rendered output, not the regex.
+    """
+    groups = _render_real_config(
+        [
+            "fix(a): bare none\n\nRepresentation-Change: none",
+            "fix(b): none dot\n\nRepresentation-Change: none.",
+            "feat(c): NONE upper\n\nRepresentation-Change: NONE",
+            "fix(d): n/a\n\nRepresentation-Change: n/a: docs",
+            "fix(e): dash reason\n\nRepresentation-Change: no — nothing reaches a normalizer",
+        ]
+    )
+    section = groups.get("Representation changes", [])
+    assert section == [], f"declines leaked into Representation changes: {section}"
+
+
+def test_config_carries_the_decline_neutralizing_preprocessor() -> None:
+    """A structural guard: the fix is a `commit_preprocessors` entry, not a parser.
+
+    Rendering (above) skips where git-cliff is absent, e.g. the Python Wheel Test job. This
+    runs everywhere and fails loudly if the preprocessor is dropped or the old
+    route-declines-to-a-fixed-group parser is reintroduced.
+    """
+    changelog = load_changelog_config(_REPO_ROOT / "release-plz.toml")
+    preprocessors = changelog.get("commit_preprocessors", [])
+    assert any(
+        "Representation-Change" in p.get("pattern", "")
+        and "none" in p.get("pattern", "")
+        and "Declined" in (p.get("replace") or "")
+        for p in preprocessors
+    ), f"the decline-neutralizing preprocessor is missing: {preprocessors}"
+    # The default PR-link preprocessor must be reproduced, or the changelog loses every link
+    # (setting commit_preprocessors replaces release-plz's defaults wholesale).
+    assert any(
+        r"(#" in p.get("pattern", "") and "pull/" in (p.get("replace") or "") for p in preprocessors
+    ), f"the PR-link preprocessor is missing, so links would vanish: {preprocessors}"
+    # No parser may route a `Representation-Change` footer to a fixed non-section group —
+    # that is the pre-#1557 shape that buried a declining `fix:` under Other.
+    for parser in changelog.get("commit_parsers", []):
+        footer = parser.get("footer", "")
+        if "Representation-Change" in footer:
+            assert parser.get("group", "").endswith("Representation changes"), (
+                f"a footer parser routes a Representation-Change trailer to {parser.get('group')!r}; "
+                "declines are handled by the preprocessor now, so the only footer parser must be "
+                "the inclusion rule (#1557)"
+            )

--- a/tests/python/test_representation_change_trailer.py
+++ b/tests/python/test_representation_change_trailer.py
@@ -35,6 +35,43 @@ find_trailers_as_git_cliff_would = check_representation_change.find_trailers_as_
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _read_config() -> str:
+    return (_REPO_ROOT / "release-plz.toml").read_text(encoding="utf-8")
+
+
+def _decline_preprocessor_pattern() -> str:
+    """Return `release-plz.toml`'s declining-trailer regex, ready to `re.compile`.
+
+    #1557 moved this rule from a `{ footer = ..., group = "Other" }` parser to a
+    `{ pattern = ..., replace = "Representation-Change-Declined:..." }` commit_preprocessor:
+    a declining trailer's key is now renamed *before* grouping, so the commit falls through
+    to its conventional-type parser (a declining `fix:` -> Fixed) instead of being routed to
+    `Other`. As a *search* regex the pattern classifies declines exactly as the old footer
+    rule did, which is why the parity tests below still compile and run it.
+    """
+    rules = re.findall(
+        r'\{ pattern = "([^"]*Representation-Change[^"]*)", '
+        r'replace = "Representation-Change-Declined',
+        _read_config(),
+    )
+    assert rules, "no declining-trailer commit_preprocessor found in release-plz.toml"
+    # A TOML basic string escapes its backslashes; undo that to recover the regex source.
+    return rules[0].replace("\\\\", "\\")
+
+
+def _inclusion_footer_rule() -> str:
+    """Return the sole footer parser — the inclusion rule for real declarations (#1557).
+
+    After #1557 the only footer parser is the inclusion rule; declines are handled by the
+    preprocessor above, so a second footer parser would be the pre-#1557 shape returning.
+    """
+    rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', _read_config())
+    assert len(rules) == 1, (
+        f"expected exactly one Representation-Change footer parser, found {rules}"
+    )
+    return rules[0]
+
+
 # ---------------------------------------------------------------------------
 # The two states the whole check exists to separate
 # ---------------------------------------------------------------------------
@@ -302,22 +339,21 @@ _TWO_TRAILERS = (
 
 
 def test_two_trailers_are_refused() -> None:
-    """Neither half of the machinery can resolve two trailers the same way, so refuse.
+    """Two trailers cannot be resolved unambiguously, so refuse.
 
-    Measured against git-cliff 2.13.1 with the real config: this message groups under
-    **Other**, because git-cliff matches its footer rule against *every* footer and takes
-    the first rule that matches any of them, so a decline wins wherever it sits. This
-    checker reads the *first* trailer and calls the same message a real disclosure. The
-    commit then passes CI as a disclosure and is filed as a decline, and the disclosure
-    disappears from the changelog — the under-reporting direction of #1522, one commit at
-    a time.
+    This checker reads the *first* trailer and calls this message a real disclosure. What
+    git-cliff does with the second one depends on the config and has moved: before #1557 a
+    declining footer routed the whole commit to **Other** (a decline won wherever it sat),
+    so the checker and the changelog disagreed outright — the under-reporting direction of
+    #1522. Since #1557 the declining trailer's key is neutralized by a `commit_preprocessor`
+    and the surviving real footer groups the commit under **Representation changes**
+    (measured against git-cliff 2.13.1 with the real config), so the two now happen to
+    agree on *this* ordering.
 
-    It is not an anchoring bug and #1573's `m` does not reach it: the shape reproduces
-    identically under `(?i)`, `(?im)` and `(?im)\\A`, because the second line is parsed as
-    its own footer and the rule matches at *that* footer's start.
-
-    Refusing rather than picking a winner keeps the rule that a decline must be *stated*,
-    never inferred from a message that also says the opposite.
+    That agreement is coincidental and order-dependent, which is the reason to refuse rather
+    than lean on it: a corrected trailer appended below a superseded one leaves the checker
+    reading the stale first line while the changelog keys on whichever footer survives. A
+    decline must be *stated*, never inferred from a message that also says the opposite.
     """
     ok, message = check(["src/normalize/merge.rs"], _TWO_TRAILERS)
     assert not ok, "two trailers must not pass; the changelog and this check disagree on them"
@@ -347,9 +383,9 @@ def test_an_indented_second_trailer_is_a_continuation_not_a_second_trailer() -> 
     """The escape hatch the refusal message names must actually work.
 
     Indenting makes the line a continuation of the value above it, which is also how
-    git-cliff sees it — measured, the indented form groups under **Representation
-    changes** where the column-0 form groups under **Other**. So the fix the message
-    recommends is the one that makes both halves agree.
+    git-cliff sees it, so only the real disclosure is read and the commit groups under
+    **Representation changes**. So the fix the message recommends is the one that leaves a
+    single, unambiguous trailer for both halves to read.
     """
     body = (
         "Representation-Change: 577 rows move, 360 merge.\n"
@@ -456,7 +492,7 @@ def test_both_streams_on_stdin_is_rejected() -> None:
 
 
 def test_decline_vocabulary_matches_the_changelog_config() -> None:
-    """`release-plz.toml`'s exclusion rule and `NONE_VALUES` must accept the same words.
+    """`release-plz.toml`'s decline rule and `NONE_VALUES` must accept the same words.
 
     They are two halves of one decision and they drift silently. If the checker accepts a
     decline the changelog rule does not, that PR passes CI and then renders under
@@ -464,16 +500,13 @@ def test_decline_vocabulary_matches_the_changelog_config() -> None:
     was written for. If the changelog excludes a word the checker rejects, a contributor
     is told to declare something the changelog then hides.
     """
-    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
-    # `[a-z]*i[a-z]*` rather than `[a-z]+`: the flag group gained `m` in #1573, so matching
-    # `(?i)` literally would read as a rename -- but dropping the `i` requirement entirely
-    # would let this find a case-*sensitive* rule while asserting it found the opposite.
-    match = re.search(
-        r'footer = "\(\?[a-z]*i[a-z]*\)\^Representation-Change:[^"]*?\(([^)]+)\)', config
-    )
+    regex = _decline_preprocessor_pattern()
+    # The vocabulary is the first non-capturing group `(?:none|no|n/a|na)`; the enclosing
+    # capture group holds the whole value for the rename's `${1}`, and the leading `(?im)`
+    # flag group is `(?im)` not `(?:`, so the first `(?:...)` found is the vocabulary.
+    match = re.search(r"\(\?:([^)]+)\)", regex)
     assert match is not None, (
-        "no case-insensitive Representation-Change exclusion rule found in release-plz.toml; "
-        "the decline vocabulary cannot be checked"
+        "no decline vocabulary group in the preprocessor pattern; the vocabulary cannot be checked"
     )
     configured = frozenset(match.group(1).split("|"))
     assert configured == check_representation_change.NONE_VALUES, (
@@ -806,18 +839,12 @@ def test_the_two_decline_rules_agree_value_by_value() -> None:
     rendered as a representation change. A word-list comparison cannot see that; only
     running both rules over the same values can.
     """
-    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
-    # Anchored on the trailer name, not on `{ footer = "`: the first such literal in the file
-    # is git-cliff's `^changelog: ?ignore` example, quoted in a comment.
-    rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', config)
-    assert rules, "no Representation-Change exclusion rule found in release-plz.toml"
-    # The rule is a TOML basic string, so its backslashes are escaped in the file.
-    #
-    # Compiled with NO flags of our own: whatever the rule needs it must declare inline,
-    # because git-cliff adds none either. Passing `re.MULTILINE` here -- as this test did
-    # until #1573 -- makes the harness kinder than production and hides exactly the class
-    # of anchoring bug it exists to catch.
-    changelog_rule = re.compile(rules[0].replace("\\\\", "\\"))
+    # The rule is a TOML basic string, so its backslashes are escaped in the file; the
+    # helper undoes that. Compiled with NO flags of our own: whatever the rule needs it must
+    # declare inline, because git-cliff adds none either. Passing `re.MULTILINE` here -- as
+    # this test did until #1573 -- makes the harness kinder than production and hides exactly
+    # the class of anchoring bug it exists to catch.
+    changelog_rule = re.compile(_decline_preprocessor_pattern())
 
     values = [
         "none",
@@ -905,11 +932,8 @@ def test_a_trailer_keeps_its_verdict_when_text_is_appended_after_it(
     Every other guard in this file inspects the config as a *string* — vocabulary, casing,
     ordering — and all of them passed throughout the bug, because anchoring is a behaviour.
     """
-    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
-    rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', config)
-    assert rules, "no Representation-Change exclusion rule found in release-plz.toml"
     # No flags of our own: git-cliff supplies none, so the rule must declare what it needs.
-    changelog_rule = re.compile(rules[0].replace("\\\\", "\\"))
+    changelog_rule = re.compile(_decline_preprocessor_pattern())
 
     footer = f"Representation-Change: {value}{_APPENDED_BLOCK}"
     assert (changelog_rule.search(footer) is not None) == is_a_decline, (
@@ -952,12 +976,15 @@ def test_the_ordering_prefix_is_stripped_from_rendered_headings() -> None:
 
 
 def test_both_representation_change_rules_are_case_insensitive() -> None:
-    """A case-sensitive *inclusion* rule drops a lowercase `representation-change:` — a real
-    disclosure — silently into `Other`, since the checker accepts any casing."""
-    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
-    rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', config)
-    assert len(rules) == 2, f"expected an exclusion and an inclusion rule, found {rules}"
-    for rule in rules:
+    """Both rules must be case-insensitive, since the checker accepts any casing.
+
+    A case-sensitive *inclusion* rule drops a lowercase `representation-change:` — a real
+    disclosure — silently into `Other`; a case-sensitive *decline preprocessor* leaves an
+    uppercase `NONE` untouched, so it reaches the inclusion rule and is filed as a real
+    change. The two rules are now the inclusion footer parser and the decline preprocessor
+    (#1557).
+    """
+    for rule in (_inclusion_footer_rule(), _decline_preprocessor_pattern()):
         # Read the inline flag group rather than matching `(?i)` literally, so that adding
         # another flag -- `m`, in #1573 -- does not read as "the rule became case-sensitive".
         flags = re.match(r"\(\?([a-z]+)\)", rule)
@@ -1212,25 +1239,31 @@ def test_the_1838_body_is_refused_by_the_check_it_slipped_past() -> None:
     assert "`Representation-Change: none`" in message
 
 
-def test_the_decline_exclusion_precedes_the_inclusion() -> None:
-    """git-cliff takes the FIRST matching parser, so swapping these two lines silently
-    restores #1526 in full.
+def test_a_decline_is_neutralized_before_the_parsers_and_inclusion_leads_them() -> None:
+    """The two ordering facts the #1557 design rests on.
 
-    Verified against git-cliff 2.13.1 rather than assumed: with the exclusion second, all
-    four trailers -- `none`, `NONE`, and both real disclosures -- group under
-    **Representation changes**. Every other guard in this file still passes in that state,
-    which is why the ordering needs one of its own.
+    1. A decline is handled by a `commit_preprocessor`, which git-cliff always applies before
+       any parser — so a declining trailer never reaches the inclusion footer rule, and the
+       commit falls through to its conventional-type parser (a declining `fix:` -> Fixed).
+       If that preprocessor were dropped, every decline would match the inclusion rule and be
+       filed under **Representation changes** — #1526 in full.
+    2. The inclusion footer rule must precede the `message = "^fix"` type parser, or a `fix:`
+       carrying a REAL declaration would match `^fix` first and land under **Fixed** instead
+       of **Representation changes**. git-cliff takes the first matching parser.
     """
-    config = (Path(__file__).resolve().parents[2] / "release-plz.toml").read_text(encoding="utf-8")
-    rules = re.findall(r'\{ footer = "([^"]*Representation-Change[^"]*)"', config)
-    assert len(rules) == 2, f"expected an exclusion and an inclusion rule, found {rules}"
-    exclusion, inclusion = rules
-    assert any(word in exclusion for word in check_representation_change.NONE_VALUES), (
-        f"the first Representation-Change rule is {exclusion!r}, which does not name a decline "
-        "value; the exclusion must come first or every decline is grouped as a real change"
+    config = _read_config()
+    # 1. The decline preprocessor exists (the helper asserts it) and names decline words.
+    decline = _decline_preprocessor_pattern()
+    assert any(word in decline for word in check_representation_change.NONE_VALUES), (
+        f"the decline preprocessor {decline!r} names no decline value; without it every "
+        "decline is grouped as a real change"
     )
-    assert not any(word in inclusion for word in check_representation_change.NONE_VALUES), (
-        f"the second rule is {inclusion!r}, which looks like the exclusion -- the two are reversed"
+    # 2. The inclusion footer rule precedes the type parsers.
+    inclusion_at = config.index('{ footer = "')
+    fix_parser_at = config.index('{ message = "^fix"')
+    assert inclusion_at < fix_parser_at, (
+        "the Representation-Change inclusion rule must come before the `^fix` type parser, or "
+        "a declaring `fix:` is filed under Fixed instead of Representation changes"
     )
 
 


### PR DESCRIPTION
Closes #1557.

## Problem

A commit carrying a declining `Representation-Change: none` trailer was filed under **Other** regardless of its conventional type, so a `fix:` that correctly declined never appeared under **Fixed**. In v0.13.1, #1533 (`fix(spec-fixture)`) and #1527 (`fix(changelog)`) landed under Other rather than Fixed.

This was a side effect of #1527's decline-exclusion parser: git-cliff assigns exactly one group and takes the first matching parser, so "not a representation change" was spelled as "route to Other". As #1557 documents, the direct repairs all fail (measured against git-cliff 2.13.1):

- `{ footer = <decline>, message = "^fix", group = "Fixed" }` — git-cliff evaluates a parser's fields as **OR, not AND**, so this matches every `fix:` regardless of its trailer, emptying the Representation changes section.
- Omitting `group` does not fall through — the commit falls back to the raw conventional type (`fix`/`test`), losing group ordering.
- A negative footer regex needs a lookahead the `regex` crate does not have (and the enumerated complement is broken by the `no` ⊂ `none` prefix overlap: `none.` gets misread as a real change).

## Fix

A `commit_preprocessor` in `release-plz.toml` renames the trailer **key** on declining commits only, before the parsers run: `Representation-Change:` → `Representation-Change-Declined:`. The inclusion parser's literal `:` no longer matches, so a declining commit falls through to its conventional-type parser (a declining `fix:` → Fixed). Real declarations keep their key and are grouped into Representation changes exactly as before.

The rename touches the footer, never the subject, so no rendered bullet changes and no strip postprocessor is needed; `scripts/inject_representation_disclosure.py` reads the raw commit message, so a decline's own text is untouched there too. The decline regex is the exact one `scripts/check_changelog_grouping.py` audits with, so the audit and the config agree on which commits decline by construction.

Setting `commit_preprocessors` replaces release-plz's defaults wholesale, so its only default — the `(#N)` → PR-link rewrite — is reproduced as the second entry, or the changelog would lose every PR link.

## Tests

- `check_changelog_grouping.py`'s `write_cliff_config` now copies `commit_preprocessors` (grouping depends on it), so the audit renders with the neutralizer.
- New end-to-end tests in `tests/python/test_changelog_grouping.py` build throwaway repos and render through the real `release-plz.toml` with real git-cliff, asserting a declining `fix:` lands under Fixed, a declining `feat:` under Added, and real declarations under Representation changes (including the documented edge forms `none, except ...` and `no rows move`). They run in the `Changelog grouping audit` CI job, which has git-cliff, and a structural guard runs everywhere.
- The config-reading parity tests in `test_representation_change_trailer.py` are updated to the new preprocessor location.

Verified the guard fails when the preprocessor is removed (sabotage check).

Representation-Change: none. Changelog tooling only; no watched source directory (`src/normalize|hgvs|spdi|project|reference|error_handling`) is touched.
