### PR TITLE
perf(ci): build libferro_hgvs optimized under coverage instrumentation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -133,10 +133,20 @@ jobs:
           # Absence of a bulk fixture fails the run rather than skipping it.
           FERRO_REQUIRE_BULK_FIXTURES: "1"
         run: |
-          cargo llvm-cov --no-report nextest --features dev \
+          # Build `libferro_hgvs` at opt-level 2 (see the `coverage` profile in
+          # Cargo.toml) rather than the llvm-cov default opt-level 0. The
+          # census/corpus tests are compute-bound in the library, so that is where
+          # the wall time is; the instrumentation is still added by llvm-cov's
+          # RUSTFLAGS regardless of the profile.
+          #
+          # The flag differs by subcommand, deliberately: on `nextest`, llvm-cov
+          # forwards `--profile` to NEXTEST (its own profile), so the cargo build
+          # profile is set with nextest's `--cargo-profile`; `report` has no nextest
+          # and takes llvm-cov's own `--profile` to find the same binaries.
+          cargo llvm-cov --no-report nextest --cargo-profile coverage --features dev \
             --partition hash:${{ matrix.shard }}/4
-          cargo llvm-cov report --codecov --output-path codecov.json
-          cargo llvm-cov report --html --output-dir coverage
+          cargo llvm-cov report --profile coverage --codecov --output-path codecov.json
+          cargo llvm-cov report --profile coverage --html --output-dir coverage
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: codecov.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -579,3 +579,33 @@ opt-level = 2
 debug = false
 debug-assertions = true
 overflow-checks = true
+
+# The `Coverage` workflow builds with llvm-cov instrumentation, and its slowest
+# jobs are the census/corpus tests, which are compute-bound in `libferro_hgvs`.
+# Under the default `test`/`dev` profile the library is `opt-level = 0`, so those
+# tests run several times slower than they need to — the same reason `[profile.soak]`
+# optimizes the library for the `censuses`/`sweeps` jobs. This profile does the
+# same for coverage, selected by `--cargo-profile coverage` in `coverage.yml`.
+#
+# It optimizes ONLY the library and the heavy parser dependencies, leaving the
+# test crates at the dev default: their code is not the bottleneck, and optimizing
+# every test binary would add build time llvm-cov's un-cached PR builds cannot
+# amortize. `debug = true` is kept for coverage line mapping; instrumentation is
+# added by llvm-cov's RUSTFLAGS regardless of profile.
+#
+# Package overrides are NOT inherited through `inherits`, so the three dependency
+# overrides `[profile.dev.package.*]` carries below are repeated here.
+[profile.coverage]
+inherits = "dev"
+
+[profile.coverage.package.ferro-hgvs]
+opt-level = 2
+
+[profile.coverage.package.miniz_oxide]
+opt-level = 3
+
+[profile.coverage.package.serde_json]
+opt-level = 3
+
+[profile.coverage.package.flate2]
+opt-level = 3


### PR DESCRIPTION
## What

Build `libferro_hgvs` at **opt-level 2** under the `Coverage` workflow instead of the llvm-cov default **opt-level 0**, via a dedicated `coverage` cargo profile. The library stays instrumented; only its optimization level changes.

## Root cause

The `Coverage` workflow's slowest jobs are the census/corpus tests, and those are compute-bound in `libferro_hgvs`. Coverage builds it un-optimized: `cargo llvm-cov nextest --features dev` uses the `dev`/`test` profile (opt-level 0). This was never a deliberate choice — it is the llvm-cov default, and `coverage.yml`'s comments (which debate sharding, nextest, caching and doctests at length) say nothing about the profile. The same censuses run in ~2m in the `Slow censuses (optimized)` job because it builds off the `soak` archive (opt-level 2); `[profile.soak]`'s own comment records that library optimization is exactly what makes that work fast.

## The change

A new `[profile.coverage]` (inherits `dev`) with `[profile.coverage.package.ferro-hgvs] opt-level = 2`, plus the three heavy parser-dependency overrides `[profile.dev.package.*]` already carries (package overrides are not inherited through `inherits`). It optimizes **only** the library and those deps, leaving the test crates at the dev default — their code is not the bottleneck, and optimizing every test binary would add build time llvm-cov's un-cached PR builds cannot amortize. `debug = true` is kept for coverage line mapping.

`coverage.yml` selects it. The flag differs by subcommand, deliberately: on `nextest`, cargo-llvm-cov forwards `--profile` to *nextest* (its own profile), so the cargo build profile is set with nextest's `--cargo-profile`; the `report` steps have no nextest and take cargo-llvm-cov's own `--profile`. Validated locally end-to-end (`nextest --cargo-profile coverage` + `report --profile coverage`).

## Trade-offs to read off the measurement

- **Build time.** opt-level 2 on the library compiles slower, and the coverage cache is restore-only on PRs, so the first run rebuilds cold. The net (run time saved vs build time added) is the thing this draft measures.
- **Coverage precision.** opt-level ≥1 inlines, which coarsens line attribution. Acceptable here: the workflow is explicitly non-gating on coverage percentage (`coverage.yml` header), and the gate it provides — "the suite compiles and passes under instrumentation" — is unchanged.
- A recorded caution (`cis_junction_crossing_shift.rs`): one micro-optimization measured *slower* at opt-level 3 than in the test profile, so profile interactions here are not always monotone. Hence the draft: measure, don't assume.

## Measurement

Draft, to compare the four `Code Coverage` shard wall-clocks against the current run (worst shard ~13m) and confirm the library rebuild cost does not eat the run-time saving.
