### PR TITLE
docs: move the comparison tables and 'Why ferro-hgvs?' into the mdBook

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,89 +179,13 @@ Full guides live in **[the documentation site](https://ferro-hgvs.readthedocs.io
 - [Comparing normalization rules (`FERRO_PARTITION`)](docs/src/guide/comparing-rules.md)
 - [Benchmarking](docs/src/guide/benchmarking.md)
 - [CLI reference](docs/src/cli/overview.md) · [Supported HGVS syntax](docs/src/reference/hgvs-syntax.md)
+- [Why ferro-hgvs? — tool comparison](docs/src/reference/comparison.md) — capability matrix, cross-tool benchmarks, and what `ferro prepare` builds
 - [Interpreting the HGVS recommendations](docs/src/shadow-spec/index.md) — how ferro reads each clause
 
 
 ## Why ferro-hgvs?
 
-ferro-hgvs provides the most comprehensive HGVS variant normalization across all pattern types, with performance orders of magnitude faster than alternatives.
-
-### Normalization Capabilities Comparison
-
-<!-- DO NOT EDIT — generated from docs/tool_support_matrix.json by `generate_tool_support_tables`. -->
-<!-- BEGIN tool-support:normalization_capabilities -->
-| Pattern Type | ferro | mutalyzer | biocommons | hgvs-rs |
-|--------------|:-----:|:---------:|:----------:|:-------:|
-| Genomic (g.) | ✓ | ✓ | ✓ | ✓ |
-| Coding (c.) exonic | ✓ | ✓ | ✓ | ✓ |
-| Coding (c.) intronic | ✓ | ✓** | ✗ | ✗ |
-| Non-coding (n.) | ✓ | ✓ | ✓ | ✓ |
-| RNA (r.) | ✓ | ✓ | ✓ | ✓ |
-| Protein (p.) | ✓ | Net* | ✗ | ✗ |
-
-\* mutalyzer protein normalization requires network access for NP_→NM_ lookups (cannot be cached locally).
-\*\* mutalyzer intronic support is enabled by default via genomic-context rewriting; disable with --no-rewrite-intronic.
-<!-- END tool-support:normalization_capabilities -->
-
-### Performance Comparison
-
-**All tools are benchmarked in ferro's offline configuration — best case for every tool.** Reference data is preloaded locally (a local UTA database and SeqRepo) and the network is disabled, so the figures below measure parse/normalize compute, not I/O. Out of the box, hgvs-rs, biocommons/hgvs, and mutalyzer resolve each variant against a remote UTA/SeqRepo or the Mutalyzer web API — a network round-trip per variant (~100–1000 ms), i.e. roughly **1–10 variants/sec, hundreds to thousands of times slower than shown here** (an order-of-magnitude estimate from per-call network latency, not separately benchmarked). That local, offline setup is exactly what ferro's `prepare` command builds; ferro needs no external service.
-
-<!-- DO NOT EDIT — generated from data/benchmark/perf_results.json by `generate_perf_tables`. -->
-
-_Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools draw from one stratified ClinVar population; per-tool sample sizes are calibrated so each tool is measured over a meaningful interval — fast cells (e.g. ferro/hgvs-rs parse) draw from millions of patterns, while slower cells (e.g. the per-tool normalize columns) draw from as few as tens to thousands. All tools exclude process/interpreter startup from the timed region — the mutalyzer/biocommons Python subprocesses are timed by their own internal startup-excluded timer, matching ferro/hgvs-rs. Only ferro parallelizes natively (rayon); the other tools are single-threaded libraries, so their normalize *@8 workers* figures come from the benchmark harness running 8 independent instances in parallel, while parsing is not sharded for them — hence the `single-threaded` label in their parse *@8 workers* column (mutalyzer normalize likewise shows no gain at 8 workers: per-call cache and IPC overhead dominate, so sharding does not help). Every tool runs fully offline against local reference data — a local UTA database and SeqRepo, with mutalyzer's network lookups disabled — the configuration ferro's `prepare` command enables; the figures therefore reflect compute throughput, not per-variant network latency. Reference-data load is excluded for all tools. ferro full-population peak: parse 20.0M/s, normalize 77.0k/s. See `docs/BENCHMARK_RUNBOOK.md` for the full method._
-
-**Parse**
-
-<!-- BEGIN perf:parse -->
-| Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
-|------|----------------------:|-----------------------:|-------------------:|
-| ferro | 5.1M/s | 12.2M/s | — |
-| mutalyzer | 352/s | single-threaded | 35,000× |
-| biocommons | 3.9k/s | single-threaded | 3,100× |
-| hgvs-rs | 3.6M/s | single-threaded | 3× |
-<!-- END perf:parse -->
-
-**Normalize**
-
-<!-- BEGIN perf:normalize -->
-| Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
-|------|----------------------:|-----------------------:|-------------------:|
-| ferro | 78.1k/s | 260.2k/s | — |
-| mutalyzer | 4/s | 4/s | 73,000× |
-| biocommons | 368/s | 818/s | 320× |
-| hgvs-rs | 195/s | 1.3k/s | 200× |
-<!-- END perf:normalize -->
-
-**ferro thread scaling**
-
-<!-- BEGIN perf:ferro_scaling -->
-| Threads | 1 | 2 | 4 | 8 |
-|---------|--:|--:|--:|--:|
-| ferro parse | 5.1M/s | 9.4M/s | 16.0M/s | 12.0M/s |
-<!-- END perf:ferro_scaling -->
-
-**Input ordering matters for batch throughput.** Resolving a transcript (reading its full sequence from the reference and rebuilding its CDS/exon metadata) dominates per-variant cost. ferro memoizes resolved transcripts in a bounded in-memory cache, so repeated lookups of the same transcript are near-free. Providing variants **sorted by transcript accession — or by genomic position, which clusters variants onto the same transcripts** — maximizes the cache hit rate and can speed up large batches by an order of magnitude versus randomly-ordered input. Ordering matters most when the number of distinct transcripts in the run exceeds the cache capacity (very large or genome-wide inputs); below that, the working set stays resident regardless of order.
-
-### Reference Data: What ferro Prepares
-
-The `ferro prepare` command downloads and organizes all reference data needed for comprehensive normalization. This data is then shared with other tools (mutalyzer, biocommons, hgvs-rs) to enable their local operation.
-
-| Data Type | Source | Size | Enables |
-|-----------|--------|------|---------|
-| **RefSeq transcripts** | NCBI | ~1GB | NM_/NR_/XM_ normalization |
-| **cdot metadata** | MANE | ~200MB | Transcript-to-genome mappings |
-| **GRCh38 + GRCh37 genomes** | NCBI | ~4GB | NC_ genomic normalization |
-| **RefSeqGene** (sequences + genome alignments) | NCBI | ~600MB | NG_ gene-region normalization; projecting c./n. variants into an NG_ parent's own g. frame (via the RefSeqGene→genome alignment GFF3) |
-| **LRG sequences + XML** | EBI | ~50MB | LRG_ stable-reference normalization; projecting c./n. variants into an LRG_ parent's own g. frame (via the LRG XML genomic mapping) |
-| **Protein sequences** | Derived from CDS | ~200MB | NP_/XP_ protein normalization |
-| **Legacy transcript versions** | NCBI | ~50MB | Historical ClinVar variants |
-
-**Key insight**: Without ferro's reference preparation, other tools require network access for each variant lookup (adding 100-1000ms latency per variant). With ferro's cached reference data, all tools can operate fully offline with consistent, reproducible results.
-
-#### Deriving version-independent NG_ placements (#728)
-
-`ferro prepare --derive-ng-placements <accessions.txt>` derives genomic placements for the listed `NG_` versions (one exact accession per line, e.g. `NG_012337.3`; blank lines and `#` comments ignored), writing `derived_refseqgene_placements.json` into the reference directory and wiring the manifest's `derived_refseqgene_placements` field. This fills version gaps the archived RefSeqGene→genome GFF3 snapshots do not cover. It needs cdot + the genome in the same prepare run and uses NCBI EFetch per accession; accessions that cannot be validated are skipped with a warning. The field is preserved across subsequent `prepare` runs.
+ferro-hgvs provides the most comprehensive HGVS variant normalization across all pattern types, with performance orders of magnitude faster than alternatives. For the full capability matrix against mutalyzer / biocommons / hgvs-rs, the cross-tool parse/normalize benchmarks, and what `ferro prepare` builds, see [**Why ferro-hgvs? — tool comparison**](docs/src/reference/comparison.md).
 
 ## Benchmark: Reference Data & Tool Comparison
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -22,6 +22,7 @@
 - [Normalization rules](reference/normalization-rules.md)
 - [CLI reference](cli/overview.md)
 - [Supported HGVS syntax](reference/hgvs-syntax.md)
+- [Tool comparison](reference/comparison.md)
 
 # Interpretation
 

--- a/docs/src/reference/comparison.md
+++ b/docs/src/reference/comparison.md
@@ -1,0 +1,80 @@
+# Why ferro-hgvs?
+
+ferro-hgvs provides the most comprehensive HGVS variant normalization across all pattern types, with performance orders of magnitude faster than alternatives.
+
+## Normalization Capabilities Comparison
+
+<!-- DO NOT EDIT — generated from docs/tool_support_matrix.json by `generate_tool_support_tables`. -->
+<!-- BEGIN tool-support:normalization_capabilities -->
+| Pattern Type | ferro | mutalyzer | biocommons | hgvs-rs |
+|--------------|:-----:|:---------:|:----------:|:-------:|
+| Genomic (g.) | ✓ | ✓ | ✓ | ✓ |
+| Coding (c.) exonic | ✓ | ✓ | ✓ | ✓ |
+| Coding (c.) intronic | ✓ | ✓** | ✗ | ✗ |
+| Non-coding (n.) | ✓ | ✓ | ✓ | ✓ |
+| RNA (r.) | ✓ | ✓ | ✓ | ✓ |
+| Protein (p.) | ✓ | Net* | ✗ | ✗ |
+
+\* mutalyzer protein normalization requires network access for NP_→NM_ lookups (cannot be cached locally).
+\*\* mutalyzer intronic support is enabled by default via genomic-context rewriting; disable with --no-rewrite-intronic.
+<!-- END tool-support:normalization_capabilities -->
+
+## Performance Comparison
+
+**All tools are benchmarked in ferro's offline configuration — best case for every tool.** Reference data is preloaded locally (a local UTA database and SeqRepo) and the network is disabled, so the figures below measure parse/normalize compute, not I/O. Out of the box, hgvs-rs, biocommons/hgvs, and mutalyzer resolve each variant against a remote UTA/SeqRepo or the Mutalyzer web API — a network round-trip per variant (~100–1000 ms), i.e. roughly **1–10 variants/sec, hundreds to thousands of times slower than shown here** (an order-of-magnitude estimate from per-call network latency, not separately benchmarked). That local, offline setup is exactly what ferro's `prepare` command builds; ferro needs no external service.
+
+<!-- DO NOT EDIT — generated from data/benchmark/perf_results.json by `generate_perf_tables`. -->
+
+_Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools draw from one stratified ClinVar population; per-tool sample sizes are calibrated so each tool is measured over a meaningful interval — fast cells (e.g. ferro/hgvs-rs parse) draw from millions of patterns, while slower cells (e.g. the per-tool normalize columns) draw from as few as tens to thousands. All tools exclude process/interpreter startup from the timed region — the mutalyzer/biocommons Python subprocesses are timed by their own internal startup-excluded timer, matching ferro/hgvs-rs. Only ferro parallelizes natively (rayon); the other tools are single-threaded libraries, so their normalize *@8 workers* figures come from the benchmark harness running 8 independent instances in parallel, while parsing is not sharded for them — hence the `single-threaded` label in their parse *@8 workers* column (mutalyzer normalize likewise shows no gain at 8 workers: per-call cache and IPC overhead dominate, so sharding does not help). Every tool runs fully offline against local reference data — a local UTA database and SeqRepo, with mutalyzer's network lookups disabled — the configuration ferro's `prepare` command enables; the figures therefore reflect compute throughput, not per-variant network latency. Reference-data load is excluded for all tools. ferro full-population peak: parse 20.0M/s, normalize 77.0k/s. See `docs/BENCHMARK_RUNBOOK.md` for the full method._
+
+**Parse**
+
+<!-- BEGIN perf:parse -->
+| Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
+|------|----------------------:|-----------------------:|-------------------:|
+| ferro | 5.1M/s | 12.2M/s | — |
+| mutalyzer | 352/s | single-threaded | 35,000× |
+| biocommons | 3.9k/s | single-threaded | 3,100× |
+| hgvs-rs | 3.6M/s | single-threaded | 3× |
+<!-- END perf:parse -->
+
+**Normalize**
+
+<!-- BEGIN perf:normalize -->
+| Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
+|------|----------------------:|-----------------------:|-------------------:|
+| ferro | 78.1k/s | 260.2k/s | — |
+| mutalyzer | 4/s | 4/s | 73,000× |
+| biocommons | 368/s | 818/s | 320× |
+| hgvs-rs | 195/s | 1.3k/s | 200× |
+<!-- END perf:normalize -->
+
+**ferro thread scaling**
+
+<!-- BEGIN perf:ferro_scaling -->
+| Threads | 1 | 2 | 4 | 8 |
+|---------|--:|--:|--:|--:|
+| ferro parse | 5.1M/s | 9.4M/s | 16.0M/s | 12.0M/s |
+<!-- END perf:ferro_scaling -->
+
+**Input ordering matters for batch throughput.** Resolving a transcript (reading its full sequence from the reference and rebuilding its CDS/exon metadata) dominates per-variant cost. ferro memoizes resolved transcripts in a bounded in-memory cache, so repeated lookups of the same transcript are near-free. Providing variants **sorted by transcript accession — or by genomic position, which clusters variants onto the same transcripts** — maximizes the cache hit rate and can speed up large batches by an order of magnitude versus randomly-ordered input. Ordering matters most when the number of distinct transcripts in the run exceeds the cache capacity (very large or genome-wide inputs); below that, the working set stays resident regardless of order.
+
+## Reference Data: What ferro Prepares
+
+The `ferro prepare` command downloads and organizes all reference data needed for comprehensive normalization. This data is then shared with other tools (mutalyzer, biocommons, hgvs-rs) to enable their local operation.
+
+| Data Type | Source | Size | Enables |
+|-----------|--------|------|---------|
+| **RefSeq transcripts** | NCBI | ~1GB | NM_/NR_/XM_ normalization |
+| **cdot metadata** | MANE | ~200MB | Transcript-to-genome mappings |
+| **GRCh38 + GRCh37 genomes** | NCBI | ~4GB | NC_ genomic normalization |
+| **RefSeqGene** (sequences + genome alignments) | NCBI | ~600MB | NG_ gene-region normalization; projecting c./n. variants into an NG_ parent's own g. frame (via the RefSeqGene→genome alignment GFF3) |
+| **LRG sequences + XML** | EBI | ~50MB | LRG_ stable-reference normalization; projecting c./n. variants into an LRG_ parent's own g. frame (via the LRG XML genomic mapping) |
+| **Protein sequences** | Derived from CDS | ~200MB | NP_/XP_ protein normalization |
+| **Legacy transcript versions** | NCBI | ~50MB | Historical ClinVar variants |
+
+**Key insight**: Without ferro's reference preparation, other tools require network access for each variant lookup (adding 100-1000ms latency per variant). With ferro's cached reference data, all tools can operate fully offline with consistent, reproducible results.
+
+### Deriving version-independent NG_ placements (#728)
+
+`ferro prepare --derive-ng-placements <accessions.txt>` derives genomic placements for the listed `NG_` versions (one exact accession per line, e.g. `NG_012337.3`; blank lines and `#` comments ignored), writing `derived_refseqgene_placements.json` into the reference directory and wiring the manifest's `derived_refseqgene_placements` field. This fills version gaps the archived RefSeqGene→genome GFF3 snapshots do not cover. It needs cdot + the genome in the same prepare run and uses NCBI EFetch per accession; accessions that cannot be validated are skipped with a warning. The field is preserved across subsequent `prepare` runs.

--- a/examples/generate_perf_tables.rs
+++ b/examples/generate_perf_tables.rs
@@ -1,8 +1,8 @@
-//! Generator for the README performance tables.
+//! Generator for the comparison-page performance tables.
 //!
 //! Reads `data/benchmark/perf_results.json` and renders the parse + normalize
-//! cross-tool tables and the ferro thread-scaling table into README.md between
-//! `perf:<id>` markers.
+//! cross-tool tables and the ferro thread-scaling table into
+//! docs/src/reference/comparison.md between `perf:<id>` markers.
 //!
 //! Run:   cargo run --features dev --example generate_perf_tables
 //! Check: cargo run --features dev --example generate_perf_tables -- --check
@@ -15,9 +15,9 @@ use clap::Parser;
 use ferro_hgvs::perf_table::PerfResults;
 
 #[derive(Parser, Debug)]
-#[command(about = "Generate the README performance tables")]
+#[command(about = "Generate the comparison-page performance tables")]
 struct Cli {
-    /// Re-render in memory and fail if README.md differs.
+    /// Re-render in memory and fail if the target differs.
     #[arg(long)]
     check: bool,
     /// Path to the results JSON.
@@ -25,7 +25,7 @@ struct Cli {
     results: String,
 }
 
-const README: &str = "README.md";
+const TARGET: &str = "docs/src/reference/comparison.md";
 
 /// Replace the text between `<!-- BEGIN perf:<id> -->` and `<!-- END perf:<id> -->`.
 fn splice(content: &str, id: &str, body: &str) -> Result<String, String> {
@@ -85,10 +85,10 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    let current = match std::fs::read_to_string(README) {
+    let current = match std::fs::read_to_string(TARGET) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("error: read {README}: {e}");
+            eprintln!("error: read {TARGET}: {e}");
             return ExitCode::FAILURE;
         }
     };
@@ -103,18 +103,18 @@ fn main() -> ExitCode {
     if cli.check {
         if rendered != current {
             eprintln!(
-                "README perf tables are out of date; rerun: \
+                "comparison-page perf tables are out of date; rerun: \
                  cargo run --features dev --example generate_perf_tables \
-                 (edit data/benchmark/perf_results.json, not README.md)"
+                 (edit data/benchmark/perf_results.json, not docs/src/reference/comparison.md)"
             );
             return ExitCode::FAILURE;
         }
     } else if rendered != current {
-        if let Err(e) = std::fs::write(README, &rendered) {
-            eprintln!("error: write {README}: {e}");
+        if let Err(e) = std::fs::write(TARGET, &rendered) {
+            eprintln!("error: write {TARGET}: {e}");
             return ExitCode::FAILURE;
         }
-        println!("updated {README}");
+        println!("updated {TARGET}");
     }
     ExitCode::SUCCESS
 }

--- a/examples/generate_tool_support_tables.rs
+++ b/examples/generate_tool_support_tables.rs
@@ -2,8 +2,9 @@
 //!
 //! Reads `docs/tool_support_matrix.json` (the single source of truth) and
 //! renders:
-//!   - the "Normalization Capabilities" markdown table into README.md and
-//!     docs/BENCHMARK_GUIDE.md (between `tool-support:<view>` markers), and
+//!   - the "Normalization Capabilities" markdown table into
+//!     docs/src/reference/comparison.md and docs/BENCHMARK_GUIDE.md (between
+//!     `tool-support:<view>` markers), and
 //!   - the render-ready website JSON into
 //!     src/service/web/static/data/tool_support_matrix.json.
 //!
@@ -44,7 +45,7 @@ struct Cli {
 }
 
 const VIEW: &str = "normalization_capabilities";
-const README: &str = "README.md";
+const COMPARISON: &str = "docs/src/reference/comparison.md";
 const GUIDE: &str = "docs/BENCHMARK_GUIDE.md";
 const WEB_JSON: &str = "src/service/web/static/data/tool_support_matrix.json";
 
@@ -86,7 +87,7 @@ struct Target {
 fn compute_targets(m: &Matrix) -> Result<Vec<Target>, String> {
     let body = m.render_markdown_view(VIEW)?;
     let mut targets = Vec::new();
-    for path in [README, GUIDE] {
+    for path in [COMPARISON, GUIDE] {
         let cur = std::fs::read_to_string(path).map_err(|e| format!("read {path}: {e}"))?;
         targets.push(Target {
             path: path.to_string(),


### PR DESCRIPTION
Follow-up to the README-slim campaign (#2114): the last generated long-form content leaves the README.

This relocates the generated tool-support capability matrix and the cross-tool performance tables — plus the surrounding "Why ferro-hgvs?" narrative and the reference-data overview — out of `README.md` and into a new `docs/src/reference/comparison.md` page, registered in `SUMMARY.md` under Reference. The README keeps a short "Why ferro-hgvs?" teaser linking to the page, and the Documentation index gains an entry for it.

The tables are generated, so this is a code change, not a copy: `generate_tool_support_tables` and `generate_perf_tables` are retargeted from `README.md` to the new page (the tool-support generator keeps its existing `docs/BENCHMARK_GUIDE.md` target). They stay single-sourced from `docs/tool_support_matrix.json` and `data/benchmark/perf_results.json`, and CI's `--check` gate now verifies the new page. The `## Benchmark:` command-reference section is intentionally left in the README — it is not a generated table.

Verified locally: `cargo fmt --check`, `cargo clippy --features dev --all-targets -D warnings`, both generators' `--check` green against the new page, `mdbook build` + linkcheck2 clean, and the generator/completeness/readme test selection (20 tests) pass.

Representation-Change: none. Docs and generator output paths only; no watched `src/` file is touched.