### PR TITLE
fix(project): surface no-placement decline in project_variant_all

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1556,6 +1556,39 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         //    (#653/#713); the parent placement must be selected by the input's
         //    build, matching what `deanchor` itself used.
         let input_build = self.build_hint_for_variant(variant);
+        // A bare `NG_`/`LRG_` genomic *input* carries parent-relative coordinates
+        // that only a chromosomal placement can map into the fan-out (`NC_`) frame.
+        // With no placement on the requested build, `deanchor_genomic_parent_input`
+        // leaves the input in its unmappable parent frame and the fan-out below
+        // enumerates nothing — degrading a genuine decline into an empty
+        // `Ok(vec![])` a caller cannot distinguish from "this locus overlaps no
+        // transcripts" (#2102). Surface the parent's decline instead, mirroring
+        // `project_to_genomic`'s no-placement decline (`reanchor_genome_output`,
+        // #480/#655). A bare `NC_` chromosome input is already in the fan-out frame
+        // and must NOT be caught here — it legitimately has no placement and fans
+        // out (or returns an empty `Vec` for a locus with no transcripts) as before.
+        if let HgvsVariant::Genome(gv) = variant {
+            if (&*gv.accession.prefix == "NG" || gv.accession.is_lrg())
+                && self
+                    .provider
+                    .genomic_placement_on_build(&gv.accession, input_build)
+                    .is_none()
+            {
+                return Err(FerroError::UnsupportedProjection {
+                    reason: format!(
+                        "cannot enumerate transcripts overlapping {}{}: no chromosomal \
+                         placement is known for this NG_/LRG_ reference, so its \
+                         parent-relative coordinates cannot be mapped into cdot's \
+                         chromosome (NC_) frame (#480/#2102)",
+                        gv.accession.transcript_accession(),
+                        match input_build {
+                            Some(build) => format!(" on {build}"),
+                            None => String::new(),
+                        },
+                    ),
+                });
+            }
+        }
         let (variant, parent) = self.deanchor_genomic_parent_input(variant);
         // 1. Normalize once in the genome frame, then fan out across the
         //    overlapping transcripts. Use `normalize_core_checked` to keep the
@@ -10564,6 +10597,41 @@ mod tests {
             let err = vp
                 .project_to_genomic(&HgvsVariant::Cds(cds))
                 .expect_err("NG_ parent without a placement must decline, not emit invalid HGVS");
+            match err {
+                FerroError::UnsupportedProjection { reason } => assert!(
+                    reason.contains("NG_TEST.1") && reason.contains("no chromosomal placement"),
+                    "expected a no-placement decline naming NG_TEST.1, got: {reason}"
+                ),
+                other => panic!("expected UnsupportedProjection, got: {other:?}"),
+            }
+        }
+
+        /// The multi-axis sibling of the decline above (#2102). A bare `NG_`/`LRG_`
+        /// genomic *input* carries parent-relative coordinates that only a
+        /// chromosomal placement can map into the fan-out (`NC_`) frame. With no
+        /// placement on the requested build, `project_variant_all` must surface the
+        /// parent's decline the way `project_to_genomic` does — not degrade it into
+        /// an empty `Ok(vec![])`, which a caller cannot distinguish from "this locus
+        /// overlaps no transcripts".
+        #[test]
+        fn project_variant_all_ng_parent_without_placement_declines() {
+            let (projector, provider) = make_test_provider_and_projector();
+            let vp = VariantProjector::new(projector, provider);
+            // NG_TEST.1 has no registered chromosomal placement in the test provider.
+            let g = GenomeVariant {
+                accession: ng_parent("TEST", 1),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    GenomeInterval::point(GenomePos::new(5)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: Base::T,
+                    },
+                ),
+            };
+            let err = vp
+                .project_variant_all(&HgvsVariant::Genome(g))
+                .expect_err("NG_ genomic input without a placement must decline, not return []");
             match err {
                 FerroError::UnsupportedProjection { reason } => assert!(
                     reason.contains("NG_TEST.1") && reason.contains("no chromosomal placement"),


### PR DESCRIPTION
Closes #2102

## Problem

After #2089, a parent (`NG_`/`LRG_`) with no chromosomal placement on the requested build correctly **declines** at the provider — but `project_variant_all` degraded that decline into a silent empty success. For a genomic parent input such as `LRG_1:g.5000A>G` under GRCh37 (where the LRG has no GRCh37 placement), `deanchor_genomic_parent_input` cannot map the parent-relative coordinate into cdot's chromosome (`NC_`) frame, so it left the input unmapped and the fan-out enumerated nothing — returning `Ok(vec![])`.

That is indistinguishable from "this locus overlaps no transcripts" (the same *checked-and-clean vs couldn't-check* ambiguity as #1998 / #2082). `warn_assembly_conflict` cannot compensate because `infer_input_build` returns `None` for an LRG accession, so nothing was logged either.

## Fix

`project_variant_all` now surfaces the parent's decline the way `project_to_genomic` already does (`reanchor_genome_output`, #480/#655): a `Genome` input on an `NG_`/`LRG_` accession with no placement on the requested build returns `Err(UnsupportedProjection)` naming the reference, rather than an empty `Ok`.

The guard is scoped precisely to the reported condition:
- A bare `NC_` chromosome input is explicitly excluded — it is already in the fan-out frame and legitimately returns an empty `Vec` for a locus with no transcripts (unchanged; covered by the existing `test_project_all_no_overlap_returns_empty`).
- An `NG_`/`LRG_` input *with* a resolvable placement is unaffected — it de-anchors and enumerates as before.

The CLI's `enumerate_transcript_ids` already maps `UnsupportedProjection` to an empty list via `engine_error_is_unavailable`, so the `ferro project` "needs `--transcript`" message is unchanged. The Python bindings (`project_all` / `project_variant_all`) now raise `ProjectionError` for this condition instead of returning `[]`, which is the distinguishability the issue asks for.

## Tests

Added `project_variant_all_ng_parent_without_placement_declines`, the multi-axis sibling of the existing `project_to_genomic_ng_parent_without_placement_declines`. Red before the fix (returned `[]`), green after.

## Representation change

The change converts a previously-silent empty-`Ok` into an `Err` for a no-placement `NG_`/`LRG_` genomic input to `project_variant_all`; it alters an API return *shape*, not any normalized spelling.

The `examples/dump_normalized_corpus.rs` run is byte-identical before/after (96182 rows), but that zero is **structural, not evidence of safety**: the synthetic corpus builds only `NC_TEST.1` / `NM_TEST.1` / `NM_TESTX.1` / `NP_TEST.1` and contains **no `NG_`/`LRG_` accession**, so the instrument cannot exercise the affected path at all. The honest statement is that this is an **API-return-shape break** for any caller that distinguishes `Ok(vec![])` (checked-clean: placed, nothing overlaps) from `Err` (couldn't-check: no placement on the requested build) — which is the whole point of the fix (the #1998/#2082 ambiguity). It moves no normalized *representation*, hence the trailer verdict is `none`, but reviewers weighing downstream impact should read the return-shape change, not the corpus zero.

Representation-Change: none. API return-shape change only (empty Ok -> Err for a no-placement NG_/LRG_ input); no normalized spelling moves. The corpus builds no NG_/LRG_ accession, so its 0/96182 is a STRUCTURAL zero (the instrument cannot see this path), not a safety measurement.

