### PR TITLE
docs(normalize): name the actual test in the 5' junction guard comment

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -11377,7 +11377,7 @@ pub(crate) fn clamp_sibling_crossing_shifts<P: ReferenceProvider>(
             // a `commutes` escape hatch this bound would otherwise override.
             //
             // Guarded by `cis_junction_crossing_shift.rs`'s
-            // `a_third_member_past_the_derivation_window_keeps_the_duplication_reaching_its_five_prime_most_position`
+            // `a_third_member_clear_of_the_tract_keeps_the_duplication_reaching_its_five_prime_most_position`
             // (#1603), and it takes a deliberately-built shape: the whole
             // over-clamp is sequence-preserving, so neither exhaustive sweep nor
             // any seam oracle can see it, and the allele has to be one the


### PR DESCRIPTION
Closes #1603.

## What #1603 asked, and what already answered it

Issue #1603 is that the 5' junction barrier in `clamp_sibling_crossing_shifts` carries a `.filter(|_| a.junction.is_none())` whose only guard was a test that stopped the sequence-first derivation *by distance* — so removing the input-relative weight bound (the ruling `derivation-may-not-be-bounded-by-the-inputs-spelling`, "DELETE THE BOUND") would silently take the guard away, since the same distant-third-member allele then merges and the guard row goes vacuous.

That substance was already resolved on `main` by **PR #2039** ("re-arm the cis guards #1835 made vacuous"). The guard now runs on a **structural** window-refusal fixture: a third member placed past `MAX_CANONICAL_WINDOW` (4096) refuses the window *before any alignment runs*, so the per-member pipeline (where `clamp_sibling_crossing_shifts` lives) decides the output, and nothing about that refusal can be undone by a better alignment or by removing the weight bound. The guard is `cis_junction_crossing_shift::a_third_member_clear_of_the_tract_keeps_the_duplication_reaching_its_five_prime_most_position`.

## The one thing #2039 left behind

#2039 renamed that test but left the `// Guarded by ...` comment in `clamp_sibling_crossing_shifts` pointing at the **old** name, `a_third_member_past_the_derivation_window_...`, which resolves nowhere in the tree. This PR points the comment at the real test so the guard's provenance stays traceable, and closes #1603 now that its substance is settled.

## Verification

The guard is genuinely armed and weight-bound-independent — verified by mutation on this branch:

- as-is: the guard **passes**.
- delete `.filter(|_| a.junction.is_none())` from the 5' branch of `clamp_sibling_crossing_shifts`: the guard goes **RED** (`5_6dup` stranded instead of reaching `4_5dup`), then restored byte-for-byte. The fixture's third member sits at position 4300, past `MAX_CANONICAL_WINDOW`, so the decline is structural rather than weight-driven.

Full local gate green: `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo nextest run --features dev --no-fail-fast` (11321 passed), and `scripts/run_oracle_suite.sh` (11152 passed).

Representation-Change: none. The diff is a single code comment; it compiles away and touches no code path, so no normalized output can move.