### PR TITLE
fix: refuse a cis collapse anchored 5' of the sequence's first base

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -717,6 +717,37 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
             return variants;
         }
     }
+    // The 5' mirror of the refusal above (#2037), and the reason it is a
+    // separate statement rather than a second arm of it: this one needs no
+    // provider round-trip. Whether an endpoint falls *before* the first base is
+    // decided by `delta` alone, since the axis coordinate `p` sits at sequence
+    // position `p + delta` — the same identity `start0` is computed with.
+    //
+    // The case is the exact counterpart of #1327's: when the group nets to a
+    // pure insertion at the window's **5'** edge the anchor is
+    // `(del_start, del_start - 1)` with `del_start == w_lo == 1`, so `a_end` is
+    // the axis coordinate `0`. Where the axis has a 5'UTR that is a real base
+    // and `c.-1` is the right spelling; where `cds_start == 1` — or on `n.`/`r.`
+    // and `g.`/`m.`, which have no negative zone at all — it is not, and
+    // `name_on_zeroless_axis` renders it `c.-1`/`n.-1` regardless. The result
+    // parses, re-parses and is a fixed point while naming a nucleotide the
+    // reference does not have.
+    //
+    // **Refusing is what fixes it, not clamping.** Nothing downstream could
+    // repair the collapsed member, because every later pass is gated on the
+    // axis's positive body region and a member starting at `c.-1` is outside
+    // it — so `collect_canonical_edits` refuses the group and
+    // `canonicalize_from_sequence` never runs. Handing the *original* members
+    // back lets that pass run, and it already answers this shape correctly on
+    // every axis: `boundary_delins_anchor` re-spells a payload resting on a
+    // sequence bound as the single-position `delins` HGVS can express
+    // (`DNA/insertion.md:95-101`; #1205, #1217, #1202). So the group is still
+    // merged — `c.[1dup;1T>A]` -> `c.1delinsAT` — just by the pass that can
+    // place it.
+    let before_first_base = |p: i64| p.checked_add(delta).is_none_or(|v| v < 1);
+    if before_first_base(a_start) || before_first_base(a_end) {
+        return variants;
+    }
     let anchor = Anchor {
         region: body,
         start: a_start,
@@ -1491,10 +1522,37 @@ fn build_genome_merged(template: &GenomeVariant, merged: Anchor) -> GenomeVarian
 ///
 /// So on `n.` this is a strict improvement and not a resolution: it replaces
 /// `n.0`, which every mode rejects and which names a nucleotide no axis has,
-/// with `n.-1`, which strict still refuses. The residue is the same open
-/// question as the genomic axis's — what a cis group nets to a pure insertion 5'
-/// of the first base of a transcript should be called at all — and it belongs
-/// with #1772 rather than to this rename.
+/// with `n.-1`, which strict still refuses.
+///
+/// # That residue is closed, and this function is no longer where it lives
+///
+/// The open question — what a cis group netting to a pure insertion 5' of a
+/// transcript's first base should be *called* — is answered by **not naming it
+/// here at all**. #2037 gave [`collapse_overlapping_cis_edits`] the 5' mirror of
+/// its `past_end` refusal, so a group whose anchor endpoint falls before the
+/// sequence's first base is handed back to the per-member ladder, where
+/// [`boundary_delins_anchor`] spells it as the single-position `delins` the
+/// genomic axis has always used for the same shape. The refusal is keyed on the
+/// **sequence** coordinate, i.e. the axis coordinate plus the frame's `delta`.
+///
+/// What reaches this function **from the collapse** is therefore exactly the
+/// case the citations above license: an axis coordinate of `0` that does name a
+/// nucleotide, because the transcript has bases below `c.1`/`r.1`. Since `n.`'s
+/// axis coordinate `0` is transcript base `0` whatever the record, the collapse
+/// can no longer produce an `n.-1` anchor at all — so read the `n.` paragraph
+/// above as a statement about the naming rule, not about shipped output. Do not
+/// restore an `n.` case to
+/// [`a_five_prime_edge_insertion_anchors_below_one_not_on_zero`] on the strength
+/// of it; `a_five_prime_edge_anchor_off_the_sequence_is_refused` is the row that
+/// covers it.
+///
+/// **The scope of that is the collapse and nothing else.** [`build_merged`] is
+/// this function's other caller, reached from `merge_consecutive_edits`, and it
+/// carries no such refusal. No input has been found that drives it to a `0`
+/// anchor — those anchors come from the members' own spellings, and a member
+/// spelled `c.-1_1ins…` against a CDS starting at base 1 is already an
+/// out-of-range *input*, which is a different question — but that is an absence
+/// of evidence, not an audit.
 fn name_on_zeroless_axis(base: i64) -> i64 {
     if base == 0 {
         -1
@@ -14658,10 +14716,22 @@ mod tests {
     /// when those conversion arms are eventually retired (they are a separate
     /// change, needing their own ruling).
     ///
-    /// The `n.` axis has no such arm, which is why it is the one that escapes:
-    /// before this fix `NM_TEST.1:n.[1G>A;1dup]` normalized to the literal
-    /// `n.0_1insA`, a description `parse_hgvs` rejects. That is asserted too,
-    /// as the user-visible half. Issue #1772.
+    /// The `n.` axis has no such arm, which is why it was the one that escaped:
+    /// before that fix `NM_TEST.1:n.[1G>A;1dup]` normalized to the literal
+    /// `n.0_1insA`, a description `parse_hgvs` rejects. Issue #1772.
+    ///
+    /// # The `n.` row is no longer here, and that is #2037
+    ///
+    /// This fixture's `cds_start` is 13, so on `c.` and `r.` the axis
+    /// coordinate `0` is transcript base 12 — a real nucleotide, correctly
+    /// named `-1`. On `n.` it is transcript base **0**, which does not exist,
+    /// and #1772's own doc comment on [`name_on_zeroless_axis`] said in as many
+    /// words that renaming it `-1` was "a strict improvement and not a
+    /// resolution". The collapse now refuses that group rather than naming it,
+    /// which is what [`a_five_prime_edge_anchor_off_the_sequence_is_refused`]
+    /// below asserts. So the two rows left here are exactly the ones where the
+    /// `-1` anchor denotes a base, which is what makes this a guard on the
+    /// naming rule rather than on the axis.
     #[test]
     fn a_five_prime_edge_insertion_anchors_below_one_not_on_zero() {
         let provider = bounds_transcript_provider();
@@ -14670,10 +14740,6 @@ mod tests {
             (
                 ["NM_TEST.1:c.1A>G", "NM_TEST.1:c.1dup"],
                 "NM_TEST.1:c.-1_1insG",
-            ),
-            (
-                ["NM_TEST.1:n.1G>A", "NM_TEST.1:n.1dup"],
-                "NM_TEST.1:n.-1_1insA",
             ),
             (
                 ["NM_TEST.1:r.1a>g", "NM_TEST.1:r.1dup"],
@@ -14700,11 +14766,7 @@ mod tests {
             // `n.-N` at *strict* parse (`W4008`) while lenient, silent and this
             // entry keep accepting it, for the five real ClinVar rows named in
             // `src/hgvs/noncoding_zones.rs`. So this assertion says the output
-            // is readable on the entry every `ferro` subcommand uses — not that
-            // `n.-1_1insA` is conformant on the non-coding axis, which
-            // `numbering.md:52`/`:54` say it is not. See
-            // `name_on_zeroless_axis`'s doc comment for why that residue is
-            // still an improvement over `n.0`, and #1772 for where it is owed.
+            // is readable on the entry every `ferro` subcommand uses.
             for r in &rendered {
                 assert!(
                     parse_hgvs(r).is_ok(),
@@ -14712,6 +14774,44 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The other half of the case above: where the `-1` anchor would name no
+    /// nucleotide, the collapse refuses the group instead of naming it (#2037).
+    ///
+    /// The refusal is decided on the **sequence** coordinate — the axis
+    /// coordinate plus the frame's `delta` — never on the rendered spelling, so
+    /// the two `c.`/`r.` rows in the test above, whose `-1` is transcript base
+    /// 12 on this same fixture, are untouched. That pairing is the point:
+    /// asserting only the refusal would be satisfied by a guard that had
+    /// swallowed the whole 5' edge.
+    ///
+    /// Refusing is not a loss of the merge. The group goes back to the
+    /// per-member ladder, where `canonicalize_from_sequence`'s
+    /// [`boundary_delins_anchor`] re-spells a payload resting on a sequence
+    /// bound as the single-position `delins` HGVS can express — end to end this
+    /// input becomes `NM_TEST.1:n.1delinsAG`, which
+    /// `issue_1796_base_zero_names_no_nucleotide` pins.
+    #[test]
+    fn a_five_prime_edge_anchor_off_the_sequence_is_refused() {
+        let provider = bounds_transcript_provider();
+        // `n.1` is transcript base 1, so the interbase 5' of it is off the
+        // transcript. `n.` also has no negative zone at all
+        // (`numbering.md:52`/`:54`), which is why the pre-#2037 answer
+        // `n.-1_1insA` was non-conformant as well as out of range.
+        let members = ["NM_TEST.1:n.1G>A", "NM_TEST.1:n.1dup"];
+        let parsed: Vec<_> = members
+            .iter()
+            .map(|m| parse_hgvs(m).unwrap_or_else(|e| panic!("fixture {m} must parse: {e}")))
+            .collect();
+        let collapsed = collapse_overlapping_cis_edits(parsed.clone(), AllelePhase::Cis, &provider);
+        let rendered: Vec<String> = collapsed.iter().map(|v| v.to_string()).collect();
+        assert_eq!(
+            rendered,
+            parsed.iter().map(|v| v.to_string()).collect::<Vec<_>>(),
+            "the group must be handed back untouched, not named on a coordinate \
+             NM_TEST.1 does not have",
+        );
     }
 
     /// The same geometry away from the axis origin is untouched — the fix

--- a/tests/it/issue_1796_base_zero_names_no_nucleotide.rs
+++ b/tests/it/issue_1796_base_zero_names_no_nucleotide.rs
@@ -252,12 +252,31 @@ fn the_rna_axis_has_no_end_to_end_case_and_this_records_why() {
 /// touched that axis, so it had no repairing arm and #1772 was *visible* there
 /// (it emitted the literal `n.0_1insA`, which ferro's own parser rejects). It
 /// must be unaffected by this change in either direction.
+///
+/// # The `n.` row moved, and #1796 is not what moved it
+///
+/// It read `n.-1_1insA` until #2037. On this fixture `cds_start` is 13, so the
+/// axis coordinate below `1` is transcript base 12 on `c.`/`r.` — a real
+/// nucleotide — and transcript base **0** on `n.`, which does not exist. #1772
+/// renamed that coordinate from `0` to `-1` and its own doc comment recorded
+/// the remainder as owed; #2037 pays it, by refusing the *collapse* rather than
+/// renaming its anchor. The group is still merged, one pass later, into the
+/// single-position `delins` that is the only spelling of an insertion resting
+/// on a sequence bound.
+///
+/// So the row is re-pinned rather than deleted, and the `c.`/`r.` rows beside
+/// it are what say this change is narrow: the refusal keys on the **sequence**
+/// coordinate, so an axis position of `-1` that names a base is untouched. A
+/// version of this test carrying only the moved row could not distinguish that
+/// from a guard that had swallowed the whole 5' edge.
 #[test]
 fn the_five_prime_edge_cis_collapse_is_unaffected() {
     for (input, expected) in [
         ("NM_TEST.1:c.[1A>G;1dup]", "NM_TEST.1:c.-1dup"),
         ("NM_TEST.1:r.[1a>g;1dup]", "NM_TEST.1:r.-1dup"),
-        ("NM_TEST.1:n.[1G>A;1dup]", "NM_TEST.1:n.-1_1insA"),
+        // #2037: `n.-1` names no base on this transcript, so the collapse
+        // declines and `boundary_delins_anchor` supplies the form instead.
+        ("NM_TEST.1:n.[1G>A;1dup]", "NM_TEST.1:n.1delinsAG"),
     ] {
         let variant = parse_hgvs(input).expect("input must parse");
         let output = normalize(&variant);

--- a/tests/it/issue_2037_cis_allele_at_transcript_start.rs
+++ b/tests/it/issue_2037_cis_allele_at_transcript_start.rs
@@ -1,0 +1,296 @@
+//! A cis group that nets to an insertion 5' of a transcript's first base must
+//! not be spelled `c.-1_1ins…` on a transcript that has no base there.
+//!
+//! # The defect
+//!
+//! `NM_TEST.1:c.[1dup;1T>A]` on a transcript whose `cds_start` is `1` came back
+//! as `NM_TEST.1:c.-1_1insA`. Both members sit on the first base of the CDS,
+//! which on that transcript is also the first base of the *sequence*, so the
+//! combined haplotype is "insert `A` immediately 5' of base 1" — a position
+//! HGVS cannot anchor an insertion at, and one this transcript does not have.
+//!
+//! # Why it is quiet
+//!
+//! `c.-1` is a perfectly legal 5'UTR spelling, so the output parses,
+//! re-parses, and is a fixed point. It is wrong only against the reference it
+//! was derived from, and only for transcripts whose CDS starts at base 1.
+//! `FERRO_ASSERT_IN_BOUNDS` is the one seam oracle that can see it, and it runs
+//! in the `Test oracle` job alone.
+//!
+//! # Where it came from
+//!
+//! `merge::collapse_overlapping_cis_edits` builds the collapsed group's anchor
+//! in dense window arithmetic, so a group netting to a pure insertion at the
+//! window's 5' edge produces the insertion-shaped anchor `(del_start,
+//! del_start - 1)` — i.e. axis endpoint `0`. #1327 gave that function a `past_end`
+//! refusal for the mirror-image case at the 3' end and left the 5' side open;
+//! #1772 then renamed the endpoint `0` to `-1` (`name_on_zeroless_axis`) so it
+//! would stop rendering as `c.?`/`n.0`, and said in its own doc comment that the
+//! residue — what such a group should be *called* — was still open. This is that
+//! residue.
+//!
+//! Nothing downstream could repair it, because every later pass is gated on the
+//! axis's **positive body region**: once the collapse has emitted a member
+//! starting at `c.-1`, `collect_canonical_edits` refuses the group and
+//! `canonicalize_from_sequence` — which already answers this shape correctly on
+//! the genomic axis, via `boundary_delins_anchor` — never runs.
+//!
+//! # What is asserted, and what makes each assertion non-vacuous
+//!
+//! The load-bearing check is **not** a string comparison. Each member of the
+//! output is resolved through [`hgvs_to_spdi`], which is the coordinate mapper
+//! rather than the normalizer, and which declines a `c.`/`n.` position that
+//! resolves to a non-positive transcript base. A test that only compared
+//! strings would pass against any future spelling that happened to differ from
+//! the recorded one, including another out-of-range one.
+//!
+//! Three controls keep the guard honest, because "every coordinate resolves" is
+//! satisfiable by doing nothing useful:
+//!
+//! * [`the_in_bounds_instrument_tells_the_two_transcripts_apart`] pins that the
+//!   instrument answers *differently* for the two references — `c.-1_1insA` is
+//!   refused against a CDS starting at base 1 and accepted against one with a
+//!   real 5'UTR. Without it, a change that made the mapper accept `c.-1`
+//!   everywhere would turn every other test here green while making the defect
+//!   worse.
+//! * [`a_transcript_with_a_real_five_prime_utr_still_spells_it_at_c_minus_one`]
+//!   is the over-fix control: banning `c.-1` outright would satisfy the
+//!   in-bounds checks and destroy a correct answer.
+//! * [`an_interior_pair_on_the_same_transcript_still_merges`] and
+//!   [`the_group_is_still_merged_into_one_member`] are the under-fix controls:
+//!   refusing to combine anything at all also produces coordinates that all
+//!   resolve.
+//!
+//! # The form, and its authority
+//!
+//! `c.1delinsAT` is not a free choice. `DNA/insertion.md:95-101` requires an
+//! insertion to name two adjacent flanking positions, so a payload resting 5' of
+//! base 1 has no `ins` spelling at all; the single-position `delins` is the same
+//! identity `insertion_to_boundary_delins` already applies at every other
+//! sequence bound — the contig start on `g.` (#1205), the mitochondrial origin
+//! (#1217) and the transcript bounds on `n.`/`r.` (#1202). Deriving it from the
+//! resulting sequence rather than preserving the input's spelling is
+//! `rulings[canonical-form-choice-when-both-legal]`.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, MockProvider, Normalizer};
+
+/// The transcript sequence every case here is drawn against.
+///
+/// Its first base is `T` and the rest is the `ACGT` period-4 rotation, so no
+/// base equals either of its neighbours and nothing in these cases can shift
+/// along a run — the only movement on show is the one the collapse performs.
+const CORE: &str = "TACGTACGTACGTACGTACG";
+
+/// A codon-complete CDS end, leaving five 3'UTR bases. Nothing here reaches the
+/// 3' end; it is fixed so the two providers differ in `cds_start` alone.
+const CDS_END: u64 = 15;
+
+/// `cds_start = 1`: the CDS begins at the transcript's first base, so the
+/// transcript has **no** 5'UTR and `c.-1` names nothing.
+const NO_FIVE_PRIME_UTR: u64 = 1;
+
+/// `cds_start = 4`: three 5'UTR bases, so `c.-1` is transcript base 3 and the
+/// same insertion spelling is correct.
+const WITH_FIVE_PRIME_UTR: u64 = 4;
+
+fn coding_provider(cds_start: u64) -> MockProvider {
+    SyntheticBuilder::cds(CORE, cds_start, CDS_END, Strand::Plus).build()
+}
+
+fn noncoding_provider() -> MockProvider {
+    SyntheticBuilder::noncoding(CORE, Strand::Plus).build()
+}
+
+/// The members of `description`, whether or not it is bracketed.
+fn members(description: &str) -> Vec<HgvsVariant> {
+    match parse_hgvs(description).unwrap_or_else(|e| panic!("`{description}` parses: {e}")) {
+        HgvsVariant::Allele(allele) => allele.variants.clone(),
+        single => vec![single],
+    }
+}
+
+fn normalized(provider: &MockProvider, input: &str) -> String {
+    Normalizer::new(provider.clone())
+        .normalize(&parse_hgvs(input).unwrap_or_else(|e| panic!("`{input}` parses: {e}")))
+        .unwrap_or_else(|e| panic!("`{input}` normalizes: {e}"))
+        .to_string()
+}
+
+/// The members of `description` that name a coordinate `provider`'s transcript
+/// does not have, each with the mapper's own reason.
+///
+/// The question is put to [`hgvs_to_spdi`] — the coordinate mapper — and not to
+/// the normalizer, so nothing here can agree with an output merely because
+/// normalization produced it. The mapper declines a `c.`/`n.` position that
+/// resolves to a non-positive transcript base, which is exactly the property
+/// this issue is about.
+fn unresolvable_members(provider: &MockProvider, description: &str) -> Vec<String> {
+    members(description)
+        .iter()
+        .filter_map(|member| match hgvs_to_spdi(member, provider) {
+            Ok(_) => None,
+            Err(e) => Some(format!("{member}: {e}")),
+        })
+        .collect()
+}
+
+/// The bases `description` denotes over [`CORE`], by splicing each member's
+/// SPDI triple into the transcript sequence.
+///
+/// `Err` for a description the mapper cannot resolve or whose members overlap;
+/// a description that denotes no sequence is a failure to report, never a
+/// comparison to skip.
+fn denoted(provider: &MockProvider, description: &str) -> Result<String, String> {
+    let mut triples = Vec::new();
+    for member in members(description) {
+        triples.push(hgvs_to_spdi(&member, provider).map_err(|e| format!("{member}: {e}"))?);
+    }
+    // 3'-to-5', longer deletion first at a tied position, so a zero-width
+    // insertion sharing an interbase with a deletion does not read as an
+    // overrun. Same order `common::synthetic`'s applier uses.
+    triples.sort_by_key(|t| std::cmp::Reverse((t.position, t.deletion.len())));
+    let mut edited = CORE.as_bytes().to_vec();
+    let mut claimed = CORE.len();
+    for triple in &triples {
+        let start =
+            usize::try_from(triple.position).map_err(|_| "position overflows".to_string())?;
+        let end = start + triple.deletion.len();
+        if end > claimed {
+            return Err(format!("members overlap at interbase {start}"));
+        }
+        edited.splice(start..end, triple.insertion.bytes());
+        claimed = start;
+    }
+    String::from_utf8(edited).map_err(|e| e.to_string())
+}
+
+/// The reproducer from the issue: both members on the first coding base of a
+/// transcript whose CDS starts at base 1.
+const REPRODUCER: &str = "NM_TEST.1:c.[1dup;1T>A]";
+
+/// The out-of-range string the reproducer produced before the fix. Named so the
+/// controls below can state what they are calibrated against.
+const OUT_OF_RANGE_OUTPUT: &str = "NM_TEST.1:c.-1_1insA";
+
+#[test]
+fn the_allele_at_the_first_coding_base_names_only_coordinates_the_transcript_has() {
+    let provider = coding_provider(NO_FIVE_PRIME_UTR);
+    let output = normalized(&provider, REPRODUCER);
+    let unresolvable = unresolvable_members(&provider, &output);
+    assert!(
+        unresolvable.is_empty(),
+        "`{REPRODUCER}` -> `{output}` names a coordinate NM_TEST.1 does not \
+         have (cds_start = {NO_FIVE_PRIME_UTR}, so there is no base 5' of c.1): \
+         {unresolvable:?}",
+    );
+}
+
+#[test]
+fn the_output_denotes_the_bases_the_input_did() {
+    let provider = coding_provider(NO_FIVE_PRIME_UTR);
+    let output = normalized(&provider, REPRODUCER);
+    let from_input = denoted(&provider, REPRODUCER).expect("the input denotes a sequence");
+    let from_output = denoted(&provider, &output)
+        .unwrap_or_else(|e| panic!("`{REPRODUCER}` -> `{output}` denotes no sequence: {e}"));
+    assert_eq!(
+        from_output, from_input,
+        "`{REPRODUCER}` -> `{output}` changed the sequence",
+    );
+}
+
+#[test]
+fn the_canonical_form_is_the_single_position_delins_at_the_first_base() {
+    let provider = coding_provider(NO_FIVE_PRIME_UTR);
+    assert_eq!(
+        normalized(&provider, REPRODUCER),
+        "NM_TEST.1:c.1delinsAT",
+        "an insertion resting 5' of base 1 has no two-anchor `ins` spelling \
+         (DNA/insertion.md:95-101), so it is the single-position delins the \
+         genomic axis already emits for the same shape",
+    );
+}
+
+#[test]
+fn the_group_is_still_merged_into_one_member() {
+    // The under-fix control for the string above: declining to combine also
+    // produces an output whose every coordinate resolves, and would leave the
+    // two members as they were.
+    let provider = coding_provider(NO_FIVE_PRIME_UTR);
+    let output = normalized(&provider, REPRODUCER);
+    assert_eq!(
+        members(&output).len(),
+        1,
+        "`{REPRODUCER}` -> `{output}`: the two members denote one contiguous \
+         change and must still collapse to one",
+    );
+}
+
+#[test]
+fn the_non_coding_axis_has_the_same_shape_and_the_same_answer() {
+    // `n.` has no negative zone at all, so `n.-1` is worse than `c.-1`: it is
+    // refused at strict parse (#1751) as well as being off the sequence.
+    let provider = noncoding_provider();
+    let input = "NR_TEST.1:n.[1dup;1T>A]";
+    let output = normalized(&provider, input);
+    let unresolvable = unresolvable_members(&provider, &output);
+    assert!(
+        unresolvable.is_empty(),
+        "`{input}` -> `{output}` names a coordinate NR_TEST.1 does not have: \
+         {unresolvable:?}",
+    );
+    assert_eq!(output, "NR_TEST.1:n.1delinsAT");
+}
+
+#[test]
+fn a_transcript_with_a_real_five_prime_utr_still_spells_it_at_c_minus_one() {
+    // The over-fix control. Same shape, same first coding base — but here
+    // `c.-1` is transcript base 3, so the insertion has two real anchors and
+    // `c.-1_1insA` is the right answer. A fix that refused the collapse
+    // whenever an endpoint rendered negative would break this.
+    let provider = coding_provider(WITH_FIVE_PRIME_UTR);
+    let input = "NM_TEST.1:c.[1dup;1G>A]";
+    let output = normalized(&provider, input);
+    assert_eq!(output, OUT_OF_RANGE_OUTPUT);
+    assert!(
+        unresolvable_members(&provider, &output).is_empty(),
+        "`{input}` -> `{output}`: with cds_start = {WITH_FIVE_PRIME_UTR} every \
+         coordinate here exists",
+    );
+}
+
+#[test]
+fn an_interior_pair_on_the_same_transcript_still_merges() {
+    // The other under-fix control: a guard written on the collapse's output
+    // rather than on its 5' endpoint would switch this off too.
+    let provider = coding_provider(NO_FIVE_PRIME_UTR);
+    let input = "NM_TEST.1:c.[2dup;2A>C]";
+    let output = normalized(&provider, input);
+    assert_eq!(output, "NM_TEST.1:c.1_2insC");
+    assert!(unresolvable_members(&provider, &output).is_empty());
+}
+
+#[test]
+fn the_in_bounds_instrument_tells_the_two_transcripts_apart() {
+    // Calibration. Every assertion above is only as good as the mapper's
+    // ability to answer this question differently for the two references — if
+    // it accepted `c.-1` unconditionally the guards would all go green while
+    // the defect got worse, and if it refused `c.-1` unconditionally the
+    // over-fix control above would be measuring nothing.
+    let no_utr = coding_provider(NO_FIVE_PRIME_UTR);
+    let with_utr = coding_provider(WITH_FIVE_PRIME_UTR);
+    assert_eq!(
+        unresolvable_members(&no_utr, OUT_OF_RANGE_OUTPUT).len(),
+        1,
+        "`{OUT_OF_RANGE_OUTPUT}` must be refused against a CDS starting at \
+         base 1 — that refusal is what every other test in this file reads",
+    );
+    assert!(
+        unresolvable_members(&with_utr, OUT_OF_RANGE_OUTPUT).is_empty(),
+        "`{OUT_OF_RANGE_OUTPUT}` must be accepted against a transcript with a \
+         real 5'UTR, or the instrument is a blanket ban rather than a bounds \
+         check",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -49,6 +49,7 @@ mod issue_1916_intron_distance_underflow;
 mod issue_1917_reversed_range_window;
 mod issue_1970_u16_cost_grid_bound;
 mod issue_1989_declined_is_indeterminate;
+mod issue_2037_cis_allele_at_transcript_start;
 mod issue_2056_edit_triples_reference_failure;
 mod recommended_form_pins;
 mod repeat_input_idempotency;


### PR DESCRIPTION
Closes #2037

`NM_TEST.1:c.[1dup;1T>A]` on a transcript whose CDS starts at base 1 came back as `NM_TEST.1:c.-1_1insA` — a description that parses, re-parses and is a fixed point while naming a nucleotide the reference does not have. `background/numbering.md:54` is directly on point: it is not allowed to describe variants in nucleotides beyond the boundaries of a transcript reference sequence.

Representation-Change: 96 of 96,182 corpus rows respell, all on the coding axis and all the reproducer shape — `c.[1dup;1X>Y]` moves from `c.-1_1insY` to `c.1delinsYX`. Every replaced string named a coordinate the transcript does not have, so this is a correction of out-of-range output rather than a choice between two valid spellings. A transcript with a real 5'UTR is untouched: the corpus carries 96 sibling rows of the identical input shape on `NM_TESTX.1`, and 0 of them move.

## Root cause

`collapse_overlapping_cis_edits` builds a collapsed group's anchor in dense window arithmetic, so a group netting to a pure insertion at the window's 5' edge produces the insertion-shaped anchor `(del_start, del_start - 1)`, whose `end` is the axis coordinate `0`. #1327 gave that function the mirror-image `past_end` refusal for the **3'** edge and left the 5' side open; #1772 then renamed the endpoint `0` to `-1` so it would stop rendering as `c.?`/`n.0`, and said in its own doc comment that the residue — what such a group should be *called* — was still owed. This is that residue.

`c.-1` is only a real base when the axis has room below `1`. On a transcript whose `cds_start` is 1 it has none, and on `n.`/`r.` and `g.`/`m.` there is no negative zone at all.

Nothing downstream could repair it. Every later pass is gated on the axis's positive body region, so once the collapse has emitted a member starting at `c.-1`, `collect_canonical_edits` refuses the group and `canonicalize_from_sequence` — which already answers this shape correctly on the genomic axis — never runs.

## The fix

Add the 5' counterpart of the `past_end` refusal. It is decided by the axis frame's `delta` alone and so needs no provider round-trip: the axis coordinate `p` sits at sequence position `p + delta`, the same identity `start0` is already computed with.

**Refusing is what fixes it, not clamping.** Handing the original members back lets `canonicalize_from_sequence` run, and its `boundary_delins_anchor` re-spells a payload resting on a sequence bound as the single-position `delins` HGVS can express. So the group is still merged — `c.[1dup;1T>A]` -> `c.1delinsAT` — just by the pass that can place it.

The form is not a free choice. `DNA/insertion.md:95-101` refuses a single-position `ins` as not unequivocal, so a payload resting 5' of base 1 has no two-anchor `ins` spelling at all; the single-position `delins` is the same identity already applied at every other sequence bound — the contig start on `g.` (#1205), the mitochondrial origin (#1217) and the transcript bounds on `n.`/`r.` (#1202). Deriving it from the resulting sequence rather than preserving the input's spelling is `rulings[canonical-form-choice-when-both-legal]`.

No new ruling record: this is not two clauses in tension but a coordinate that names no base, and the boundary-`delins` identity it resolves to is already settled and applied on the sibling axes.

## Observed failing first

With the guard reverted and the tests kept, 6 tests fail, reproducing the issue byte-for-byte:

```
issue_2037_..::the_allele_at_the_first_coding_base_names_only_coordinates_the_transcript_has
  `NM_TEST.1:c.[1dup;1T>A]` -> `NM_TEST.1:c.-1_1insA` names a coordinate NM_TEST.1
  does not have (cds_start = 1, so there is no base 5' of c.1):
  ["... transcript position from c. coordinate -1 resolves to a non-positive base (0)"]

issue_2037_..::the_canonical_form_is_the_single_position_delins_at_the_first_base
  left: "NM_TEST.1:c.-1_1insA"   right: "NM_TEST.1:c.1delinsAT"
```

The three controls (`a_transcript_with_a_real_five_prime_utr_still_spells_it_at_c_minus_one`, `an_interior_pair_on_the_same_transcript_still_merges`, `the_in_bounds_instrument_tells_the_two_transcripts_apart`) pass in that same reverted run, which is what makes them controls rather than more of the same assertion.

## Sabotage

| mutation | result | caught by |
|---|---|---|
| `v < 1` -> `v < 0` (off-by-one loosening) | 6 fail | the four `issue_2037` bounds/form rows, `issue_1796::the_five_prime_edge_cis_collapse_is_unaffected`, `merge::tests::a_five_prime_edge_anchor_off_the_sequence_is_refused` |
| drop the `a_end` arm, keep only `a_start` | 6 fail | same six — `a_start` can never trip, so this is equivalent to no guard |
| drop the `+ delta` term, guard the **axis** coordinate instead of the sequence coordinate (over-fix) | 3 fail | `a_transcript_with_a_real_five_prime_utr_still_spells_it_at_c_minus_one`, plus the `c.`/`r.` rows of `a_five_prime_edge_insertion_anchors_below_one_not_on_zero` and `issue_1796::the_five_prime_edge_cis_collapse_is_unaffected` |

The third row is the one worth reading: it is the difference between a bounds check and a blanket ban on `c.-1`, and only the over-fix control sees it.

## Measured reach, including what the corpus cannot see

`examples/dump_normalized_corpus.rs`, same generator both sides: 96 of 96,182 rows move, all in `coincident_bounds`, across 4 distinct before/after pairs, all of the form `c.[1dup;1X>Y]`: `c.-1_1insY` -> `c.1delinsYX`.

The corpus's axis set is `g`, `c`, `cx`, `p`. Two zeros in it are **structural**, not evidence:

- **No `n.`/`r.` axis exists in this corpus at all**, so it cannot witness that half of the fix. That is covered by the dedicated tests instead (`the_non_coding_axis_has_the_same_shape_and_the_same_answer`, the re-pinned `n.` row in `issue_1796_base_zero_names_no_nucleotide`, and the new `merge::tests` unit test).
- **The `g` axis has 1,536 `coincident_bounds` rows and none names a sub-1 anchor** — the corpus never places this shape at contig position 1, so the genomic half is likewise unmeasured here.

What the corpus does establish, and what a hand-written test could not: the 192 rows carrying the reproducer input shape split exactly 96 on `NM_TEST.1` (no 5'UTR, all move) and 96 on `NM_TESTX.1` (real 5'UTR, none move). The over-fix control is measured, not merely asserted.

## Gate

`cargo nextest run --features dev --no-fail-fast` 11336 passed / 0 failed; `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean; `pytest tests/python/ -q` 1137 passed, 8 skipped.
