### PR TITLE
perf(ci): skip the census/confluence tests in the coverage job (−0.34pp, ~2× faster)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -133,8 +133,14 @@ jobs:
           # Absence of a bulk fixture fails the run rather than skipping it.
           FERRO_REQUIRE_BULK_FIXTURES: "1"
         run: |
+          # EXPERIMENT (isolated carve-out, no profile change): skip the heavy
+          # census/confluence tests, which measure ~90% of the coverage wall and
+          # exercise normalization paths hundreds of cheaper tests also cover.
+          # The report still instruments those source files, so the codecov delta
+          # vs `main` is exactly the coverage those tests contributed uniquely.
           cargo llvm-cov --no-report nextest --features dev \
-            --partition hash:${{ matrix.shard }}/4
+            --partition hash:${{ matrix.shard }}/4 \
+            -E 'not (test(conformance_census_runs) or test(spec_conformance_axis) or test(cis_confluence))'
           cargo llvm-cov report --codecov --output-path codecov.json
           cargo llvm-cov report --html --output-dir coverage
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0


### PR DESCRIPTION
## What

Skip the heavy census/confluence tests (`conformance_census_runs`, `spec_conformance_axis`, `cis_confluence*`) in the `Coverage` job's nextest run. They run the whole spec corpus through the normalizer and dominate the Coverage wall.

## Why it's nearly free

A controlled two-pass `llvm-cov` diff on `origin/main` (all `it`+`lib` tests, with vs. without these tests) measured them covering **514 lines nothing else reaches — 502 of them the census harness itself** (`src/conformance/census.rs`), and only **~14 lines of `src/normalize/`**. The 8,000-line partitioner (`merge.rs`) loses **5 lines**; it's already covered by the targeted regression suite.

Net coverage: **83.79% → 83.45% (−0.34 pp)** — confirmed on Codecov once all four shards merged.

Their *value* is their aggregate confluence/conformance assertions, which stay gated in the required `censuses` job (~106 s, optimized, un-instrumented). `Coverage` is non-gating and only re-counts their line execution under instrumentation.

## Measured effect

Wall (this branch's first run): worst shard **803s → ~477s (−41%)**; heavy shards −42–49%.

## Not included

A follow-up could add a tiny sampled-census unit test to reclaim the ~500 harness lines cheaply — but that needs a sampling mode on the (pinned) corpus generator, not a one-liner, so it's deliberately out of scope here.

Representation-Change: none. CI-workflow change only; no source touched.
