### PR TITLE
ci: cover #2080's fourth dead-coverage site (service hgvs_rs enabled arm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2131,6 +2131,27 @@ jobs:
         run: |
           cargo nextest run --features hgvs-rs --lib --no-tests=fail \
             -E 'test(benchmark::hgvs_rs::)'
+      # src/service/tools/hgvs_rs.rs was #2080's FOURTH dead-coverage site (#2101),
+      # which the step above cannot reach. `src/service` compiles only under
+      # `web-service` (`#[cfg(feature = "web-service")] pub mod service;`), while the
+      # enabled arm of `service::tools::hgvs_rs::tests::test_hgvs_rs_service_creation`
+      # is `#[cfg(feature = "hgvs-rs")]`. No other CI job builds BOTH features at once:
+      # `dev` (the sharded `test` jobs) has `web-service` but not `hgvs-rs`, and the
+      # step above has `hgvs-rs` but not `web-service` — so that arm ran nowhere and a
+      # break in it passed every check, the same family as the step above. It is
+      # reached here by asking for the two features together.
+      #
+      # Hermetic for the same reason: the test drives `HgvsRsService::new` with an
+      # empty seqrepo path, which fails during provider path parsing before any UTA
+      # connection is attempted, so it needs no database, SeqRepo, or spec submodule.
+      # A SEPARATE build (not folded into the step above) because `web-service` pulls
+      # axum/tokio/tower, a tree the benchmark step does not need — keeping them apart
+      # leaves #2080's proven coverage on exactly the feature set it was verified with.
+      # SCOPED and `--no-tests=fail` for the same non-vacuity reasons as above.
+      - name: Run src/service/tools/hgvs_rs.rs unit tests
+        run: |
+          cargo nextest run --features hgvs-rs,web-service --lib --no-tests=fail \
+            -E 'test(service::tools::hgvs_rs::)'
 
   # The generated-doc `--check` gates. Split out of the old monolithic Test job
   # so they no longer sit behind the whole suite on the critical path.

--- a/src/service/tools/hgvs_rs.rs
+++ b/src/service/tools/hgvs_rs.rs
@@ -182,33 +182,49 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn test_hgvs_rs_service_creation_without_feature() {
+    fn test_hgvs_rs_service_creation() {
+        // An empty `seqrepo_path` makes provider construction fail deterministically
+        // and *independently of any live UTA database*: with the `hgvs-rs` feature
+        // enabled, `HgvsRsService::new` builds a real UTA/SeqRepo provider, and the
+        // empty path aborts provider construction during path parsing — before any
+        // database connection is attempted (an empty `Path` has no `parent()`). So
+        // the assertions below hold whether or not a UTA server happens to be
+        // reachable from the test host. Without the feature, the value is ignored and
+        // the constructor returns its static feature-not-enabled error.
         let config = HgvsRsConfig {
             enabled: true,
             uta_url: "postgresql://anonymous:anonymous@localhost:5432/uta/uta_20210129b"
                 .to_string(),
             uta_schema: "uta_20210129b".to_string(),
-            seqrepo_path: PathBuf::from("/tmp"),
+            seqrepo_path: PathBuf::new(),
             lrg_mapping_file: None,
             parallel_workers: Some(1),
         };
 
-        // Without hgvs-rs feature, this should return a configuration error
-        #[cfg(not(feature = "hgvs-rs"))]
-        {
-            let result = HgvsRsService::new(&config);
-            assert!(result.is_err());
-            if let Err(ServiceError::ConfigError(msg)) = result {
-                assert!(msg.contains("hgvs-rs"));
-            }
-        }
+        let result = HgvsRsService::new(&config);
 
-        // With hgvs-rs feature, this might fail due to missing database, but shouldn't panic
-        #[cfg(feature = "hgvs-rs")]
-        {
-            // This may succeed or fail depending on whether the database is available,
-            // but it must not panic — the binding is discarded deliberately.
-            let _result = HgvsRsService::new(&config);
+        // In every feature configuration, construction with this config must fail with
+        // a `ConfigError` and must never panic. The error-variant assertion is
+        // unconditional: an `Ok`, or a differently-typed `ServiceError`, now fails the
+        // test instead of passing silently (the previous `if let` swallowed both).
+        match result {
+            Err(ServiceError::ConfigError(msg)) => {
+                // Without the feature the message is our own static string, which names
+                // the missing feature; assert on it. With the feature the message comes
+                // from the provider layer and is not contractually fixed, so only the
+                // variant is asserted there.
+                #[cfg(not(feature = "hgvs-rs"))]
+                assert!(
+                    msg.contains("hgvs-rs"),
+                    "config error should name the required feature, got: {msg}"
+                );
+                #[cfg(feature = "hgvs-rs")]
+                let _ = msg;
+            }
+            Err(other) => panic!("expected ServiceError::ConfigError, got {other:?}"),
+            Ok(_) => {
+                panic!("HgvsRsService::new unexpectedly succeeded with an empty seqrepo path")
+            }
         }
     }
 


### PR DESCRIPTION
Closes #2101

## What

#2080 documented four dead-coverage sites; #2084 reached three. This covers the fourth: the `#[cfg(feature = "hgvs-rs")]` arm of `service::tools::hgvs_rs::tests::test_hgvs_rs_service_creation` (formerly `..._without_feature`).

## Why it was uncovered

`src/service` compiles only under `web-service` (`#[cfg(feature = "web-service")] pub mod service;`), while the enabled arm is gated on `hgvs-rs`. No CI job builds both features at once:

- the sharded `Test` jobs use `--features dev`, which has `web-service` but not `hgvs-rs`;
- #2084's `hgvs-rs Rust tests` job uses `--features hgvs-rs`, without `web-service`.

So the enabled arm ran nowhere and a break in it passed every check — the same dead-coverage family as #2084's benchmark tests, one feature combination over.

## Changes

- **CI**: a second step in the `hgvs-rs Rust tests` job builds `--features hgvs-rs,web-service` and runs `-E 'test(service::tools::hgvs_rs::)'` under nextest with `--no-tests=fail`. It is a separate build from #2084's benchmark step, so that proven coverage stays on exactly the feature set it was verified with.
- **Test**: both feature arms now assert unconditionally that `HgvsRsService::new` fails with a `ServiceError::ConfigError` and never panics. The previous enabled arm asserted nothing (`let _result = ...`), and the disabled arm's `assert!(msg.contains("hgvs-rs"))` sat inside an `if let`, so a differently-typed error passed silently. The config uses an empty `seqrepo_path`, which makes provider construction fail during path parsing *before any UTA connection is attempted* — so the failure is deterministic and independent of whether a live UTA database is reachable.

## Verification

- `--features hgvs-rs,web-service` selection: both tests PASS (enabled arm now executes).
- `--features dev` selection: both tests PASS (disabled arm).
- **Mutation**: changing the enabled arm's error variant `ConfigError` → `InternalError` turns the test RED (`expected ServiceError::ConfigError, got InternalError(... could not get parent from ...)`), confirming the test exercises the enabled arm and asserts on its real behavior, and that the failure arises pre-database.
- Full local gate green: `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo nextest run --features dev --no-fail-fast` (11354 passed), `actionlint`.

Representation-Change: none. CI/test-coverage only; no library normalization behavior changed and no watched prefix (`src/normalize|hgvs|spdi|project|reference|error_handling`) is touched.