### PR TITLE
ci(soak): lower [profile.soak] opt-level from 3 to 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1200,7 +1200,7 @@ jobs:
           path: nextest.tar.zst
           retention-days: 1
 
-  # A SECOND archive, built at `opt-level = 3`, for the soak shards only.
+  # A SECOND archive, built at `opt-level = 2` (#1963), for the soak shards only.
   #
   # The soak is compute-bound in a way the other jobs are not: eight shards each
   # run 125,000 proptest cases, so a constant factor on the code under test is
@@ -1214,8 +1214,8 @@ jobs:
   # tests — at `opt-level = 3` so that about 45 of them can run. Measured on an
   # M2 Max, `user` CPU with the workspace artifacts scrubbed the way `rust-cache`
   # scrubs them here, deps warm: 394.8s for the `it` archive, of which the
-  # library is a minority. The rest was the driver, and the runtime
-  # `opt-level = 3` buys comes from optimizing the LIBRARY.
+  # library is a minority. The rest was the driver, and the runtime this
+  # profile's optimization buys comes from optimizing the LIBRARY.
   #
   # Cargo profile overrides are keyed on the PACKAGE, never on the target, so
   # `[profile.soak.package.ferro-hgvs]` reaches the lib, the bins and the `it`
@@ -1279,8 +1279,8 @@ jobs:
       # Skip the rebuild entirely when this exact commit already produced an
       # archive. `rust-cache` above caches DEPENDENCIES only — it deliberately
       # deletes workspace artifacts — so `ferro_hgvs` and the `it` test crate are
-      # recompiled at `opt-level = 3` on every run even when not one byte of Rust
-      # changed. Measured on run 31275848682: 142s of this job's 170s is that
+      # recompiled at `opt-level = 2` (#1963) on every run even when not one byte
+      # of Rust changed. Measured on run 31275848682: 142s of this job's 170s is that
       # rebuild, and this job plus `sweeps` IS the critical path.
       #
       # Keyed on the commit SHA, deliberately, rather than on `hashFiles` over the
@@ -1316,7 +1316,7 @@ jobs:
         if: steps.soak-archive.outputs.cache-hit != 'true'
         # No `--features dev`. That feature pulls in `web-service` (axum, tokio,
         # tower, tracing) and `benchmark` (reqwest, rusqlite, tokio-postgres,
-        # futures) — an entire dependency tree compiled at `opt-level = 3` to
+        # futures) — an entire dependency tree compiled at `opt-level = 2` to
         # produce one test binary that never touches any of it. None of the ten
         # modules this package compiles is gated on the feature and none of the
         # three consuming jobs selects a gated one, so the selections are

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -93,7 +93,7 @@ jobs:
       # it hashed this workflow file as well as the lockfile, suffix-before-hash
       # so its restore-key was a real prefix, after the measurement that a
       # lockfile-only key had frozen dev-feature artifacts into an
-      # `opt-level = 3` tree and was re-compiling reqwest/hyper/criterion every
+      # `opt-level = 2` tree and was re-compiling reqwest/hyper/criterion every
       # run. That reasoning is preserved in `ci.yml`; what it could not fix is
       # size, and this job's `soak` profile tree is the largest in the repo.
       # `rust-cache` stores dependency artifacts only, and its key already
@@ -139,10 +139,10 @@ jobs:
         # ci.yml for why that package exists. The three proptest modules this
         # workflow's shards select are `#[path]`-included by
         # `tests-soak/tests/soak/main.rs`, so they are in the archive; nothing
-        # else in `tests/it/` is compiled at `opt-level = 3` to get them there.
+        # else in `tests/it/` is compiled at `opt-level = 2` to get them there.
         #
         # No `--features dev`, also as in ci.yml. The feature drags
-        # `web-service` and `benchmark` into an `opt-level = 3` build for a
+        # `web-service` and `benchmark` into an `opt-level = 2` build for a
         # binary that uses neither, and `test(proptest)` resolves to the same
         # 10 tests with or without it.
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -531,39 +531,51 @@ opt-level = 3
 # run against an optimized `libferro_hgvs`: their work is compute-bound and a
 # constant factor on the library is multiplied a million times over.
 #
-# THE TEST DRIVER IS NOT LOWERED, and that is a measured answer rather than an
-# omission — #1964 asked for exactly such an override and the measurement refused
-# it. Recorded here so it is not re-derived.
+# opt-level is 2, NOT 3 (#1963). After #1960 this archive build is the workflow's
+# critical path — 161s of `cargo nextest archive --cargo-profile soak` on CI, of
+# which the optimizer is the dominant term (`test-build` compiles every test
+# binary at the `test` profile — opt-level 0 — in 82s). opt-level 2 cuts optimizer
+# time on `libferro_hgvs` unconditionally, for every PR; the trade is `sweeps` /
+# `censuses` run-time, which those jobs measure directly on CI.
+#
+# THE TEST DRIVER IS NOT LOWERED BELOW THE PROFILE DEFAULT, and that is a measured
+# answer rather than an omission — #1964 asked for exactly such a per-package
+# override and the measurement refused it. Recorded here so it is not re-derived.
 #
 # The premise was that the driver is loops and `format!`, so it could sit at a
-# low `opt-level` while `ferro-hgvs` stayed at 3. That became expressible with
-# #1964's split — `ferro-hgvs-soak-tests` is its own package, and profile
-# overrides are keyed on the package — and it does not pay. Measured on an M2 Max
-# (12 core), `user` CPU seconds because wall clock on a shared machine is not
-# reproducible; deps warm and the workspace artifacts scrubbed every rep the way
-# `rust-cache` scrubs them in CI. Build is the median of 5 reps, run the mean of
-# 2; "sweeps" is that job's selection at `FERRO_SWEEP_SEEDS=full` with all four
-# oracles armed, "censuses" is both of that job's steps:
+# lower `opt-level` than `ferro-hgvs`. That became expressible with #1964's split
+# — `ferro-hgvs-soak-tests` is its own package, and profile overrides are keyed on
+# the package — and it does not pay. Measured on an M2 Max (12 core), `user` CPU
+# seconds because wall clock on a shared machine is not reproducible; deps warm
+# and the workspace artifacts scrubbed every rep the way `rust-cache` scrubs them
+# in CI. THE LIBRARY WAS HELD AT opt-level 3 FOR THIS TABLE — it predates #1963,
+# and only the driver's per-package override varies across rows. Build is the
+# median of 5 reps, run the mean of 2; "sweeps" is that job's selection at
+# `FERRO_SWEEP_SEEDS=full` with all four oracles armed, "censuses" is both of
+# that job's steps:
 #
 #   driver opt-level | build (soak archive) | run: sweeps | run: censuses
 #   -----------------+----------------------+-------------+---------------
-#   3 (as shipped)   |                105.7 |       139.8 |          90.2
+#   3 (profile then) |                105.7 |       139.8 |          90.2
 #   2                |                105.1 |       141.2 |          89.7
 #   1                |                101.1 |       143.9 |          92.8
 #   0                |                 85.5 |       240.9 |         109.2
 #
-# So `opt-level = 0` buys ~20s of compile and gives back ~101s of run; 1 and 2
-# are a wash in both directions. The compile column is flat because of the
-# *other* half of #1964: this package compiles ~8k lines where the `it` crate is
-# 139k, so there is little left for a lower `opt-level` to save. The comparison
-# that pays is against what this job used to build — `--test it`, 394.8s — and
-# that is the split, not the `opt-level`.
+# So a driver `opt-level = 0` buys ~20s of compile and gives back ~101s of run; 1
+# and 2 are a wash in both directions against 3. The compile column is flat
+# because of the *other* half of #1964: this package compiles ~8k lines where the
+# `it` crate is 139k, so there is little left for a lower driver `opt-level` to
+# save. Two things follow for #1963: the driver inheriting the new profile default
+# of 2 rather than pinning its own override costs nothing here (2 and 3 are a wash
+# for it), and the #1963 saving therefore comes from the library — which this
+# table does not vary, so re-measure the library trade on CI rather than reading
+# it off these rows.
 #
 # `debug-assertions` and `overflow-checks` stay ON so this buys speed without
 # quietly weakening what the soak checks.
 [profile.soak]
 inherits = "test"
-opt-level = 3
+opt-level = 2
 debug = false
 debug-assertions = true
 overflow-checks = true


### PR DESCRIPTION
Closes #1963

## What

Lower `[profile.soak]`'s `opt-level` from 3 to 2 in `Cargo.toml`.

After #1960, the `test-build-soak` archive build is the workflow's critical path — measured at ~161s of `cargo nextest archive --cargo-profile soak` on CI, of which the optimizer is the dominant term (`test-build` compiles every test binary at the `test` profile — opt-level 0 — in ~82s). This is lever (1) from the issue: the only change that speeds up the critical path unconditionally, on every PR.

`opt-level = 2` cuts optimizer time on `libferro_hgvs` (the dominant compile term; the ~8k-line soak driver is a wash between opt-levels 2 and 3, per the measured #1964 table). `debug-assertions` and `overflow-checks` stay ON, so nothing the soak checks is weakened — the `#[cfg(debug_assertions)]` oracles and every `debug_assert!` behave exactly as before.

The trade is `sweeps` / `censuses` run-time, which those jobs measure directly on CI. Per the issue, this is the lever to take first and measure there; the local #1964 driver-opt-level table does not vary the library, so the library trade is a CI measurement rather than a pre-committed local number.

## Also

Comments in `.github/workflows/ci.yml` and `.github/workflows/nightly-soak.yml` that stated the soak profile's current `opt-level` are updated from 3 to 2 to match, and the #1964 driver-override table in `Cargo.toml` is annotated to note its rows were measured with the library held at opt-level 3 (which predates this change). `actionlint` passes on both workflows.

## Representation change

Representation-Change: none. Build-config only (`Cargo.toml` profile + workflow comments); touches no watched prefix (`src/normalize|hgvs|spdi|project|reference|error_handling`) and cannot move any normalized output.
