### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.15.0...v0.16.0) - 2026-08-19
+
+### Representation changes
+
+- *(normalize)* collapse payload-coincidence delins on all DNA axes ([#2155](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2155)) ([#2165](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2165))
+- *(normalize)* type a whole-span reverse complement as inv, uniformly ([#2163](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2163))
+
+### Other
+
+- *(normalize)* skip the sequence-first pass for a lone substitution ([#2169](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2169))
+- *(api)* [**breaking**] rename sequence_normalize to rederive, normalize param to recommended_form ([#2160](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2160))
+- *(ledger)* record cross-zone c. position ordering as a house choice ([#1856](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1856)) ([#2162](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2162))
+
 ## [0.15.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.14.0...v0.15.0) - 2026-08-17
 
 ### Representation changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Representation changes
 
 - *(normalize)* collapse payload-coincidence delins on all DNA axes ([#2155](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2155)) ([#2165](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2165))
+  > 728 of 9,949,738 real-corpus rows move (0.0073%),
+  > measured by normalizing all four release-asset corpora (ClinVar 500k +
+  > ClinVar-unique + CMRG + Paraphase) through base vs HEAD against the
+  > prepared reference. All are on the DNA axes the carve-out newly reaches:
+  > g=692, n=36, m=0; the c. axis is unchanged by construction (the change
+  > only widens the carve-out from c. to the other DNA axes), confirmed by a
+  > 1,001-row c. control that is byte-identical on both revisions. 0 of the
+  > 728 moved rows denote different bases — every base-side string
+  > round-trips byte-for-byte to HEAD's output — so this is a pure
+  > representation change (respelling, same denoted sequence). The
+  > payload-coincidence delins-collapse is extended from the c. axis to the
+  > other DNA axes, on both the normalize and from_sequences surfaces.
+  > Mechanism-stress cross-check over the churn-enriched synthetic corpus
+  > (examples/dump_normalized_corpus.rs): 2196 of 96182 rows move, all g., 0
+  > base-differences — a denser bound on the mechanism, not the consumer
+  > impact. r. axis excluded by design (a DNA-axis document has no
+  > jurisdiction over the RNA axis).
 - *(normalize)* type a whole-span reverse complement as inv, uniformly ([#2163](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2163))
+  > Over the inversion-sweep corpus (2,075 authored
+  > inversions on the `c.`/`n.`/`r.` axes) 92 rows change representation —
+  > an exact whole-span reverse complement that previously repartitioned
+  > into its substitution/`delins` members now types as one `inv`
+  > (`CENSUS_REPARTITIONED` 92 → 0; of those 92, 75 return
+  > character-for-character to the authored inversion, `CENSUS_UNCHANGED`
+  > 1491 → 1566, and 17 shift but stay `inv`, `CENSUS_SHIFTED_STILL_INV` 466
+  > → 483). Named singleton on the coding axis:
+  > `NM_000500.9:c.[710T>A;713T>A]` → `NM_000500.9:c.710_713inv` (#1541).
+  > Whole-span reverse complements above the canonical window gate were
+  > already `inv` via the per-member pipeline and do not move.
 
 ### Other
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]


### PR DESCRIPTION
## Representation stability

Any PR that moves a normalized output should carry a `Representation-Change:`
trailer (see CONTRIBUTING.md). Those are collected into the **Representation
changes** section of the changelog below, and each entry's trailer text is
attached under its bullet by `scripts/inject_representation_disclosure.py`.

Reviewer checklist:

- [x] Either that section lists every output-moving change in this cycle, or
      there were none and it is absent.
- [x] Nothing in it merely *declined*. A decline reads `Representation-Change:
      none`, optionally followed by a reason, and belongs under its own type —
      not here. Spot-check two entries against their PR descriptions.
- [x] Every entry carries its trailer's own text, quoted under the bullet, and
      that text says whether the affected inputs were previously **rejected**
      (no stored string, so free) or previously **accepted** (a real migration
      for the consumer). release-plz writes the bullet from the commit subject
      alone; `python scripts/inject_representation_disclosure.py` attaches the
      rest, and CI's `Changelog grouping audit` fails until it has been run.
      Re-run it after any push that regenerates this section — it is idempotent.

A commit under `src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`,
`src/reference/` or `src/error_handling/` that moved output without declaring it
means the trailer is missing. Fix that before releasing, not after.

Reviewer checklist verification (v0.15.0 → v0.16.0, all 5 substantive commits audited):

- Two output-movers, both listed here: **#2165** (728 / 9,949,738 real-corpus rows, all g/n axes, 0 base-differences — pure respelling) and **#2163** (92 rows, whole-span reverse complement now typed as one `inv`). Both quote old→new forms, so affected inputs were previously **accepted** — a real consumer migration, not free.
- Three declines correctly grouped by type under **Other**, not here: **#2169** (`none`, byte-identical fast path), **#2160** (`none`, identifier/doc rename only), **#2162** (`none`, ledger-only, no watched prefix touched).
- `scripts/inject_representation_disclosure.py` has been run — both disclosures attached to `CHANGELOG.md`, and `Changelog grouping audit` is green on this head.
- #2160's `[**breaking**]` and the cargo-semver-checks `incompatible` note below are the expected result of the public `sequence_normalize`→`rederive` rename, carried by the 0.15→0.16 minor bump (pre-1.0 semver).

---


### [0.16.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.15.0...v0.16.0) - 2026-08-19
### Representation changes

- *(normalize)* collapse payload-coincidence delins on all DNA axes ([#2155](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2155)) ([#2165](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2165))
- *(normalize)* type a whole-span reverse complement as inv, uniformly ([#2163](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2163))

### Other

- *(normalize)* skip the sequence-first pass for a lone substitution ([#2169](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2169))
- *(api)* [**breaking**] rename sequence_normalize to rederive, normalize param to recommended_form ([#2160](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2160))
- *(ledger)* record cross-zone c. position ordering as a house choice ([#1856](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1856)) ([#2162](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2162))

#### API breaking changes

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Normalizer::sequence_normalize, previously in file /tmp/.tmpJLBfm7/ferro-hgvs/src/normalize/mod.rs:2966
  Normalizer::sequence_normalize, previously in file /tmp/.tmpJLBfm7/ferro-hgvs/src/normalize/mod.rs:2966


#### cargo-semver-checks

incompatible



