### PR TITLE
ci: run the census-instrument tests off the censuses job, not the Test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ env:
   CENSUS_FILTER: >-
     test(issue_1542_direction_symmetry) + test(normalize_axis_preserving)
     + test(spec_conformance_axis) + test(clinvar_hgvs_tests)
+    + test(conformance_census_runs)
 
   # Negated from `test` ONLY. These run in `test-oracle` with the three seam
   # oracles armed, and an armed run strictly subsumes an un-armed one — the
@@ -273,6 +274,7 @@ env:
     + test(defect_non_idempotent_outputs)
     + test(issue_1715_rna_alignment_symbol_reach)
     + test(conformance_census_instrument)
+    + test(conformance_census_runs)
 
 # Every job carries a `timeout-minutes`. Without one a job inherits GitHub's
 # 360-minute default, so a wedged runner holds a PR for six hours: observed on
@@ -2045,14 +2047,16 @@ jobs:
           scripts/run_nextest_archive.sh --archive-file nextest-soak.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite --no-tests=fail \
             -E "test(issue_1542_direction_symmetry) + test(normalize_axis_preserving) + test(clinvar_hgvs_tests)"
-      - name: Run the census that may not be measured with an oracle armed
-        # No `FERRO_ASSERT_*` here, deliberately, and no bulk fixtures: this
-        # module builds its corpus in code (`conformance::spec_corpus`) and
-        # reads nothing from disk.
+      - name: Run the censuses that may not be measured with an oracle armed
+        # No `FERRO_ASSERT_*` here, deliberately, and no bulk fixtures: these
+        # modules build their corpus in code (`conformance::spec_corpus`) and
+        # read nothing from disk. `conformance_census_runs` (#2094) joins
+        # `spec_conformance_axis` here because `run_census` refuses outright
+        # with a seam oracle armed, which would fail the armed step below.
         run: |
           scripts/run_nextest_archive.sh --archive-file nextest-soak.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite --no-tests=fail \
-            -E "test(spec_conformance_axis)"
+            -E "test(spec_conformance_axis) + test(conformance_census_runs)"
 
   # The generated-doc `--check` gates. Split out of the old monolithic Test job
   # so they no longer sit behind the whole suite on the critical path.

--- a/tests-soak/tests/soak/main.rs
+++ b/tests-soak/tests/soak/main.rs
@@ -160,6 +160,12 @@ mod issue_1542_direction_symmetry;
 mod normalize_axis_preserving;
 #[path = "../../../tests/it/spec_conformance_axis.rs"]
 mod spec_conformance_axis;
+// The run-backed census instrument tests (#2094), carved out of
+// `conformance_census_instrument` so the `censuses` job owns them instead of the
+// `Test` shards. Selected by the job's UN-armed step, beside `spec_conformance_axis`
+// and for the same reason: `run_census` refuses with a seam oracle armed.
+#[path = "../../../tests/it/conformance_census_runs.rs"]
+mod conformance_census_runs;
 // A parser benchmark rather than a normalization census — it never reaches
 // `canonicalize_from_sequence` — which is exactly why it belongs here: its cost
 // is a constant factor on gzip decode, JSON deserialization and `parse_hgvs`,

--- a/tests/it/conformance_census_instrument.rs
+++ b/tests/it/conformance_census_instrument.rs
@@ -12,31 +12,36 @@
 //! that the two agree is unnecessary: the gate's own `assert_eq!(census, pinned)`
 //! is that cross-check.
 //!
-//! Each full census run normalizes the whole corpus (~seconds), so the tests that
-//! need a real run are kept few and the properties that are pure — the burn-down
-//! classification and the seam-oracle prefix rule — are tested against hand-built
-//! inputs so they cost nothing and do not race the process environment.
+//! Each full census run normalizes the whole corpus, which costs tens of seconds
+//! to minutes rather than the milliseconds a pure test costs — so the tests that
+//! need a real run live in the carved-out sibling `conformance_census_runs`
+//! (#2094), which `ci.yml`'s `CENSUS_FILTER` moves off the `Test` shards and onto
+//! the `censuses` job. **This** module keeps the properties that are pure — the
+//! burn-down classification and the seam-oracle prefix rule — tested against
+//! hand-built inputs so they cost nothing and do not race the process
+//! environment, plus the one refusal test below.
 //!
 //! The one property that needs a real *process* rather than a real run is the
 //! seam-oracle **refusal**, since the thing that can be wrong is reading the live
 //! environment. It gets a subprocess with a controlled environment, which costs a
 //! process start and not a census — the refusal happens before any measurement,
-//! and the test asserts that too.
+//! and the test asserts that too. It stays here rather than in
+//! `conformance_census_runs` because it is `#[cfg(feature = "benchmark")]` and
+//! needs the `ferro-benchmark` binary, which the soak driver the `censuses` job
+//! runs off does not build — so it must stay in the `Test` shards.
 //!
 //! This module is named in `ci.yml`'s `ORACLE_EXCLUDE` for the same reason
-//! `spec_conformance_axis` is: it measures the census, and an armed oracle makes a
-//! census read better than the truth. Since the refusal moved inside `run_census`
-//! it would simply be red there instead, which is the louder half of the same
-//! fact.
+//! `conformance_census_runs` and `spec_conformance_axis` are: it consumes
+//! `conformance::census`, and an armed oracle makes a census read better than the
+//! truth. Since the refusal moved inside `run_census` it would simply be red there
+//! instead, which is the louder half of the same fact.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use ferro_hgvs::conformance::census::{
-    compare_reports, oracle_armed, run_census, Census, CensusReport, CorpusShape, CorpusSource,
-    DirectionOfVirtue, Equivalence, Movement,
+    compare_reports, oracle_armed, Census, CensusReport, CorpusShape, DirectionOfVirtue, Movement,
 };
 use ferro_hgvs::conformance::completeness::CaptureCounts;
-use ferro_hgvs::ShuffleDirection;
 
 /// A hand-built report for the pure tests, so they neither run a full census nor
 /// touch the environment.
@@ -56,241 +61,6 @@ fn synthetic_report(census: Census) -> CensusReport {
         census,
         confluence_unkeyable_outputs: 0,
     }
-}
-
-/// The instrument produces a machine-readable report whose corpus completeness is
-/// accounted, whose confluence decision under a real relation flags the outputs it
-/// could not key, and which round-trips through JSON.
-///
-/// The `CaptureCounts` stamped beside the census is the discipline from
-/// `CLAUDE.md`'s "a generator must account for what it dropped": `attempted ==
-/// succeeded + dropped`, and the corpus really does drop designs, so `dropped` is
-/// positive and every drop carries a reason. SPDI has no offset notation, so the
-/// corpus's intronic outputs have no `sequence` key — a family carrying one cannot
-/// be certified converged, so it is `underdetermined` and the unkeyable output is
-/// counted rather than swept into a bucket.
-#[test]
-fn a_spec_census_run_is_accounted_and_flags_unkeyable_outputs() {
-    let run = run_census(
-        CorpusSource::Spec,
-        ShuffleDirection::ThreePrime,
-        Equivalence::Sequence,
-    )
-    .expect("the hermetic spec census runs with no reference");
-    let report = &run.report;
-
-    assert_eq!(report.corpus, "spec");
-    assert_eq!(report.direction, "3prime");
-    assert_eq!(report.equivalence, "sequence");
-
-    // The corpus shape travels beside the census (the #1460 hazard), and a zero
-    // would be a claim about the corpus, so the denominators are non-zero.
-    assert!(report.shape.rows > 0, "VACUOUS: the corpus built no rows");
-    assert!(report.shape.family_rows > 0, "VACUOUS: no family rows");
-    assert!(
-        report.census.outputs > 0,
-        "VACUOUS: no outputs were produced"
-    );
-
-    // Completeness is a claim carried in the artifact, and it is self-consistent.
-    assert!(
-        report.capture.is_self_consistent(),
-        "the capture counts do not add up: {:?}",
-        report.capture
-    );
-    assert_eq!(
-        report.capture.succeeded, report.shape.rows,
-        "every surviving row must be a captured success"
-    );
-    assert!(
-        report.capture.dropped > 0,
-        "the corpus drops designs by construction, so a zero drop count means the ledger \
-         was not actually routing the population"
-    );
-    assert!(
-        !report.capture.dropped_by_reason.is_empty(),
-        "a drop with no reason is exactly the silent drop the ledger exists to prevent"
-    );
-
-    // The allowance is a CEILING, not decoration. It was `at_most(attempted)`,
-    // which with `empty_pass_permitted: false` refuses exactly one thing — a run
-    // that attempted nothing — so every drop count from 0 to 100% passed while the
-    // command's docs called a drop past the allowance a refusal. A bound that
-    // cannot be exceeded is a bound nobody is standing behind.
-    let allowance = report
-        .capture
-        .allowance
-        .as_ref()
-        .expect("the run declares the allowance it accepted its shortfall under");
-    assert!(
-        allowance.max_dropped < report.capture.attempted,
-        "an allowance of {} against {} attempted designs permits dropping EVERYTHING, so it \
-         refuses nothing a run could actually do",
-        allowance.max_dropped,
-        report.capture.attempted
-    );
-    assert!(
-        report.capture.dropped <= allowance.max_dropped,
-        "the corpus dropped {} of {} designs, past its own ceiling of {} — either the corpus \
-         changed shape or the ceiling is wrong; both need a person",
-        report.capture.dropped,
-        report.capture.attempted,
-        allowance.max_dropped
-    );
-
-    // A real relation cannot key every output, and the unkeyable ones are counted
-    // rather than folded into a converged family.
-    assert!(
-        report.confluence_unkeyable_outputs > 0,
-        "the corpus produces intronic outputs SPDI cannot key, so a real relation must report \
-         some unkeyable outputs; zero means they were silently swept into a bucket"
-    );
-    assert!(
-        report.census.underdetermined > 0,
-        "families carrying an unkeyable output cannot be certified converged, so some must be \
-         undecided"
-    );
-
-    // Every family lands in exactly one confluence bucket — nothing is lost.
-    let census = &report.census;
-    assert_eq!(
-        census.converged
-            + census.split_two
-            + census.split_three
-            + census.split_more
-            + census.underdetermined,
-        report.shape.family_rows,
-        "the confluence buckets must partition the family rows"
-    );
-
-    // The artifact round-trips, which is the whole point of a machine-readable
-    // report: a consumer stores it and diffs a later one.
-    let json = serde_json::to_string(report).expect("serializes");
-    let back: CensusReport = serde_json::from_str(&json).expect("deserializes");
-    assert_eq!(*report, back);
-}
-
-/// The summary's divergence cap, restated here as the *vacuity floor* the test
-/// below needs rather than as a value under test.
-///
-/// It is deliberately not imported: `MAX_DIVERGENCES` is private to the library,
-/// and the assertion it guards is "the export is not capped", which needs only
-/// *some* number the corpus is known to exceed. If the summary's cap ever rises
-/// above this, the worst outcome is that the vacuity guard is looser than it could
-/// be — never that a truncated export passes, because the export is compared
-/// against the census's own bucket counts and not against this literal.
-const MAX_SUMMARY_DIVERGENCES: usize = 12;
-
-/// **Every** divergent family reaches the export, not the first twelve.
-///
-/// This is the property `--findings` rests on. The cap was sized for a panic
-/// message and was carried into a machine-readable export, so two releases' files
-/// held the same corpus-order-first twelve however many families moved behind
-/// them, and #1891's release-to-release diff read "no change" on a release in
-/// which hundreds changed.
-///
-/// Measured under `partition` deliberately, and that choice is the whole test:
-/// `sequence` finds **2** divergent families on this corpus, which is under the
-/// cap, so the same assertions there would pass whether or not the export
-/// truncates — a green test proving nothing. The vacuity guard below is what
-/// stops that happening silently again if the corpus changes shape.
-///
-/// It costs one more full census run than the module strictly needs. That is the
-/// price of asserting a completeness property against a population large enough
-/// for completeness to mean anything.
-#[test]
-fn every_divergent_family_reaches_the_export() {
-    let run = run_census(
-        CorpusSource::Spec,
-        ShuffleDirection::ThreePrime,
-        Equivalence::Partition,
-    )
-    .expect("the hermetic spec census runs with no reference");
-
-    // The three split buckets ARE the divergent families, so this is not a
-    // restated literal — it is the same fact read off the census.
-    let census = &run.report.census;
-    let divergent = census.split_two + census.split_three + census.split_more;
-    assert!(
-        divergent > MAX_SUMMARY_DIVERGENCES,
-        "VACUOUS: the corpus produced only {divergent} divergent families under `partition`, \
-         at or under the summary's cap of {MAX_SUMMARY_DIVERGENCES} — so this test cannot \
-         tell a complete export from a truncated one and is not checking what it claims"
-    );
-    assert_eq!(
-        run.measured.divergences.len(),
-        divergent,
-        "the export must carry EVERY divergent family, not the first \
-         {MAX_SUMMARY_DIVERGENCES}: a consumer diffing two releases' findings files cannot \
-         tell a truncated file from a complete one"
-    );
-
-    let ids: BTreeSet<&str> = run
-        .measured
-        .divergences
-        .iter()
-        .map(|d| d.id.as_str())
-        .collect();
-    assert_eq!(
-        ids.len(),
-        run.measured.divergences.len(),
-        "a family must be exported once"
-    );
-    assert!(
-        run.measured.divergences.iter().all(|d| d.outputs.len() > 1),
-        "a family with one output is not divergent and must not be exported as one"
-    );
-}
-
-/// A looser relation can only converge MORE families than a stricter one — never
-/// fewer.
-///
-/// `sequence` (same bases) is looser than `partition` (same bases AND same member
-/// partition), so under `sequence` at least as many families reach one bucket.
-/// This is the property that makes "confluence under relation R" meaningful; if it
-/// failed, the relations would not be ordered by strictness.
-#[test]
-fn a_looser_relation_converges_at_least_as_many_families() {
-    let sequence = CensusReport::build(
-        CorpusSource::Spec,
-        ShuffleDirection::ThreePrime,
-        Equivalence::Sequence,
-    )
-    .expect("sequence census runs");
-    let partition = CensusReport::build(
-        CorpusSource::Spec,
-        ShuffleDirection::ThreePrime,
-        Equivalence::Partition,
-    )
-    .expect("partition census runs");
-
-    assert!(
-        sequence.census.converged >= partition.census.converged,
-        "sequence (looser) converged {} families but partition (stricter) converged {} — \
-         a looser relation cannot converge fewer",
-        sequence.census.converged,
-        partition.census.converged,
-    );
-}
-
-/// The `spdi` relation runs end-to-end and its report round-trips. Its member-key
-/// grouping is the one the issue names as already having a backbone
-/// (`group_by_spdi_key`), so it is exercised over the real corpus rather than only
-/// in the ordering test.
-#[test]
-fn the_spdi_relation_runs_and_round_trips() {
-    let report = CensusReport::build(
-        CorpusSource::Spec,
-        ShuffleDirection::ThreePrime,
-        Equivalence::Spdi,
-    )
-    .expect("spdi census runs");
-    assert_eq!(report.equivalence, "spdi");
-    assert!(report.census.outputs > 0, "VACUOUS: no outputs");
-
-    let json = serde_json::to_string(&report).expect("serializes");
-    let back: CensusReport = serde_json::from_str(&json).expect("deserializes");
-    assert_eq!(report, back);
 }
 
 /// The **prefix rule** [`oracle_armed`] applies, over hand-written key lists.

--- a/tests/it/conformance_census_runs.rs
+++ b/tests/it/conformance_census_runs.rs
@@ -1,0 +1,269 @@
+//! The conformance census's **run-backed** properties (#2063, carved out #2094).
+//!
+//! These are the tests from `conformance_census_instrument` that need a *real*
+//! census run — each one normalizes the whole spec corpus, which costs tens of
+//! seconds to minutes rather than the milliseconds a pure test costs. They live
+//! in their own file so the census carve-out can address them by module name:
+//! `ci.yml`'s `CENSUS_FILTER` negates this module from the `test` / `test-oracle`
+//! shards and the `censuses` job runs it off the optimized archive, exactly as it
+//! already does for `spec_conformance_axis` and the other census modules. The
+//! pure and subprocess tests stay in `conformance_census_instrument`, which is
+//! cheap and stays in the shards — and which keeps the `#[cfg(feature =
+//! "benchmark")]` refusal test with the `ferro-benchmark` binary it needs, a
+//! binary the soak driver does not build.
+//!
+//! **Why the split, and why it is a move rather than an optimization (#2094).**
+//! Before the carve-out both 60s+ census tests hashed into one `Test` shard, and
+//! that shard ran 277s while its other 1,885 tests finished in ~72s — three
+//! quarters of the shard's wall was two tests. `--partition hash:K/N` balances
+//! shard *counts* and is blind to cost, so re-sharding cannot fix it; a shard's
+//! wall can never fall below its slowest single test. Moving the run-backed tests
+//! to the job that owns the census does. The tests are otherwise unchanged: they
+//! call `run_census` / `CensusReport::build` directly, as they always did.
+//! Deduplicating the censuses across tests was tried and dropped — nextest runs
+//! each test in its own process, so a shared `LazyLock` would never be reused, and
+//! `a_looser_relation_converges_at_least_as_many_families` genuinely needs both a
+//! `sequence` and a `partition` census in one process regardless.
+//!
+//! This module is named in `ci.yml`'s `ORACLE_EXCLUDE` for the same reason
+//! `conformance_census_instrument` and `spec_conformance_axis` are: it measures
+//! the census, and an armed seam oracle makes a census read better than the truth
+//! (a panicking row contributes no output, so its family silently converges).
+//! Since the refusal moved inside `run_census` it would be a red `OracleArmed`
+//! error here instead, which is the louder half of the same fact.
+
+use std::collections::BTreeSet;
+
+use ferro_hgvs::conformance::census::{run_census, CensusReport, CorpusSource, Equivalence};
+use ferro_hgvs::ShuffleDirection;
+
+/// The instrument produces a machine-readable report whose corpus completeness is
+/// accounted, whose confluence decision under a real relation flags the outputs it
+/// could not key, and which round-trips through JSON.
+///
+/// The `CaptureCounts` stamped beside the census is the discipline from
+/// `CLAUDE.md`'s "a generator must account for what it dropped": `attempted ==
+/// succeeded + dropped`, and the corpus really does drop designs, so `dropped` is
+/// positive and every drop carries a reason. SPDI has no offset notation, so the
+/// corpus's intronic outputs have no `sequence` key — a family carrying one cannot
+/// be certified converged, so it is `underdetermined` and the unkeyable output is
+/// counted rather than swept into a bucket.
+#[test]
+fn a_spec_census_run_is_accounted_and_flags_unkeyable_outputs() {
+    let run = run_census(
+        CorpusSource::Spec,
+        ShuffleDirection::ThreePrime,
+        Equivalence::Sequence,
+    )
+    .expect("the hermetic spec census runs with no reference");
+    let report = &run.report;
+
+    assert_eq!(report.corpus, "spec");
+    assert_eq!(report.direction, "3prime");
+    assert_eq!(report.equivalence, "sequence");
+
+    // The corpus shape travels beside the census (the #1460 hazard), and a zero
+    // would be a claim about the corpus, so the denominators are non-zero.
+    assert!(report.shape.rows > 0, "VACUOUS: the corpus built no rows");
+    assert!(report.shape.family_rows > 0, "VACUOUS: no family rows");
+    assert!(
+        report.census.outputs > 0,
+        "VACUOUS: no outputs were produced"
+    );
+
+    // Completeness is a claim carried in the artifact, and it is self-consistent.
+    assert!(
+        report.capture.is_self_consistent(),
+        "the capture counts do not add up: {:?}",
+        report.capture
+    );
+    assert_eq!(
+        report.capture.succeeded, report.shape.rows,
+        "every surviving row must be a captured success"
+    );
+    assert!(
+        report.capture.dropped > 0,
+        "the corpus drops designs by construction, so a zero drop count means the ledger \
+         was not actually routing the population"
+    );
+    assert!(
+        !report.capture.dropped_by_reason.is_empty(),
+        "a drop with no reason is exactly the silent drop the ledger exists to prevent"
+    );
+
+    // The allowance is a CEILING, not decoration. It was `at_most(attempted)`,
+    // which with `empty_pass_permitted: false` refuses exactly one thing — a run
+    // that attempted nothing — so every drop count from 0 to 100% passed while the
+    // command's docs called a drop past the allowance a refusal. A bound that
+    // cannot be exceeded is a bound nobody is standing behind.
+    let allowance = report
+        .capture
+        .allowance
+        .as_ref()
+        .expect("the run declares the allowance it accepted its shortfall under");
+    assert!(
+        allowance.max_dropped < report.capture.attempted,
+        "an allowance of {} against {} attempted designs permits dropping EVERYTHING, so it \
+         refuses nothing a run could actually do",
+        allowance.max_dropped,
+        report.capture.attempted
+    );
+    assert!(
+        report.capture.dropped <= allowance.max_dropped,
+        "the corpus dropped {} of {} designs, past its own ceiling of {} — either the corpus \
+         changed shape or the ceiling is wrong; both need a person",
+        report.capture.dropped,
+        report.capture.attempted,
+        allowance.max_dropped
+    );
+
+    // A real relation cannot key every output, and the unkeyable ones are counted
+    // rather than folded into a converged family.
+    assert!(
+        report.confluence_unkeyable_outputs > 0,
+        "the corpus produces intronic outputs SPDI cannot key, so a real relation must report \
+         some unkeyable outputs; zero means they were silently swept into a bucket"
+    );
+    assert!(
+        report.census.underdetermined > 0,
+        "families carrying an unkeyable output cannot be certified converged, so some must be \
+         undecided"
+    );
+
+    // Every family lands in exactly one confluence bucket — nothing is lost.
+    let census = &report.census;
+    assert_eq!(
+        census.converged
+            + census.split_two
+            + census.split_three
+            + census.split_more
+            + census.underdetermined,
+        report.shape.family_rows,
+        "the confluence buckets must partition the family rows"
+    );
+
+    // The artifact round-trips, which is the whole point of a machine-readable
+    // report: a consumer stores it and diffs a later one.
+    let json = serde_json::to_string(report).expect("serializes");
+    let back: CensusReport = serde_json::from_str(&json).expect("deserializes");
+    assert_eq!(*report, back);
+}
+
+/// The summary's divergence cap, restated here as the *vacuity floor* the test
+/// below needs rather than as a value under test.
+///
+/// It is deliberately not imported: `MAX_DIVERGENCES` is private to the library,
+/// and the assertion it guards is "the export is not capped", which needs only
+/// *some* number the corpus is known to exceed. If the summary's cap ever rises
+/// above this, the worst outcome is that the vacuity guard is looser than it could
+/// be — never that a truncated export passes, because the export is compared
+/// against the census's own bucket counts and not against this literal.
+const MAX_SUMMARY_DIVERGENCES: usize = 12;
+
+/// **Every** divergent family reaches the export, not the first twelve.
+///
+/// This is the property `--findings` rests on. The cap was sized for a panic
+/// message and was carried into a machine-readable export, so two releases' files
+/// held the same corpus-order-first twelve however many families moved behind
+/// them, and #1891's release-to-release diff read "no change" on a release in
+/// which hundreds changed.
+///
+/// Measured under `partition` deliberately, and that choice is the whole test:
+/// `sequence` finds **2** divergent families on this corpus, which is under the
+/// cap, so the same assertions there would pass whether or not the export
+/// truncates — a green test proving nothing. The vacuity guard below is what
+/// stops that happening silently again if the corpus changes shape.
+#[test]
+fn every_divergent_family_reaches_the_export() {
+    let run = run_census(
+        CorpusSource::Spec,
+        ShuffleDirection::ThreePrime,
+        Equivalence::Partition,
+    )
+    .expect("the hermetic spec census runs with no reference");
+
+    // The three split buckets ARE the divergent families, so this is not a
+    // restated literal — it is the same fact read off the census.
+    let census = &run.report.census;
+    let divergent = census.split_two + census.split_three + census.split_more;
+    assert!(
+        divergent > MAX_SUMMARY_DIVERGENCES,
+        "VACUOUS: the corpus produced only {divergent} divergent families under `partition`, \
+         at or under the summary's cap of {MAX_SUMMARY_DIVERGENCES} — so this test cannot \
+         tell a complete export from a truncated one and is not checking what it claims"
+    );
+    assert_eq!(
+        run.measured.divergences.len(),
+        divergent,
+        "the export must carry EVERY divergent family, not the first \
+         {MAX_SUMMARY_DIVERGENCES}: a consumer diffing two releases' findings files cannot \
+         tell a truncated file from a complete one"
+    );
+
+    let ids: BTreeSet<&str> = run
+        .measured
+        .divergences
+        .iter()
+        .map(|d| d.id.as_str())
+        .collect();
+    assert_eq!(
+        ids.len(),
+        run.measured.divergences.len(),
+        "a family must be exported once"
+    );
+    assert!(
+        run.measured.divergences.iter().all(|d| d.outputs.len() > 1),
+        "a family with one output is not divergent and must not be exported as one"
+    );
+}
+
+/// A looser relation can only converge MORE families than a stricter one — never
+/// fewer.
+///
+/// `sequence` (same bases) is looser than `partition` (same bases AND same member
+/// partition), so under `sequence` at least as many families reach one bucket.
+/// This is the property that makes "confluence under relation R" meaningful; if it
+/// failed, the relations would not be ordered by strictness.
+#[test]
+fn a_looser_relation_converges_at_least_as_many_families() {
+    let sequence = CensusReport::build(
+        CorpusSource::Spec,
+        ShuffleDirection::ThreePrime,
+        Equivalence::Sequence,
+    )
+    .expect("sequence census runs");
+    let partition = CensusReport::build(
+        CorpusSource::Spec,
+        ShuffleDirection::ThreePrime,
+        Equivalence::Partition,
+    )
+    .expect("partition census runs");
+
+    assert!(
+        sequence.census.converged >= partition.census.converged,
+        "sequence (looser) converged {} families but partition (stricter) converged {} — \
+         a looser relation cannot converge fewer",
+        sequence.census.converged,
+        partition.census.converged,
+    );
+}
+
+/// The `spdi` relation runs end-to-end and its report round-trips. Its member-key
+/// grouping is the one the issue names as already having a backbone
+/// (`group_by_spdi_key`), so it is exercised over the real corpus rather than only
+/// in the ordering test.
+#[test]
+fn the_spdi_relation_runs_and_round_trips() {
+    let report = CensusReport::build(
+        CorpusSource::Spec,
+        ShuffleDirection::ThreePrime,
+        Equivalence::Spdi,
+    )
+    .expect("spdi census runs");
+    assert_eq!(report.equivalence, "spdi");
+    assert!(report.census.outputs > 0, "VACUOUS: no outputs");
+
+    let json = serde_json::to_string(&report).expect("serializes");
+    let back: CensusReport = serde_json::from_str(&json).expect("deserializes");
+    assert_eq!(report, back);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -116,6 +116,7 @@ mod comprehensive_external_tests;
 mod con_conversion_audit;
 mod confluence_self_check_tests;
 mod conformance_census_instrument;
+mod conformance_census_runs;
 mod conformance_summary_generated;
 mod convert_gff_library_parity;
 mod convert_tests;


### PR DESCRIPTION
Closes #2094.

## The defect

`conformance_census_instrument` (#2063) holds four tests that each run a full spec-corpus census via `run_census` / `CensusReport::build`, costing 60–271s apiece. The module was enrolled only in `ORACLE_EXCLUDE` (which keeps it off the armed `test-oracle` shards); it was **not** named in `CENSUS_FILTER`, the mechanism that negates slow census modules from the 6-way `Test` shards and moves them to the dedicated `censuses` job. So the module ran in full in every shard.

On [run 31973592268 / `Test (1/6)`](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/31973592268/job/95229867903) the name-hash landed both 60s+ tests in shard 1:

| milestone | elapsed |
|---|---|
| 1,885 of 1,887 tests done | **~72s** |
| `every_divergent_family_reaches_the_export` (one `Partition` census) | **207.399s** |
| `a_looser_relation_converges_at_least_as_many_families` (`Sequence`+`Partition`, back-to-back) | **271.331s** |

The two run concurrently at the tail, so `a_looser…` at 271s *is* the shard's wall clock — three quarters of a ~5-minute job. `--partition hash:K/N` balances shard *counts*, not cost, and a shard's wall can never fall below its slowest single test, so re-sharding cannot fix it.

## The fix

Split the four full-census tests into a new module `conformance_census_runs` and enroll it in the census carve-out, matching the four modules already there (`spec_conformance_axis`, `issue_1542_direction_symmetry`, `normalize_axis_preserving`, `clinvar_hgvs_tests`):

- `#[path]`-included in the soak driver `tests-soak/tests/soak/main.rs`;
- named in `CENSUS_FILTER` (negated from `test` and `test-oracle`);
- selected by the `censuses` job's **un-armed** step, beside `spec_conformance_axis` — `run_census` refuses with a seam oracle armed, so it must not be in the armed step;
- named in `ORACLE_EXCLUDE` too, because it imports `conformance::census` (required by `oracle_exclude_invariant`).

This removes ~205s from the shards. The three CI liveness guards (`census_filter_invariant`, `oracle_exclude_invariant`, `soak_package_membership`) now enforce the enrollment stays consistent.

The moved tests are **otherwise unchanged** — they call `run_census` / `CensusReport::build` directly, as before. (Deduplicating the three distinct censuses across tests via a shared `LazyLock` was tried and dropped: nextest runs each test in its own process, so a shared cache is never reused, and `a_looser…` genuinely needs both a `sequence` and a `partition` census in one process regardless. Measured: `a_looser…` stayed at ~282s with the `LazyLock` in place, so it bought nothing.)

## Unchanged on purpose

- The **pure** tests (`compare_reports`, the burn-down, the relation-change and oracle-detector rules) stay in `conformance_census_instrument` — they use hand-built inputs and cost milliseconds, so they belong in the shards.
- The `#[cfg(feature = "benchmark")]` refusal test `a_seam_oracle_in_the_environment_is_refused` stays there too, and deliberately: it needs `CARGO_BIN_EXE_ferro-benchmark`, and the soak driver is built `-p ferro-hgvs-soak-tests` with default features (no `benchmark`), so it cannot run in the `censuses` job. Carving the whole module out would have stranded it — it would run nowhere. Keeping it in the shards keeps it with the binary it needs.

## Representation stability

None — this is a CI-topology and test-structure change. No `src/normalize|hgvs|spdi|project` file changes; normalized output is untouched. The moved tests assert the same properties over the same (deterministic) censuses.

## Verification

```
cargo fmt --all --check                                              # clean
cargo test --features dev --test it --no-run                         # IT_EXIT=0
cargo build -p ferro-hgvs-soak-tests --tests                         # SOAK_EXIT=0 (census_runs compiles under default features)
cargo clippy --all-features --all-targets -- -D warnings             # clean
cargo nextest run --features dev --test it \
  -E 'test(census_filter_invariant) + test(oracle_exclude_invariant) + test(soak_package_membership) + test(conformance_census_instrument)'
                                                                      # 21 passed
cargo nextest run --features dev --test it -E 'test(conformance_census_runs)'   # 4 passed (4 slow)
scripts/run_oracle_suite.sh --print-selection                        # conformance_census_runs is negated (armed list resolves to 0)
```
