### PR TITLE
fix(project): apply the codon-frame delins exception on a projected coding axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Full guides live in **[the documentation site](https://ferro-hgvs.readthedocs.io
 - [Normalization rules](docs/src/reference/normalization-rules.md) — ferro's output contract: what a normalized description is allowed to be
 - [Deriving a description from sequences](docs/src/guide/deriving-from-sequences.md) — turn a window of bases into one canonical description, no reference needed
 - [Normalize variants](docs/src/guide/normalize-variants.md) · [Reference data](docs/src/guide/reference-data.md)
+- [Project to another axis](docs/src/guide/project-variants.md) — re-express a variant on a transcript; the projected `c.`/`r.` axis applies the coding-axis rules a genomic axis cannot
 - [Error handling](docs/src/guide/error-handling.md) — strict / lenient / silent modes and warning codes
 - [Comparing normalization rules (`FERRO_PARTITION`)](docs/src/guide/comparing-rules.md)
 - [Benchmarking](docs/src/guide/benchmarking.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,6 +11,7 @@
 # Guides
 
 - [Normalize variants](guide/normalize-variants.md)
+- [Project to another axis](guide/project-variants.md)
 - [Deriving a description from sequences](guide/deriving-from-sequences.md)
 - [Reference data](guide/reference-data.md)
 - [Error handling](guide/error-handling.md)

--- a/docs/src/guide/project-variants.md
+++ b/docs/src/guide/project-variants.md
@@ -1,0 +1,34 @@
+# Project a variant to another axis
+
+`ferro project` re-expresses a variant on a chosen output axis — genomic (`g`), coding (`c`), non-coding (`n`), protein (`p`), or RNA (`r`) — against a transcript. It is how you move a genomic call onto a transcript, or read the protein consequence of a coding one.
+
+```bash
+ferro project --axis c --transcript NM_000059.4 --reference <dir> \
+  'NC_000013.11:g.32316466T>G'
+# NC_000013.11(NM_000059.4):c.6T>G
+```
+
+## Coding-axis rules apply on the projected axis
+
+The projected `c.`/`r.` axis is normalized on the transcript, so it applies the coding-axis rules a bare genomic axis cannot — and produces the same string `ferro normalize` gives for the coding-authored form of the variant, whichever axis you started from.
+
+The clearest case is the coding one-amino-acid `delins` exception (`DNA/delins.md:18`): two substitutions one nucleotide apart **within a single codon** are written as one `delins`, not as two members.
+
+```bash
+# BRCA2 codon 2 (c.4_6 = CCT): c.4 C>A and c.6 T>G, with c.5 unchanged.
+ferro project --axis c --transcript NM_000059.4 --reference <dir> \
+  'NC_000013.11:g.[32316464C>A;32316466T>G]'
+# NC_000013.11(NM_000059.4):c.4_6delinsACG
+```
+
+Because both members fall in one codon, the coding axis merges them into `c.4_6delinsACG` — identical to `ferro normalize` on `NM_000059.4:c.[4C>A;6T>G]`. The genomic axis has no reading frame, so it keeps the members individual, and a pair that straddles a codon boundary or an exon junction stays split on every axis.
+
+## Pairs with deriving from sequences
+
+If you hold bases rather than a description — a window from a BAM, a VCF row — derive the genomic description with `from_sequences` first (see [Deriving a description from sequences](deriving-from-sequences.md)), then project it onto the transcript:
+
+```bash
+# 1. derive the g. description from the bases
+# 2. project it onto the transcript
+ferro project --axis c --transcript NM_000059.4 --reference <dir> '<the g. description>'
+```

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1012,12 +1012,16 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         }
     }
 
-    /// Non-variant-aware transcript fetch with caching. Kept for inline tests
+    /// Non-variant-aware transcript fetch with caching. Used by inline tests
     /// that need to populate a `Transcript` for `cached_ref_translation`
-    /// without constructing an `HgvsVariant`. Hot-path callers go through
-    /// [`Self::cached_get_transcript_for_variant`] so an NG/NC-parented input
-    /// resolves to the correct cdot build (issue #332).
-    #[cfg(test)]
+    /// without constructing an `HgvsVariant`, and by
+    /// [`Self::codon_pair_is_within_one_exon`], which wants the transcript's own
+    /// exon table by id irrespective of the projected input's accession.
+    /// Coordinate-mapping hot-path callers go through
+    /// [`Self::cached_get_transcript_for_variant`] instead, so an NG/NC-parented
+    /// input resolves to the correct cdot build (issue #332); the exon-membership
+    /// check does not need that, because a versioned `transcript_id` fixes the
+    /// transcript-coordinate exon offsets regardless of genome build.
     fn cached_get_transcript(&self, transcript_id: &str) -> Result<Arc<Transcript>, FerroError> {
         let key = (transcript_id.to_string(), None);
         if let Some(tx) = self
@@ -3761,7 +3765,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // projection names, rather than inheriting whatever the authoring axis
         // chose (#1664). Runs on the assembled projection so it can compare the
         // axis that carries the reading frame against the ones that do not.
-        projection = self.apply_codon_frame_exception(projection, variant, transcript_id)?;
+        projection = self.apply_codon_frame_exception(projection, transcript_id)?;
         // Withhold a genomic axis that came out as a non-flanking insertion
         // (#1264). Done here, on the assembled projection, so only the genomic
         // axis declines: the same variant's c./n./r./p. forms are unaffected by
@@ -3816,7 +3820,6 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     fn apply_codon_frame_exception(
         &self,
         mut projection: VariantProjection,
-        original: &HgvsVariant,
         transcript_id: &str,
     ) -> Result<VariantProjection, FerroError> {
         use crate::project::codon_exception as codon;
@@ -3845,17 +3848,12 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             // result instead of predicting it.
             let all_within_one_exon = !pairs.is_empty()
                 && pairs.iter().all(|&(left, right)| {
-                    self.codon_pair_is_within_one_exon(original, transcript_id, left, right)
+                    self.codon_pair_is_within_one_exon(transcript_id, left, right)
                 });
             if all_within_one_exon {
                 if let Ok(merged) = self.normalizer.normalize(&coding) {
                     if codon::member_count(&merged) < codon::member_count(&coding)
-                        && self.merged_members_stay_within_one_exon(
-                            original,
-                            transcript_id,
-                            &coding,
-                            &merged,
-                        )
+                        && self.merged_members_stay_within_one_exon(transcript_id, &coding, &merged)
                     {
                         // Terminates: `merged` has strictly fewer members, so
                         // the re-projection's coding axis cannot re-enter here.
@@ -3937,7 +3935,6 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// unservable transcript.
     fn merged_members_stay_within_one_exon(
         &self,
-        variant: &HgvsVariant,
         transcript_id: &str,
         coding: &HgvsVariant,
         merged: &HgvsVariant,
@@ -3946,9 +3943,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         else {
             return false;
         };
-        spans.iter().all(|&(first, last)| {
-            self.codon_pair_is_within_one_exon(variant, transcript_id, first, last)
-        })
+        spans
+            .iter()
+            .all(|&(first, last)| self.codon_pair_is_within_one_exon(transcript_id, first, last))
     }
 
     /// Do CDS positions `left` and `right` sit inside one exon of
@@ -3957,14 +3954,15 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// `false` for an unservable transcript or one with no CDS: without an exon
     /// table there is no basis to claim the pair does not cross a junction, and
     /// the codon exception's caller declines on `false`.
-    fn codon_pair_is_within_one_exon(
-        &self,
-        variant: &HgvsVariant,
-        transcript_id: &str,
-        left: i64,
-        right: i64,
-    ) -> bool {
-        let Ok(transcript) = self.cached_get_transcript_for_variant(variant, transcript_id) else {
+    fn codon_pair_is_within_one_exon(&self, transcript_id: &str, left: i64, right: i64) -> bool {
+        // `cached_get_transcript`, not `cached_get_transcript_for_variant`: for a
+        // genomic-authored input the latter resolves the *chromosome* accession to
+        // a CDS-less transcript — an `Ok`, so the `ReferenceNotFound` fallback to
+        // `get_transcript(transcript_id)` never fires — which left `cds_start`
+        // `None` and declined every codon-frame merge on the projected coding
+        // axis, so `project --axis c` of a genomic cis allele disagreed with
+        // `normalize` of the coding-authored form (#2127).
+        let Ok(transcript) = self.cached_get_transcript(transcript_id) else {
             return false;
         };
         let Some(cds_start) = transcript.cds_start.and_then(|s| i64::try_from(s).ok()) else {
@@ -7387,17 +7385,61 @@ mod tests {
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
-        // Genomic sequence so the genomic-projection step of each member resolves:
-        // N*1000 + DELINS CDS + filler + SEP CDS + tail (plus strand → genomic
-        // bases equal the transcript bases at each exon offset).
+        // Genomic sequence so the genomic-projection step of each member resolves.
+        provider.add_genomic_sequence("chr1", multicodon_genome());
+        (projector, provider)
+    }
+
+    /// The `chr1` contig backing [`make_multicodon_provider_and_projector`]:
+    /// N*1000 + DELINS CDS + filler + SEP CDS + tail (plus strand → genomic
+    /// bases equal the transcript bases at each exon offset).
+    fn multicodon_genome() -> String {
         let mut genome = String::new();
         genome.push_str(&"N".repeat(1000));
         genome.push_str("ATGGATTATTAA"); // [1000, 1012)
         genome.push_str(&"N".repeat(2000 - 1012));
         genome.push_str("ATGGATTATTGCTAA"); // [2000, 2015)
         genome.push_str(&"N".repeat(100));
-        provider.add_genomic_sequence("chr1", genome);
-        (projector, provider)
+        genome
+    }
+
+    /// Register the multicodon fixture's `chr1` contig as a **CDS-less
+    /// transcript record**, which is what a
+    /// real `MultiFastaProvider` serves when asked for a chromosome accession:
+    /// `get_transcript` resolves the contig out of the genome FASTA index, finds
+    /// no cdot record and no supplemental CDS for it, and returns
+    /// `TranscriptMetadata::default()` — an `Ok` carrying `cds_start: None` and
+    /// an empty exon table (`multi_fasta.rs`'s `get_supplemental_cds_info`).
+    ///
+    /// Without this the mock answers `ReferenceNotFound` for a bare contig, so
+    /// `cached_get_transcript_for_variant`'s fallback to `get_transcript` fires
+    /// and resolves the *right* transcript anyway — which makes #2127
+    /// structurally unreachable on a `JsonProvider` and any guard against it
+    /// vacuous. Only `cds_start: None` is load-bearing (the codon-frame exon
+    /// guard returns `false` on it before reading the exon table); the sequence
+    /// and empty exons are carried so the record matches what the real provider
+    /// builds.
+    fn register_multicodon_contig_as_cds_less_transcript(provider: &mut MockProvider) {
+        provider.add_transcript(Transcript {
+            cds_start_incomplete: false,
+            id: "chr1".to_string(),
+            gene_symbol: None,
+            strand: TxStrand::Plus,
+            sequence: Some(multicodon_genome()),
+            cds_start: None,
+            cds_end: None,
+            exons: Vec::new(),
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
     }
 
     /// Provider for the #1076 intron-split-codon test: `NM_SPLIT.1`, a two-exon
@@ -14513,6 +14555,114 @@ mod tests {
         assert_eq!(
             format!("{protein}"),
             "NP_DELINS.1:p.(Asp2_Tyr3delinsTyrCys)"
+        );
+    }
+
+    /// #2127: a genomic-authored cis allele whose two members sit one nucleotide
+    /// apart **within one codon** must project to the merged coding delins — the
+    /// same string `normalize` produces for the coding-authored form — not the
+    /// split it used to leave. `NM_SEP.1` codon 2 is `GAT` (`c.4_6`, `c.5`
+    /// unchanged) at `g.2004_2006`; `g.2004G>C` + `g.2006T>A` give `CAA` (Gln).
+    ///
+    /// The defect was axis-of-origin dependence: the projector's codon-frame
+    /// exon guard resolved the transcript from the *input's* accession, which for
+    /// a genomic input is a chromosome carrying no CDS, so `cds_start` was `None`
+    /// and every merge was declined. The coding-authored form
+    /// (`project_cis_adjacent_substitutions_combine_to_delins`, above) already
+    /// merged, so the two routes disagreed on one variant's `c.` string. The
+    /// junction-crossing negative control is
+    /// `project_cis_intron_split_codon_combines_to_single_missense`, which must
+    /// stay split — the guard now declines it on the exon test rather than on a
+    /// missing CDS.
+    ///
+    /// **Read this as a change detector, not as the arming guard.** Measured with
+    /// the fix reverted, this end-to-end assertion passes anyway, for two
+    /// separate reasons — so do not cite it as evidence the defect is caught.
+    /// First, a bare `JsonProvider` answers `ReferenceNotFound` for a contig,
+    /// which fires `cached_get_transcript_for_variant`'s fallback and resolves
+    /// `NM_SEP.1` regardless; `register_multicodon_contig_as_cds_less_transcript`
+    /// closes that half by serving what a real `MultiFastaProvider` serves for a
+    /// chromosome accession. Second, and not closable from here: since #2108 the
+    /// projector shares its transcript cache with its normalizer, and the
+    /// normalizer's own `get_transcript("NM_SEP.1")` populates
+    /// `("NM_SEP.1", None)` — the very key the pre-fix variant-aware lookup
+    /// computes for a bare `g.` input — *before* the codon guard runs, so the
+    /// pre-fix guard reads the right transcript out of the cache and merges.
+    ///
+    /// The guard that is actually armed against #2127 is
+    /// `the_codon_frame_exon_guard_resolves_the_transcript_by_id`, which asks
+    /// `codon_pair_is_within_one_exon` on a **cold** projector: measured `false`
+    /// pre-fix, `true` after. On the real reference the end-to-end defect is
+    /// live either way (`project --axis c` of
+    /// `NC_000013.11:g.[32316464C>A;32316466T>G]` onto `NM_000059.4` gave
+    /// `c.[4C>A;6T>G]` before and gives `c.4_6delinsACG` after).
+    #[test]
+    fn project_genomic_cis_same_codon_pair_merges_on_the_coding_axis() {
+        let (projector, mut provider) = make_multicodon_provider_and_projector();
+        register_multicodon_contig_as_cds_less_transcript(&mut provider);
+        let contig_record = provider.get_transcript("chr1").expect(
+            "the fixture must serve chr1 as a transcript record, as the real provider does",
+        );
+        assert!(
+            contig_record.cds_start.is_none(),
+            "the contig record must carry no CDS, or the pre-fix guard would have resolved one"
+        );
+        let vp = VariantProjector::new(projector, provider);
+        let v1 = crate::parse_hgvs("chr1:g.2004G>C").expect("v1 parse");
+        let v2 = crate::parse_hgvs("chr1:g.2006T>A").expect("v2 parse");
+        let allele = HgvsVariant::Allele(AlleleVariant::cis(vec![v1, v2]));
+        let proj = vp
+            .project_variant(&allele, "NM_SEP.1")
+            .expect("projection should succeed");
+        let coding = proj.coding.as_ref().expect("coding present").to_string();
+        assert!(
+            coding.contains("c.4_6delinsCAA"),
+            "genomic cis same-codon pair must merge on the coding axis, got {coding}"
+        );
+    }
+
+    /// #2127, at the seam the fix changed: exon membership is a property of the
+    /// transcript the `c.` members are numbered on, so
+    /// [`VariantProjector::codon_pair_is_within_one_exon`] must resolve it by
+    /// `transcript_id` and never from the projected input's accession.
+    ///
+    /// This is the armed half of the pair — it calls the guard on a **cold**
+    /// projector, so no earlier fetch can have cached the right transcript under
+    /// the `(transcript_id, None)` key the pre-fix variant-aware lookup computes
+    /// for a bare `g.` input. Measured: `false` with the fix reverted (the
+    /// contig record's `cds_start` is `None`), `true` with it applied.
+    ///
+    /// The three negative halves are what the fix must NOT change: a pair
+    /// straddling an exon junction stays declined, a pair inside one exon of the
+    /// same two-exon transcript is still admitted, and a transcript with no CDS
+    /// (a contig, or an `NR_`/`n.` transcript) is still declined rather than
+    /// treated as one exon.
+    #[test]
+    fn the_codon_frame_exon_guard_resolves_the_transcript_by_id() {
+        let (projector, mut provider) = make_multicodon_provider_and_projector();
+        register_multicodon_contig_as_cds_less_transcript(&mut provider);
+        let vp = VariantProjector::new(projector, provider);
+        assert!(
+            vp.codon_pair_is_within_one_exon("NM_SEP.1", 4, 6),
+            "codon 2 of NM_SEP.1 is one exon deep in a single-exon transcript; the guard \
+             must read that transcript's exon table, not the contig the input names"
+        );
+        assert!(
+            !vp.codon_pair_is_within_one_exon("chr1", 4, 6),
+            "a CDS-less record (a contig, or an NR_ transcript) has no exon basis and \
+             must still decline"
+        );
+
+        let (projector, provider) = make_intron_split_codon_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        assert!(
+            !vp.codon_pair_is_within_one_exon("NM_SPLIT.1", 4, 6),
+            "NM_SPLIT.1 c.4 ends exon 1 and c.6 sits in exon 2; the pair crosses the \
+             junction and must decline"
+        );
+        assert!(
+            vp.codon_pair_is_within_one_exon("NM_SPLIT.1", 5, 7),
+            "NM_SPLIT.1 c.5_7 is wholly inside exon 2 and must still be admitted"
         );
     }
 


### PR DESCRIPTION
Closes #2127.

## The defect

Projecting a genomic-authored (or otherwise multi-member) cis allele onto a transcript left two same-codon substitutions one nucleotide apart **split** on the coding axis, while `normalize` of the coding-authored form **merged** them — one variant, two `c.` strings by entry route.

Measured against the prepared reference (BRCA2 `NM_000059.4`, codon 2 = `c.4_6` = `CCT`, `c.5` unchanged; `--axis` as shown, base `159bd867`):

| input | axis | before | after |
|---|---|---|---|
| `NC_000013.11:g.[32316464C>A;32316466T>G]` | `c` | `c.[4C>A;6T>G]` | `c.4_6delinsACG` |
| `NC_000013.11:g.32316464_32316466delinsACG` | `c` | `c.[4C>A;6T>G]` | `c.4_6delinsACG` |
| `NM_000059.4:c.[4C>A;6T>G]` (coding-authored) | `c` | `c.4_6delinsACG` | unchanged |
| `NC_000013.11:g.[32316464C>A;32316466T>G]` | `n` | `n.[203C>A;205T>G]` | `n.203_205delinsACG` |
| `NC_000013.11:g.[32316464C>A;32316466T>G]` | `r` | `r.[(4c>a;6u>g)]` | `r.(4_6delinsacg)` |
| `NC_000013.11:g.[32316464C>A;32316466T>G]` | `g` | `g.[32316464C>A;32316466T>G]` | unchanged |
| `NC_000013.11:g.[32316464C>A;32316466T>G]` | `p` | `p.(Pro2Thr)` | unchanged |

`c.4_6` is deep in exon 1 (CDS starts at tx offset 199; exon 1 spans tx 161–266), so this is not a junction decline. This is the mirror of the closed #1664, which covered a coding-authored input's projected *genomic* axis; `projection-codon-exception-is-decided-by-the-rendered-axis` (decided) keeps the genomic axis split and states the `c.`/`r.` axes merge — the merge this restores.

## The fix

`VariantProjector::apply_codon_frame_exception` found the candidate pair correctly (`coding_codon_pairs` → `[(4, 6)]`), but its one-exon guard `codon_pair_is_within_one_exon` resolved the transcript with `cached_get_transcript_for_variant(original, transcript_id)`. For a genomic-authored input that accession is a chromosome, which `get_transcript_for_variant` resolves out of the genome FASTA index; with no cdot record and no supplemental CDS for a contig it returns `TranscriptMetadata::default()` — an `Ok`, so the `ReferenceNotFound` fallback to `get_transcript(transcript_id)` never fires — leaving `cds_start = None` and declining every merge.

Exon membership is a property of the transcript the `c.` members are numbered on, not of the input's accession, so the guard now resolves by `transcript_id` via `cached_get_transcript`. The now-unused `variant` argument is dropped from `codon_pair_is_within_one_exon`, `merged_members_stay_within_one_exon` and `apply_codon_frame_exception`, and `cached_get_transcript` is promoted from `#[cfg(test)]` to production for this caller (it shares the existing `transcript_cache`).

## The regression guard, and which half of it is armed

`the_codon_frame_exon_guard_resolves_the_transcript_by_id` is the armed guard. It calls the exon test directly on a **cold** projector, with the fixture serving `chr1` as the CDS-less transcript record a real `MultiFastaProvider` returns for a contig: measured `false` before the change and `true` after. Its three negative halves are the properties the change must not move — a junction-crossing pair still declines, a pair inside one exon of the same two-exon transcript is still admitted, and a CDS-less record still declines rather than being treated as one exon.

The end-to-end `project_genomic_cis_same_codon_pair_merges_on_the_coding_axis` is **documented in the source as a change detector, not as the arming guard**, because it was measured passing with the fix reverted, for two independent reasons. A bare `JsonProvider` answers `ReferenceNotFound` for a contig, which fires the variant-aware fallback and resolves the right transcript anyway; registering the contig record closes that half. The half that cannot be closed from a test: since #2108 the projector shares its transcript cache with its normalizer, and the normalizer's own `get_transcript("NM_SEP.1")` populates `("NM_SEP.1", None)` — the very key the pre-fix variant-aware lookup computes for a bare `g.` input — before the codon guard runs, so the pre-fix guard reads the right transcript out of the cache. Both facts are recorded on the tests so the next reader does not cite a vacuous pass.

Sabotage results on the shipped tree (mutate, run, restore, `git hash-object` verified byte-identical):

| mutation of `codon_pair_is_within_one_exon` | exit | red |
|---|---|---|
| resolve the contig instead of `transcript_id` (the #2127 mechanism) | 100 | the armed guard **and** the end-to-end test |
| return `true` unconditionally | 100 | the armed guard and `project_cis_intron_split_codon_combines_to_single_missense` |
| return `false` unconditionally | 100 | the armed guard and the end-to-end test |

## Unchanged on purpose

- **Junction-crossing / cross-codon pairs stay split.** `project_cis_intron_split_codon_combines_to_single_missense` (an intron-split codon) still declines, now on the exon test rather than on a missing CDS, and the armed guard asserts the junction pair directly. On real data a separation-one pair straddling a codon boundary (`c.6` in codon 2, `c.8` in codon 3) stays `c.[6T>G;8T>A]` on both entry routes, and a separation-two pair stays `c.[4C>A;7A>T]`.
- **The genomic axis is unchanged** — still split, per `projection-codon-exception-is-decided-by-the-rendered-axis`. The protein axis is unchanged too (`p.(Pro2Thr)` both sides; codon-level combination there is #1076's, already shipped).
- **The `n.` and `r.` axes move, and that is confluence rather than new policy.** The ruling leaves `n.` open and grounds the `r.` merge in `RNA/delins.md:18`. Both axes were **already** merged on the coding-authored route before this change (measured: `n.203_205delinsACG`, `r.(4_6delinsacg)`), so what moves is the projected route catching up with the authored one; no axis gains a merge that ferro did not already emit for the same variant by another route.
- **Non-coding transcripts are untouched** — `cds_start = None` is legitimate for an `NR_`/`n.` transcript, and this guard still returns `false` there (asserted in the armed guard). The fix was made at the call site rather than by teaching the shared resolver a CDS-less fallback, which would misfire on those and on the #332 build-resolution path.

## Representation stability

Representation-Change: three projected axes move (c., n., r.); the genomic and protein axes are byte-identical. Projecting a variant whose accession is not the transcript — a genomic-authored or otherwise multi-member cis allele — now merges a same-codon gap-of-one pair into the spanning delins instead of leaving it split, which is the string normalize already produced for the coding-authored form of the same variant, so the change removes an entry-route disagreement rather than introducing a new form. Measured on NM_000059.4: c.[4C>A;6T>G] to c.4_6delinsACG, n.[203C>A;205T>G] to n.203_205delinsACG, r.[(4c>a;6u>g)] to r.(4_6delinsacg), with the g. and p. axes unchanged. Previously-accepted output, so a real migration for a consumer that projects onto a transcript axis and keys on the resulting string. Corpus movement is a STRUCTURAL ZERO and must not be read as a safety measurement: the change is reachable only through VariantProjector::project_variant, and examples/dump_normalized_corpus.rs contains zero references to VariantProjector or project_variant — it exercises normalize alone, so the corpus cannot construct the path this change is on at any seed count.

## Verification

Rebased onto `159bd867`. Each command run unpiped with its own exit status captured into a log and read back:

| gate | exit |
|---|---|
| `cargo nextest run --features dev --no-fail-fast` | 0 — 11374 passed, 151 skipped |
| `cargo clippy --all-features --all-targets -- -D warnings` | 0 |
| `cargo fmt --all --check` | 0 |
| `python3 -m pytest tests/python/ -q` | 0 — 1137 passed, 8 skipped |
| `mdbook build` (docs) | 0 — linkcheck2 clean; `create-missing = false` in place and `guide/project-variants.html` renders 26 KB, not a stub |

The README/`SUMMARY.md` conflicts with the README-slim campaign (#2116, #2121, #2131) were resolved **toward the new structure**: `README.md` is left byte-identical to `origin/main` plus one pointer bullet in its Documentation list, and the long-form content lives in the new mdBook guide, which is linked from `SUMMARY.md` beside the other guides.
