### PR TITLE
perf(ci): skip the census/confluence tests in the coverage job (−0.34pp, ~2× faster)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -133,8 +133,31 @@ jobs:
           # Absence of a bulk fixture fails the run rather than skipping it.
           FERRO_REQUIRE_BULK_FIXTURES: "1"
         run: |
+          # Skip the heavy census/confluence tests here. They run the whole spec
+          # corpus through the normalizer and dominate the coverage wall (~13 min
+          # -> ~5-6 min without them), but they add almost NO unique coverage: a
+          # controlled two-pass llvm-cov diff on `origin/main` measured them
+          # covering just 514 lines nothing else reaches, 502 of which are the
+          # census harness itself (`src/conformance/census.rs`), and ~15 lines of
+          # shipped normalizer/reference code (13 in `src/normalize/`, 2 in
+          # `src/reference/`). Net coverage drops ~0.34 pp (83.79% -> 83.45%)
+          # because the normalization machinery they exercise is already covered
+          # by the hundreds of targeted regression tests. Their VALUE is their
+          # aggregate confluence/conformance assertions, which gate in the
+          # required `censuses` job (~106 s, optimized, un-instrumented) — this
+          # only drops re-counting their line execution under instrumentation.
+          #
+          # This census carve set is deliberately NOT ci.yml's CENSUS_FILTER: that
+          # filter routes modules to the optimized `censuses` archive and names
+          # normalize_axis_preserving / clinvar_hgvs_tests /
+          # issue_1542_direction_symmetry; this one drops the corpus-heavy
+          # census/confluence tests from the *instrumented* run for wall time and
+          # adds cis_confluence_* (which CENSUS_FILTER omits). Nothing cross-checks
+          # the two lists — keep them in mind together.
           cargo llvm-cov --no-report nextest --features dev \
-            --partition hash:${{ matrix.shard }}/4
+            --partition hash:${{ matrix.shard }}/4 \
+            -E 'not (test(conformance_census_runs) or test(spec_conformance_axis)
+                     or test(cis_confluence_axis) or test(cis_confluence_nr_axis))'
           cargo llvm-cov report --codecov --output-path codecov.json
           cargo llvm-cov report --html --output-dir coverage
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0


### PR DESCRIPTION
## What

Skip the heavy census/confluence tests (`conformance_census_runs`, `spec_conformance_axis`, `cis_confluence*`) in the `Coverage` job's nextest run. They run the whole spec corpus through the normalizer and dominate the Coverage wall.

## Why it's nearly free

A controlled two-pass `llvm-cov` diff on `origin/main` (all `it`+`lib` tests, with vs. without these tests) measured them covering **514 lines nothing else reaches — 502 of them the census harness itself** (`src/conformance/census.rs`), and only **~14 lines of `src/normalize/`**. The 8,000-line partitioner (`merge.rs`) loses **5 lines**; it's already covered by the targeted regression suite.

Net coverage: **83.79% → 83.45% (−0.34 pp)** — confirmed on Codecov once all four shards merged.

Their *value* is their aggregate confluence/conformance assertions, which stay gated in the required `censuses` job (~106 s, optimized, un-instrumented). `Coverage` is non-gating and only re-counts their line execution under instrumentation.

## Measured effect

Wall (this branch's first run): worst shard **803s → ~477s (−41%)**; heavy shards −42–49%.

## Not included

A follow-up could add a tiny sampled-census unit test to reclaim the ~500 harness lines cheaply — but that needs a sampling mode on the (pinned) corpus generator, not a one-liner, so it's deliberately out of scope here.

Representation-Change: none. CI-workflow change only; no source touched.
