### PR TITLE
fix(release): pin git_release_name so the release title matches the tag

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -45,6 +45,19 @@ features_always_increment_minor = true
 # on the new tag, which the gate accepts.
 git_tag_name = "v{{ version }}"
 
+# Pin the GitHub release *name* for the same reason, and to the same value. This
+# is a SEPARATE field from `git_tag_name` above, with its own workspace-shape
+# default: release-plz names a single-package release `v{version}` and a
+# multi-package one `{package}-v{version}`. The `git_tag_name` pin fixes only the
+# tag; with the name left to default, `tests-soak` (the `publish = false` member
+# #1977 added — see above) tips the shape to multi-package and the release title
+# renders `ferro-hgvs-v{version}`. That is cosmetic — no workflow gates on the
+# release name the way `release-wheels.yml` gates on the tag prefix — but it drifts
+# from every release before v0.16.0, which were titled bare `v{version}`, and had
+# to be hand-corrected each cycle. Pinning both fields keeps tag and title
+# identical and stops the workspace shape from renaming either.
+git_release_name = "v{{ version }}"
+
 # Prepend a representation-stability block to the release PR body (#1424).
 #
 # Representation stability is a shipped guarantee: the downstream consumer keys

--- a/tests/it/release_tag_gate.rs
+++ b/tests/it/release_tag_gate.rs
@@ -761,3 +761,66 @@ fn every_publishing_job_requires_a_release() {
         publishers.len(),
     );
 }
+
+/// The GitHub release **title** must be pinned, and pinned to the same string as
+/// the tag.
+///
+/// `git_release_name` is a field distinct from `git_tag_name`, with its own
+/// workspace-shape default (`v{version}` for a single-package workspace,
+/// `{package}-v{version}` for a multi-package one — the same fork [`minted_tag`]
+/// models). Pinning only the tag left the name on that default, so once
+/// `tests-soak` made this workspace multi-package the v0.16.0 release was titled
+/// `ferro-hgvs-v0.16.0` while its tag was `v0.16.0`, and it had to be renamed by
+/// hand — as v0.15.0 was before it. Unlike the tag, nothing downstream *gates* on
+/// the release name, so this cannot be folded into the gate assertions above; it
+/// is its own guard, and its property is simply that title and tag agree.
+#[test]
+fn the_release_name_is_pinned_and_matches_the_tag() {
+    let config: toml::Value =
+        toml::from_str(&read(RELEASE_PLZ_TOML)).expect("release-plz.toml parses as TOML");
+
+    let template = config
+        .get("workspace")
+        .and_then(|w| w.get("git_release_name"))
+        .and_then(toml::Value::as_str)
+        .unwrap_or_else(|| {
+            panic!(
+                "{RELEASE_PLZ_TOML} does not pin `git_release_name`, so the GitHub release title \
+                 falls back to release-plz's workspace-shape default. With `tests-soak` in the \
+                 workspace that default is `{{{{ package }}}}-v{{{{ version }}}}`, which titles \
+                 the release `ferro-hgvs-v<version>` while the tag stays `v<version>` — the \
+                 mismatch that was hand-corrected every cycle before this pin. Pin it beside \
+                 `git_tag_name`."
+            )
+        });
+
+    // Same discipline as the tag pin: the template must interpolate the version,
+    // or every release shares one title.
+    assert!(
+        template.contains("{{ version }}") || template.contains("{{version}}"),
+        "{RELEASE_PLZ_TOML}'s git_release_name = {template:?} does not reference \
+         {{{{ version }}}}, so every release would reuse one title."
+    );
+
+    let manifest: toml::Value =
+        toml::from_str(&read("Cargo.toml")).expect("Cargo.toml parses as TOML");
+    let package = manifest
+        .get("package")
+        .expect("Cargo.toml declares a root [package]");
+    let name = package
+        .get("name")
+        .and_then(toml::Value::as_str)
+        .expect("the root package is named");
+    let version = package
+        .get("version")
+        .and_then(toml::Value::as_str)
+        .expect("the root package is versioned");
+
+    let release_name = render(template, name, version);
+    let (tag, _) = minted_tag();
+    assert_eq!(
+        release_name, tag,
+        "the GitHub release title ({release_name:?}) and the git tag ({tag:?}) must be identical; \
+         pin `git_release_name` and `git_tag_name` to the same template in {RELEASE_PLZ_TOML}."
+    );
+}


### PR DESCRIPTION
## Problem

The v0.16.0 GitHub release was titled **`ferro-hgvs-v0.16.0`** while its tag was **`v0.16.0`**, and had to be renamed by hand — as v0.15.0 was before it.

Root cause: release-plz derives **two** shape-dependent strings from the workspace — the git tag *and* the GitHub release name (`v{version}` for a single-package workspace, `{package}-v{version}` for a multi-package one). The earlier fix (the `git_tag_name` pin, with the long comment above it) pinned only the tag. `git_release_name` was left on its default, so once `tests-soak` (the `publish = false` member #1977 added) tipped the workspace to multi-package, the release *title* picked up the `{package}-v{version}` form while the tag stayed pinned. This is why the title has drifted and been hand-corrected each cycle.

## Fix

Pin `git_release_name = "v{{ version }}"` beside `git_tag_name`, so tag and title are always the same string, and the workspace shape can rename neither.

Unlike the tag, nothing downstream *gates* on the release name (`release-wheels.yml` keys on the tag prefix), so the impact of the old bug was cosmetic — but it drifted from every release before v0.16.0 and cost a manual rename each time.

## Guard

`release_tag_gate::the_release_name_is_pinned_and_matches_the_tag` asserts the release name is explicitly pinned (a bare default is the bug), references the version, and renders identical to the minted tag. Verified it fails loudly (exit 100, naming the fix) when the pin is removed, and passes with it.

Representation-Change: none. Release tooling and a test only; no watched src/ prefix is touched and no normalized output moves.