### PR TITLE
fix(project): name the build a placement is on when declining a build mismatch

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -2343,7 +2343,11 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// with no known placement or an endpoint outside the placed span, and
     /// [`FerroError::InvalidCoordinates`] for an uncertain/compound endpoint
     /// (#655) — rather than emit a chromosome coordinate under the parent
-    /// accession (invalid HGVS).
+    /// accession (invalid HGVS). When a placement exists but only on a build
+    /// other than the requested one (an LRG/NG declining an explicit `GRCh37`
+    /// request whose only placement is `GRCh38`, #2089), the decline names the
+    /// build the placement is on and points at re-running under it, rather than
+    /// reporting the placement as unknown (#2103).
     fn reanchor_genome_output(
         &self,
         gv: crate::hgvs::variant::GenomeVariant,
@@ -2354,12 +2358,44 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .genomic_placement_on_build(&gv.accession, build)
         {
             Some(placement) => Self::reanchor_genome_to_parent(gv, &placement)?,
-            // No placement: an `NC_` chromosome parent is already in the genome
-            // frame and passes through unchanged, but an `NG_`/`LRG_` parent
-            // cannot be re-anchored (cdot carries only the transcript's `NC_`
-            // alignment). Emitting the `NC_` coordinate under the `NG_`/`LRG_`
-            // accession would be invalid HGVS, so decline instead (#480/#655).
+            // No placement for the requested build: an `NC_` chromosome parent
+            // is already in the genome frame and passes through unchanged, but
+            // an `NG_`/`LRG_` parent cannot be re-anchored (cdot carries only
+            // the transcript's `NC_` alignment). Emitting the `NC_` coordinate
+            // under the `NG_`/`LRG_` accession would be invalid HGVS, so decline
+            // instead (#480/#655).
             None if &*gv.accession.prefix == "NG" || gv.accession.is_lrg() => {
+                // Distinguish a genuine data gap (no placement on any build)
+                // from a placement that exists on a *different* build than the
+                // one requested (#2103). After #2089 an LRG/NG whose only
+                // chromosomal placement is GRCh38 declines an explicit GRCh37
+                // request, and the two causes want different user actions: the
+                // first is unplaceable, the second is answerable by re-running
+                // under the build the placement actually carries. A build was
+                // requested only when `build.is_some()`; with no preference a
+                // `None` here is a genuine data gap (the no-preference lookup
+                // returns the first available placement).
+                let placed_on_other_build = build.and_then(|_| {
+                    self.provider
+                        .genomic_placement_on_build(&gv.accession, None)
+                });
+                if let Some(available) = placed_on_other_build {
+                    let requested = build.unwrap_or("the requested build");
+                    let available_build = self
+                        .provider
+                        .infer_genome_build(&available.nc)
+                        .unwrap_or("another build");
+                    return Err(FerroError::UnsupportedProjection {
+                        reason: format!(
+                            "cannot project to the {} parent frame on {requested}: its \
+                             chromosomal placement is on {available_build} ({}), not \
+                             {requested}; re-run with --assembly {available_build} to \
+                             project against the placement's own build (#480/#2103)",
+                            gv.accession.transcript_accession(),
+                            available.nc,
+                        ),
+                    });
+                }
                 return Err(FerroError::UnsupportedProjection {
                     reason: format!(
                         "cannot project to the {} parent frame: no chromosomal \
@@ -10613,6 +10649,104 @@ mod tests {
                 FerroError::UnsupportedProjection { reason } => assert!(
                     reason.contains("outside the placed genomic span"),
                     "expected an out-of-span decline, got: {reason}"
+                ),
+                other => panic!("expected UnsupportedProjection, got: {other:?}"),
+            }
+        }
+
+        /// After #2089 an LRG/NG whose only chromosomal placement is GRCh38
+        /// declines an explicit GRCh37 request. The decline must name the build
+        /// the placement *is* on and point at re-running under it, rather than
+        /// claim no placement is known: the two causes want different user
+        /// actions — an unplaced parent is a data gap, a placed-elsewhere parent
+        /// is answerable by re-running with `--assembly GRCh38` (#2103).
+        #[test]
+        fn reanchor_ng_parent_placed_on_other_build_names_the_available_build() {
+            let (projector, mut provider) = make_test_provider_and_projector();
+            // NG_TEST.1 is placed only on GRCh38 (NC_000017.11).
+            provider.add_genomic_placement(
+                "NG_TEST.1",
+                crate::reference::GenomicPlacement {
+                    nc: Accession::new("NC", "000017", Some(11)),
+                    parent_start: 1,
+                    nc_start: 50_182_096,
+                    nc_end: 50_182_106,
+                    strand: crate::reference::Strand::Plus,
+                    gaps: Vec::new(),
+                },
+            );
+            let vp = VariantProjector::new(projector, provider);
+            // A chromosome-frame genome variant stamped with the NG parent, as
+            // `project_to_genomic` hands to `reanchor_genome_output`.
+            let gv = GenomeVariant {
+                accession: ng_parent("TEST", 1),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    GenomeInterval::point(GenomePos::new(50_182_100)),
+                    NaEdit::Substitution {
+                        reference: Base::C,
+                        alternative: Base::A,
+                    },
+                ),
+            };
+            let err = vp
+                .reanchor_genome_output(gv, Some("GRCh37"))
+                .expect_err("a GRCh37 request on a GRCh38-only placement must decline");
+            match err {
+                FerroError::UnsupportedProjection { reason } => {
+                    assert!(
+                        reason.contains("GRCh38") && reason.contains("GRCh37"),
+                        "decline must name both the available (GRCh38) and requested \
+                         (GRCh37) builds, got: {reason}"
+                    );
+                    assert!(
+                        reason.contains("--assembly GRCh38"),
+                        "decline must point at re-running under the placement's own \
+                         build, got: {reason}"
+                    );
+                    assert!(
+                        !reason.contains("no chromosomal placement is known"),
+                        "decline must not claim the placement is unknown when it exists \
+                         on GRCh38, got: {reason}"
+                    );
+                    assert!(
+                        reason.contains("NC_000017.11"),
+                        "decline should name the placement's chromosome accession, \
+                         got: {reason}"
+                    );
+                }
+                other => panic!("expected UnsupportedProjection, got: {other:?}"),
+            }
+        }
+
+        /// The genuine data-gap case is unchanged (#2103): an NG/LRG with no
+        /// placement on any build still declines with the "no chromosomal
+        /// placement is known" message, even when a build is explicitly
+        /// requested. The build-aware branch must not swallow the unplaced case
+        /// into the placed-elsewhere message.
+        #[test]
+        fn reanchor_ng_parent_with_no_placement_on_any_build_still_reports_unknown() {
+            let (projector, provider) = make_test_provider_and_projector();
+            let vp = VariantProjector::new(projector, provider);
+            let gv = GenomeVariant {
+                accession: ng_parent("TEST", 1),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    GenomeInterval::point(GenomePos::new(1003)),
+                    NaEdit::Substitution {
+                        reference: Base::C,
+                        alternative: Base::A,
+                    },
+                ),
+            };
+            let err = vp
+                .reanchor_genome_output(gv, Some("GRCh37"))
+                .expect_err("no placement on any build must decline");
+            match err {
+                FerroError::UnsupportedProjection { reason } => assert!(
+                    reason.contains("no chromosomal placement is known")
+                        && reason.contains("NG_TEST.1"),
+                    "expected the unplaced-parent message, got: {reason}"
                 ),
                 other => panic!("expected UnsupportedProjection, got: {other:?}"),
             }


### PR DESCRIPTION
## Summary

Split off from the #2089 review. #2089 made 1294 LRG records decline an explicit `GRCh37` projection request (an LRG/NG carries a single GRCh38 main-assembly placement), which newly exercised a latent defect in the decline path.

When `genomic_placement_on_build` returns `None`, `reanchor_genome_output` declined every `NG_`/`LRG_` parent with the same message — *"no chromosomal placement is known for this NG_/LRG_ reference"*. After #2089 that message is wrong for the build-mismatch case: a placement **is** known, just on a different build than the one requested. The message conflated two causes that want different user actions — an **unplaced** parent is a data gap, a **placed-elsewhere** parent is answerable by re-running under the build the placement carries.

## Fix

In the `NG_`/`LRG_` decline arm, when a build was requested, look the placement up build-agnostically (`build = None`) to detect whether one exists on any build:

- **Placement exists on another build** → decline naming the build it is on, its `NC_` accession, and pointing at `--assembly <build>` (e.g. *"its chromosomal placement is on GRCh38 (NC_000017.11), not GRCh37; re-run with --assembly GRCh38"*).
- **No placement on any build** → the unchanged *"no chromosomal placement is known"* message.

The extra lookup runs only inside the (already-declining) error branch, so no successful projection changes.

## Scope note on the issue's second item

Issue #2103 has a second item — the parser reads only `type="main_assembly"` and discards each LRG XML's `type="other_assembly"` (GRCh37) mapping, so ferro cannot *serve* a GRCh37 request. The issue itself frames that as future work: *"Declining is the right immediate fix and #2089 is right to make it. Serving the answer is the better eventual one."* Serving it requires extending the single-span/`<diff>` parser to the `other_assembly` mappings (which carry 967 `lrg_ins` / 860 `other_ins` indel diffs across the prepared reference) and is unverifiable without the full 1294-record reference — a separate, larger change. This PR delivers the determinate defect (the misstated cause) and the actionable core of the second item: the decline no longer claims the mapping is absent — it names the build the placement is on. Recovering the GRCh37 mapping itself remains follow-up work.

## Test

`reanchor_ng_parent_placed_on_other_build_names_the_available_build` pins that a `GRCh37` request against a GRCh38-only placement names both builds, points at `--assembly GRCh38`, names `NC_000017.11`, and does **not** say "no chromosomal placement is known". `reanchor_ng_parent_with_no_placement_on_any_build_still_reports_unknown` pins that a genuine data gap keeps the unknown-placement message even when a build is requested. Verified failing-first: with the detection neutralized, the first test fails on the old message text.

## Gate

`cargo fmt --check`, `cargo clippy --all-features --all-targets -D warnings`, `cargo nextest run --features dev --no-fail-fast` (11347 passed), `scripts/run_oracle_suite.sh` (11177 passed), the scoped Python-binding Rust tests (10 passed), and `pytest tests/python/` (1137 passed) all green.

Representation-Change: none. The change only alters the *text* of a decline-branch error (decline stays a decline in every case — no previously-accepted input is now declined and no previously-declined input is now accepted), so no normalized corpus row moves.

Closes #2103
