### PR TITLE
feat: add parallel batch parse_and_rederive to BatchProcessor

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1879,6 +1879,37 @@ class BatchProcessor:
         """
         ...
 
+    def parse_and_rederive(
+        self,
+        variants: list[str],
+        *,
+        max_grid_cells: int | None = None,
+        recommended_form: bool = False,
+        workers: int = 0,
+    ) -> BatchResult:
+        """Parse and re-derive multiple HGVS strings in parallel (GIL released).
+
+        The batch, parallel counterpart of `Normalizer.rederive`: each variant is
+        expressed as the bases it denotes and one canonical description is derived
+        from those bases, so two spellings of one variant converge. This is a
+        different operation from `parse_and_normalize` (which 3'-shifts the input's
+        spelling), mirroring how `Normalizer.rederive` differs from
+        `Normalizer.normalize`. The returned BatchResult preserves input order
+        regardless of the worker count.
+
+        Args:
+            variants: HGVS strings to parse and re-derive.
+            max_grid_cells: Largest alignment grid, in cells (as
+                `Normalizer.rederive`). None uses the default.
+            recommended_form: When True, also apply `normalize`'s recommended-form
+                rules to each re-derived description.
+            workers: Worker threads. 0 (default) uses all cores; 1 is serial; N uses N threads.
+
+        Raises:
+            ValueError: for a `max_grid_cells` of 0.
+        """
+        ...
+
     def parse_streaming(self, variants: Iterable[str], workers: int = 0) -> BatchStream:
         """Parse an iterable of HGVS strings lazily, yielding results in input order.
 

--- a/src/batch/processor.rs
+++ b/src/batch/processor.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use crate::error::FerroError;
 use crate::hgvs::parser::parse_hgvs;
 use crate::hgvs::variant::HgvsVariant;
+use crate::normalize::from_sequences::FromSequencesOptions;
 use crate::normalize::Normalizer;
 use crate::reference::ReferenceProvider;
 
@@ -534,6 +535,57 @@ impl<P: ReferenceProvider + Sync> BatchProcessor<P> {
         BatchResult::new(results, start.elapsed())
     }
 
+    /// Parse and *re-derive* multiple HGVS strings in parallel — the batch,
+    /// order-preserving counterpart of [`Normalizer::rederive`].
+    ///
+    /// This is the "one canonical description per variant" round trip
+    /// (`to_sequences` -> `from_sequences`, widening while a member rests on a
+    /// growable window edge), applied to a whole list across `num_threads`
+    /// workers. It is distinct from [`parse_and_normalize_parallel`] the same
+    /// way [`Normalizer::rederive`] is distinct from [`Normalizer::normalize`]:
+    /// re-derivation reads the denoted bases rather than 3'-shifting the input's
+    /// spelling, and `recommended_form` additionally applies `normalize`'s
+    /// recommended-form rules to the result.
+    ///
+    /// Options are built from this processor's own normalizer config, so the
+    /// shuffle direction matches what the serial `rederive` path would use.
+    /// `max_grid_cells` bounds the alignment grid exactly as
+    /// [`from_sequences`](crate::normalize::from_sequences) does; `None` uses the
+    /// default. `Some(0)` is a degenerate grid; rather than propagate it (and risk
+    /// a per-item failure or panic downstream) this treats it as `None` and uses
+    /// the default. This method is infallible by design, so a caller that needs 0
+    /// *rejected* must validate before calling — which the `parse_and_rederive`
+    /// Python binding does, raising `ValueError`.
+    ///
+    /// [`parse_and_normalize_parallel`]: Self::parse_and_normalize_parallel
+    pub fn parse_and_rederive_parallel<S: AsRef<str> + Sync>(
+        &self,
+        variants: &[S],
+        max_grid_cells: Option<usize>,
+        recommended_form: bool,
+        num_threads: usize,
+    ) -> BatchResult<HgvsVariant> {
+        let start = Instant::now();
+        // Built once, shared by every worker: `rederive` borrows it immutably,
+        // and `FromSequencesOptions` is `Sync`, so one instance serves the fan-out.
+        let mut options = FromSequencesOptions::default()
+            .with_direction(self.normalizer.config().shuffle_direction);
+        if let Some(cells) = max_grid_cells.filter(|&c| c != 0) {
+            options = options.with_max_grid_cells(cells);
+        }
+        let map = |input: &S| match parse_hgvs(input.as_ref())
+            .and_then(|v| self.normalizer.rederive(&v, &options, recommended_form))
+        {
+            Ok(rederived) => ItemResult::Ok(rederived),
+            Err(error) => ItemResult::Err {
+                input: Some(input.as_ref().to_string()),
+                error,
+            },
+        };
+        let results = self.map_collect(variants, num_threads, map);
+        BatchResult::new(results, start.elapsed())
+    }
+
     /// Parse a *stream* of HGVS strings, yielding results in input order (#975).
     ///
     /// The streaming counterpart to [`parse_parallel`](Self::parse_parallel), and
@@ -792,6 +844,105 @@ mod tests {
 
         let result = processor.parse_and_normalize(&variants);
         assert_eq!(result.total(), 2);
+    }
+
+    /// Render one result to a comparable key: the description for a success, a
+    /// tagged error string for a failure. Lets serial and parallel runs be
+    /// compared item-by-item without depending on `HgvsVariant`'s `PartialEq`.
+    fn rederive_key(item: &ItemResult<HgvsVariant>) -> String {
+        match item {
+            ItemResult::Ok(v) => format!("OK:{v}"),
+            ItemResult::Err { error, .. } => format!("ERR:{error}"),
+        }
+    }
+
+    /// A batch processor over a genome-capable provider carrying one contig
+    /// `NC_TEST.1` whose bases are `seq`, so `rederive` — which reads the bases a
+    /// variant denotes — can actually succeed. `MockProvider::with_test_data()`
+    /// (what `processor()` uses) registers no genomic sequences, so rederive
+    /// errors on every input there, which would leave the checks below exercising
+    /// only the error arm rather than the ordering of successful results under
+    /// parallelism.
+    fn genome_processor_over(seq: &str) -> BatchProcessor<MockProvider> {
+        use std::io::Write;
+        let doc = serde_json::json!({
+            "version": "1.0",
+            "genome_build": "GRCh38",
+            "transcripts": [],
+            "genomic_sequences": { "NC_TEST.1": seq },
+        });
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(doc.to_string().as_bytes()).unwrap();
+        BatchProcessor::new(MockProvider::from_json(file.path()).unwrap())
+    }
+
+    /// The default genome provider: 10 leading non-A bases, a 300-base A-run
+    /// (positions 11..=310), then 12 more — an interior run long enough that a
+    /// deletion inside it shifts under rederivation.
+    fn genome_processor() -> BatchProcessor<MockProvider> {
+        genome_processor_over(&format!("GCTAGCTAGC{}GCTAGCTAGCTA", "A".repeat(300)))
+    }
+
+    #[test]
+    fn test_parse_and_rederive_parallel_matches_serial() {
+        let processor = genome_processor();
+        // Genomic edits that rederive successfully (they read the contig's bases),
+        // plus an unparseable input — so both the Ok and Err arms are exercised.
+        let variants = vec![
+            "NC_TEST.1:g.100del",
+            "NC_TEST.1:g.5G>C",
+            "NC_TEST.1:g.50_52del",
+            "not a variant",
+        ];
+
+        let serial = processor.parse_and_rederive_parallel(&variants, None, false, 1);
+        let serial_keys: Vec<String> = serial.results.iter().map(rederive_key).collect();
+        assert_eq!(serial_keys.len(), variants.len());
+        // The point of a genome-capable provider: rederive actually succeeds, so
+        // the Ok arm — not only the error arm — is placed under parallelism.
+        assert!(
+            serial.success_count() > 0,
+            "expected some successful rederivations; got all errors: {serial_keys:?}"
+        );
+        assert!(matches!(serial.results[3], ItemResult::Err { .. }));
+
+        // Parallel over several worker counts must reproduce the serial result
+        // exactly, in order (rayon's ordered collect preserves input order).
+        for workers in [0usize, 2, 4] {
+            let parallel = processor.parse_and_rederive_parallel(&variants, None, false, workers);
+            let parallel_keys: Vec<String> = parallel.results.iter().map(rederive_key).collect();
+            assert_eq!(
+                parallel_keys, serial_keys,
+                "parse_and_rederive_parallel(workers={workers}) differs from serial"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_and_rederive_recommended_form_flag_is_threaded() {
+        // A lone reference `A` immediately 5' of an insertion of three `A`s
+        // derives, unnormalized, as a literal `ins`; `recommended_form = true`
+        // routes the result through `normalize`, which collapses it to repeat
+        // notation. The two settings therefore produce DIFFERENT descriptions, so
+        // this asserts the flag actually reaches `rederive` and changes the
+        // output — not merely that the call succeeds. Mirrors
+        // `tests/it/rederive.rs::recommended_form_true_routes_through_normalize`.
+        let processor = genome_processor_over("GCTAGCATCGATC"); // lone 'A' at position 7
+        let variants = vec!["NC_TEST.1:g.7_8insAAA"];
+        for workers in [0usize, 1, 2, 4] {
+            let plain = processor.parse_and_rederive_parallel(&variants, None, false, workers);
+            let recommended = processor.parse_and_rederive_parallel(&variants, None, true, workers);
+            assert_eq!(
+                rederive_key(&plain.results[0]),
+                "OK:NC_TEST.1:g.7_8insAAA",
+                "recommended_form=false (workers={workers}) must keep the literal insertion",
+            );
+            assert_eq!(
+                rederive_key(&recommended.results[0]),
+                "OK:NC_TEST.1:g.7A[4]",
+                "recommended_form=true (workers={workers}) must collapse to repeat notation",
+            );
+        }
     }
 
     #[test]

--- a/src/python.rs
+++ b/src/python.rs
@@ -4974,6 +4974,61 @@ impl PyBatchProcessor {
         PyBatchResult { inner }
     }
 
+    /// Parse and *re-derive* multiple HGVS strings — the batch, parallel
+    /// counterpart of `Normalizer.rederive`.
+    ///
+    /// Re-derivation expresses each variant as the bases it denotes and derives
+    /// one canonical description from those bases, so two spellings of one
+    /// variant converge. It is a different operation from `parse_and_normalize`
+    /// (which 3'-shifts the input's spelling) exactly as `Normalizer.rederive`
+    /// differs from `Normalizer.normalize`. This is the entry point to use when
+    /// re-deriving a large corpus: it makes one Python->Rust call, releases the
+    /// GIL for the whole batch, and scales across cores. Results are returned in
+    /// input order.
+    ///
+    /// Args:
+    ///     variants: List of HGVS strings to parse and re-derive.
+    ///     max_grid_cells: Largest alignment grid, in cells, the partitioner
+    ///         will build (as `Normalizer.rederive` / `from_sequences`). None
+    ///         uses the default.
+    ///     recommended_form: When True, also apply `normalize`'s recommended-form
+    ///         rules to each re-derived description.
+    ///     workers: Number of worker threads. 0 (default) uses all available
+    ///         cores; 1 runs serially; N uses N threads.
+    ///
+    /// Returns:
+    ///     BatchResult with re-derived variants and errors.
+    ///
+    /// Raises:
+    ///     ValueError: for a `max_grid_cells` of 0, matching `Normalizer.rederive`.
+    #[pyo3(signature = (variants, *, max_grid_cells=None, recommended_form=false, workers=0))]
+    fn parse_and_rederive(
+        &self,
+        py: Python<'_>,
+        variants: Vec<String>,
+        max_grid_cells: Option<usize>,
+        recommended_form: bool,
+        workers: usize,
+    ) -> PyResult<PyBatchResult> {
+        // Reject a zero grid up front, as the single `rederive` does via
+        // `from_sequences_options`, so the batch path raises the same ValueError
+        // rather than silently substituting the default inside the fan-out.
+        if max_grid_cells == Some(0) {
+            return Err(PyValueError::new_err(
+                "max_grid_cells must be positive; 0 admits no alignment grid at all",
+            ));
+        }
+        let inner = py.detach(|| {
+            self.processor.parse_and_rederive_parallel(
+                &variants,
+                max_grid_cells,
+                recommended_form,
+                workers,
+            )
+        });
+        Ok(PyBatchResult { inner })
+    }
+
     /// Parse an *iterable* of HGVS strings, yielding results lazily (#975).
     ///
     /// The streaming counterpart to `parse`. Use it when the input does not fit

--- a/tests/python/test_batch_parallel.py
+++ b/tests/python/test_batch_parallel.py
@@ -1,10 +1,17 @@
-"""Tests for the parallel batch API (``BatchProcessor.parse`` / ``parse_and_normalize``).
+"""Tests for the parallel batch API (``BatchProcessor.parse`` / ``parse_and_normalize`` /
+``parse_and_rederive``).
 
 The core property is invariance: parallel results must equal serial results
 (same order, same per-item success/error classification) for any worker count.
-These use the mock provider (``BatchProcessor()`` with no manifest), so they need
-no reference data.
+The ``parse`` / ``parse_and_normalize`` tests use the mock provider
+(``BatchProcessor()`` with no manifest), so they need no reference data. The
+``parse_and_rederive`` tests need a genome-capable provider — ``rederive`` reads
+the bases a variant denotes, which the mock test data does not carry — so they
+build a small single-contig ``reference_json`` under ``tmp_path``.
 """
+
+import json
+from pathlib import Path
 
 import ferro_hgvs
 
@@ -19,12 +26,16 @@ def _variants(n: int) -> list[str]:
 
 
 def _key(result) -> tuple:
-    """Order-sensitive fingerprint of a BatchResult."""
+    """Order-sensitive fingerprint of a BatchResult: counts, the ordered success
+    descriptions, and the ordered ``(index, message)`` errors — so a run that
+    misplaces or mis-tags a failure fails the comparison even when the success
+    list and the counts still match."""
     return (
         result.total(),
         result.success_count(),
         result.error_count(),
         [str(v) for v in result.successes()],
+        list(result.errors()),
     )
 
 
@@ -69,3 +80,103 @@ def test_default_workers_is_parallel_and_correct() -> None:
     bp = ferro_hgvs.BatchProcessor()
     variants = _variants(2000)
     assert _key(bp.parse(variants)) == _key(bp.parse(variants, workers=1))
+
+
+def _genome_bp(tmp_path: Path) -> "ferro_hgvs.BatchProcessor":
+    """A genome-capable BatchProcessor over one synthetic contig.
+
+    ``rederive`` reads the bases a variant denotes, so it needs genomic sequence
+    data — the default ``BatchProcessor()`` test data has none, and rederive would
+    error on every input there.
+    """
+    seq = ["A"] * 5000
+    for i in range(1000, 4000, 7):
+        seq[i] = "G"
+    ref = {
+        "transcripts": [],
+        "proteins": {},
+        "genomic_sequences": {"NC_000001.11": "".join(seq)},
+    }
+    path = tmp_path / "genome_ref.json"
+    path.write_text(json.dumps(ref))
+    return ferro_hgvs.BatchProcessor(reference_json=str(path))
+
+
+def _genome_variants(n: int) -> list[str]:
+    """`n` in-bounds genomic deletions that rederive successfully, with two parse
+    errors at known indices."""
+    assert n >= 3, "need n >= 3 for two distinct, in-bounds error indices"
+    vs = [f"NC_000001.11:g.{100 + i}del" for i in range(n)]
+    vs[1] = "definitely not a variant"
+    vs[n - 1] = "also::not:valid"
+    return vs
+
+
+def test_parse_and_rederive_parallel_matches_serial(tmp_path: Path) -> None:
+    bp = _genome_bp(tmp_path)
+    variants = _genome_variants(2000)
+
+    serial = _key(bp.parse_and_rederive(variants, workers=1))
+    assert serial[1] > 0, "expected successful rederivations, not an all-error corpus"
+    assert serial[2] == 2, "expected exactly the two injected parse errors"
+
+    for workers in (0, 2, 4, 8):
+        assert _key(bp.parse_and_rederive(variants, workers=workers)) == serial, (
+            f"parse_and_rederive(workers={workers}) differs from serial"
+        )
+
+
+def _insertion_repeat_bp(tmp_path: Path) -> "ferro_hgvs.BatchProcessor":
+    """A genome-capable BatchProcessor over a contig with a lone 'A' at position 7.
+
+    On this contig ``g.7_8insAAA`` derives, unnormalized, as the literal
+    ``g.7_8insAAA``; ``recommended_form=True`` routes it through ``normalize``,
+    which collapses it to the repeat ``g.7A[4]``. The two settings therefore
+    produce different descriptions — which is what lets a test prove the flag
+    reaches the parallel path rather than only that the call succeeds. Mirrors
+    ``tests/it/rederive.rs::recommended_form_true_routes_through_normalize``.
+    """
+    ref = {
+        "transcripts": [],
+        "proteins": {},
+        "genomic_sequences": {"NC_TEST.1": "GCTAGCATCGATC"},
+    }
+    path = tmp_path / "insertion_repeat_ref.json"
+    path.write_text(json.dumps(ref))
+    return ferro_hgvs.BatchProcessor(reference_json=str(path))
+
+
+def test_parse_and_rederive_recommended_form_runs_parallel(tmp_path: Path) -> None:
+    # recommended_form must reach the parallel rederive path AND change the
+    # output: the literal insertion `g.7_8insAAA` collapses to the repeat
+    # `g.7A[4]` only when the flag is honoured. Asserting the two settings
+    # differ — and stay invariant across worker counts — fails if the binding
+    # silently drops the flag.
+    bp = _insertion_repeat_bp(tmp_path)
+    variants = ["NC_TEST.1:g.7_8insAAA"]
+    for workers in (0, 1, 2, 4, 8):
+        plain = bp.parse_and_rederive(variants, recommended_form=False, workers=workers)
+        recommended = bp.parse_and_rederive(variants, recommended_form=True, workers=workers)
+        assert [str(v) for v in plain.successes()] == ["NC_TEST.1:g.7_8insAAA"], (
+            f"recommended_form=False (workers={workers}) must keep the literal insertion"
+        )
+        assert [str(v) for v in recommended.successes()] == ["NC_TEST.1:g.7A[4]"], (
+            f"recommended_form=True (workers={workers}) must collapse to repeat notation"
+        )
+
+
+def test_parse_and_rederive_is_deterministic(tmp_path: Path) -> None:
+    bp = _genome_bp(tmp_path)
+    variants = _genome_variants(1000)
+    a = _key(bp.parse_and_rederive(variants, workers=8))
+    b = _key(bp.parse_and_rederive(variants, workers=8))
+    assert a == b
+
+
+def test_parse_and_rederive_rejects_zero_grid() -> None:
+    import pytest
+
+    # No reference needed: the 0-grid ValueError is raised before any work.
+    bp = ferro_hgvs.BatchProcessor()
+    with pytest.raises(ValueError):
+        bp.parse_and_rederive(["NM_000088.3:c.1A>G"], max_grid_cells=0)


### PR DESCRIPTION
Closes #2177.

## What

Exposes `rederive` (recommended-form re-derivation) on the parallel batch API. Until now `BatchProcessor` parallelized `parse` and `parse_and_normalize`, but there was no batch or parallel entry point for `rederive` — so a large-scale recommended-form workload (e.g. a Mutalyzer-vs-ferro comparison over millions of variants) had to loop one variant at a time in Python, on a single core. `parse_and_normalize` runs plain `normalize`, which is a different operation from `rederive(recommended_form=True)`, so it was not a substitute.

- **Rust** — `BatchProcessor::parse_and_rederive_parallel(variants, max_grid_cells, recommended_form, num_threads)` in `src/batch/processor.rs`, mirroring `parse_and_normalize_parallel` but calling `self.normalizer.rederive(&v, &options, recommended_form)`. Options are built from the processor’s own normalizer config, so the shuffle direction matches the serial `rederive` path.
- **Python** — `BatchProcessor.parse_and_rederive(variants, *, max_grid_cells=None, recommended_form=False, workers=0)`, same GIL-release and `workers` (0/1/N) semantics as `parse_and_normalize`, returning a `BatchResult`. `max_grid_cells=0` raises `ValueError`, matching `Normalizer.rederive`.
- Type stub in `python/ferro_hgvs/__init__.pyi`.

## Why

Recommended-form normalization at scale was single-core-bound purely for lack of a parallel entry point. This closes that gap without changing any normalization behavior — it is a new API surface wrapping the existing, unchanged `Normalizer::rederive`.

## Tests

- Rust unit tests (Mock provider): parallel results are identical (same order, same per-item ok/error classification) to serial across worker counts `{0,1,2,4}`, and the `recommended_form` flag is threaded through.
- Python tests (`tests/python/test_batch_parallel.py`): invariance vs serial across `{0,1,2,4,8}` workers, `recommended_form=True` invariance, determinism, and `ValueError` on `max_grid_cells=0`.

Local gate green: `cargo fmt`, `cargo clippy --features dev`, `cargo clippy --features python`, the new lib tests, `ruff check`, `ruff format --check`, `mypy` on the stub, and the full `tests/python/test_batch_parallel.py` suite (8 passed) against a freshly built wheel.

## Follow-up (not in this PR)

A streaming counterpart (`parse_and_rederive_streaming`, mirroring `parse_and_normalize_streaming`) is the natural next step for the very large corpora this is aimed at — it bounds peak memory and avoids materializing one result object per input, which is the dominant serial cost of the Vec-based batch API at scale. Filed separately to keep this PR focused on the Vec-based parallel entry point.

Representation-Change: none. New parallel entry point wrapping the existing, unchanged `Normalizer::rederive`; no normalization behavior changes.
