### PR TITLE
feat: add streaming parse_and_rederive to BatchProcessor

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1942,6 +1942,34 @@ class BatchProcessor:
         """
         ...
 
+    def parse_and_rederive_streaming(
+        self,
+        variants: Iterable[str],
+        *,
+        max_grid_cells: int | None = None,
+        recommended_form: bool = False,
+        workers: int = 0,
+    ) -> BatchStream:
+        """Parse and re-derive an iterable of HGVS strings lazily, in input order.
+
+        The streaming counterpart of `parse_and_rederive`: use it for a large
+        corpus, where materializing one result object per input is the dominant
+        cost. See `parse_streaming` for the rationale and memory numbers, and
+        `parse_and_rederive` for how re-derivation differs from normalization.
+
+        Args:
+            variants: Iterable of HGVS strings.
+            max_grid_cells: Largest alignment grid, in cells (as
+                `Normalizer.rederive`). None uses the default.
+            recommended_form: When True, also apply `normalize`'s recommended-form
+                rules to each re-derived description.
+            workers: Worker threads. 0 (default) uses all cores; 1 is serial; N uses N threads.
+
+        Raises:
+            ValueError: for a `max_grid_cells` of 0.
+        """
+        ...
+
     def parse_with_progress(
         self, variants: list[str], callback: Callable[[BatchProgress], None]
     ) -> BatchResult:

--- a/src/batch/processor.rs
+++ b/src/batch/processor.rs
@@ -644,6 +644,46 @@ impl<P: ReferenceProvider + Sync> BatchProcessor<P> {
         })
     }
 
+    /// Parse and *re-derive* a *stream* of HGVS strings, yielding results in input
+    /// order (#975). The streaming counterpart of
+    /// [`parse_and_rederive_parallel`](Self::parse_and_rederive_parallel); see
+    /// [`parse_streaming`](Self::parse_streaming) for why the signature is shaped
+    /// this way (bounded peak memory, order preserved).
+    ///
+    /// Options are built once from this processor's normalizer config and shared
+    /// across workers; `max_grid_cells == Some(0)` is treated as the default, as
+    /// in the `Vec`-based method.
+    pub fn parse_and_rederive_streaming<'a, I, S>(
+        &'a self,
+        variants: I,
+        max_grid_cells: Option<usize>,
+        recommended_form: bool,
+        num_threads: usize,
+    ) -> impl Iterator<Item = ItemResult<HgvsVariant>> + 'a
+    where
+        I: IntoIterator<Item = S> + 'a,
+        S: AsRef<str> + Send + Sync + 'a,
+    {
+        // Built once and moved into the per-item closure; `FromSequencesOptions`
+        // is `Send + Sync`, so one instance serves every streaming worker.
+        let mut options = FromSequencesOptions::default()
+            .with_direction(self.normalizer.config().shuffle_direction);
+        if let Some(cells) = max_grid_cells.filter(|&c| c != 0) {
+            options = options.with_max_grid_cells(cells);
+        }
+        self.map_streaming(variants, num_threads, move |input: &S| {
+            match parse_hgvs(input.as_ref())
+                .and_then(|v| self.normalizer.rederive(&v, &options, recommended_form))
+            {
+                Ok(rederived) => ItemResult::Ok(rederived),
+                Err(error) => ItemResult::Err {
+                    input: Some(input.as_ref().to_string()),
+                    error,
+                },
+            }
+        })
+    }
+
     /// Shared engine behind the streaming methods: read a bounded chunk, map it
     /// order-preservingly, drain it, repeat.
     ///
@@ -941,6 +981,37 @@ mod tests {
                 rederive_key(&recommended.results[0]),
                 "OK:NC_TEST.1:g.7A[4]",
                 "recommended_form=true (workers={workers}) must collapse to repeat notation",
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_and_rederive_streaming_matches_parallel() {
+        // The streaming Rust API must yield exactly what the Vec-based parallel
+        // method returns, in input order. (The Python BatchStream drives the Vec
+        // method per chunk; this covers the Rust `_streaming` method itself.)
+        let processor = genome_processor();
+        let variants = vec!["NC_TEST.1:g.100del", "NC_TEST.1:g.5G>C", "not a variant"];
+
+        let expected: Vec<String> = processor
+            .parse_and_rederive_parallel(&variants, None, false, 1)
+            .results
+            .iter()
+            .map(rederive_key)
+            .collect();
+        assert!(
+            expected.iter().any(|k| k.starts_with("OK:")),
+            "expected some successful rederivations; got {expected:?}"
+        );
+
+        for workers in [1usize, 2, 4] {
+            let streamed: Vec<String> = processor
+                .parse_and_rederive_streaming(variants.clone(), None, false, workers)
+                .map(|item| rederive_key(&item))
+                .collect();
+            assert_eq!(
+                streamed, expected,
+                "parse_and_rederive_streaming(workers={workers}) differs from the Vec method"
             );
         }
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -4748,6 +4748,13 @@ impl PyBatchItem {
 enum StreamOp {
     Parse,
     ParseAndNormalize,
+    /// Re-derive, carrying the same options as the `Vec`-based
+    /// `parse_and_rederive`. `Option<usize>` and `bool` are `Copy`, so the enum
+    /// stays `Copy` and can be read out of `self.op` per chunk.
+    Rederive {
+        max_grid_cells: Option<usize>,
+        recommended_form: bool,
+    },
 }
 
 /// Lazy, order-preserving batch stream over a Python iterable (#975).
@@ -4830,6 +4837,19 @@ impl PyBatchStream {
                 StreamOp::ParseAndNormalize => {
                     processor
                         .parse_and_normalize_parallel(&chunk, workers)
+                        .results
+                }
+                StreamOp::Rederive {
+                    max_grid_cells,
+                    recommended_form,
+                } => {
+                    processor
+                        .parse_and_rederive_parallel(
+                            &chunk,
+                            max_grid_cells,
+                            recommended_form,
+                            workers,
+                        )
                         .results
                 }
             });
@@ -5077,6 +5097,51 @@ impl PyBatchProcessor {
         workers: usize,
     ) -> PyResult<PyBatchStream> {
         self.streaming(variants, workers, StreamOp::ParseAndNormalize)
+    }
+
+    /// Parse and *re-derive* an *iterable* of HGVS strings, yielding results lazily
+    /// (#975). The streaming counterpart of `parse_and_rederive` — use it for a
+    /// large corpus, where materializing one result object per input is the
+    /// dominant cost. See `parse_streaming` for the rationale and memory numbers,
+    /// and `parse_and_rederive` for how re-derivation differs from normalization.
+    ///
+    /// Args:
+    ///     variants: Iterable of HGVS strings.
+    ///     max_grid_cells: Largest alignment grid, in cells (as
+    ///         `Normalizer.rederive`). None uses the default.
+    ///     recommended_form: When True, also apply `normalize`'s recommended-form
+    ///         rules to each re-derived description.
+    ///     workers: Number of worker threads. 0 (default) uses all available
+    ///         cores; 1 runs serially; N uses N threads.
+    ///
+    /// Returns:
+    ///     BatchStream yielding one BatchItem per input, in input order.
+    ///
+    /// Raises:
+    ///     ValueError: for a `max_grid_cells` of 0, matching `parse_and_rederive`.
+    #[pyo3(signature = (variants, *, max_grid_cells=None, recommended_form=false, workers=0))]
+    fn parse_and_rederive_streaming(
+        &self,
+        variants: Bound<'_, pyo3::PyAny>,
+        max_grid_cells: Option<usize>,
+        recommended_form: bool,
+        workers: usize,
+    ) -> PyResult<PyBatchStream> {
+        // Reject a zero grid up front, as `parse_and_rederive` does, so the error
+        // is raised at the call rather than on the first `__next__`.
+        if max_grid_cells == Some(0) {
+            return Err(PyValueError::new_err(
+                "max_grid_cells must be positive; 0 admits no alignment grid at all",
+            ));
+        }
+        self.streaming(
+            variants,
+            workers,
+            StreamOp::Rederive {
+                max_grid_cells,
+                recommended_form,
+            },
+        )
     }
 
     /// Parse multiple HGVS strings with progress callback

--- a/tests/python/test_batch_streaming.py
+++ b/tests/python/test_batch_streaming.py
@@ -20,6 +20,9 @@ These use the mock provider (``BatchProcessor()`` with no manifest), so they nee
 no reference data.
 """
 
+import json
+from pathlib import Path
+
 import pytest
 
 import ferro_hgvs
@@ -71,6 +74,65 @@ def test_streaming_normalize_matches_the_list_api(processor, workers):
     expected = _from_list(processor.parse_and_normalize(variants, workers=workers))
     streamed = _from_stream(processor.parse_and_normalize_streaming(variants, workers=workers))
     assert streamed == expected
+
+
+def _genome_bp(tmp_path: Path) -> "ferro_hgvs.BatchProcessor":
+    """A genome-capable BatchProcessor: ``rederive`` reads the bases a variant
+    denotes, which the default ``BatchProcessor()`` test data does not carry."""
+    seq = ["A"] * 5000
+    for i in range(1000, 4000, 7):
+        seq[i] = "G"
+    ref = {
+        "transcripts": [],
+        "proteins": {},
+        "genomic_sequences": {"NC_000001.11": "".join(seq)},
+    }
+    path = tmp_path / "genome_ref.json"
+    path.write_text(json.dumps(ref))
+    return ferro_hgvs.BatchProcessor(reference_json=str(path))
+
+
+def _genome_variants(n: int) -> list[str]:
+    """`n` in-bounds genomic deletions that rederive, with two parse errors."""
+    assert n >= 3
+    vs = [f"NC_000001.11:g.{100 + i}del" for i in range(n)]
+    vs[1] = "definitely not a variant"
+    vs[n - 1] = "also::not:valid"
+    return vs
+
+
+@pytest.mark.parametrize("workers", [0, 1, 2])
+def test_streaming_rederive_matches_the_list_api(tmp_path: Path, workers: int) -> None:
+    bp = _genome_bp(tmp_path)
+    variants = _genome_variants(50)
+    expected = _from_list(bp.parse_and_rederive(variants, workers=workers))
+    # A genome-capable provider means rederive actually succeeds, so this
+    # compares streaming vs list over real (Ok) results, not only errors.
+    assert any(ok for ok, _ in expected), "expected successful rederivations"
+    streamed = _from_stream(bp.parse_and_rederive_streaming(variants, workers=workers))
+    assert streamed == expected
+
+
+@pytest.mark.parametrize("workers", [0, 1, 2])
+def test_streaming_rederive_recommended_form_matches_the_list_api(
+    tmp_path: Path, workers: int
+) -> None:
+    bp = _genome_bp(tmp_path)
+    variants = _genome_variants(40)
+    expected = _from_list(bp.parse_and_rederive(variants, recommended_form=True, workers=workers))
+    # As in the sibling above: prove the comparison runs over real (Ok) results,
+    # not a vacuously-passing all-error corpus.
+    assert any(ok for ok, _ in expected), "expected successful rederivations"
+    streamed = _from_stream(
+        bp.parse_and_rederive_streaming(variants, recommended_form=True, workers=workers)
+    )
+    assert streamed == expected
+
+
+def test_streaming_rederive_rejects_zero_grid(processor: "ferro_hgvs.BatchProcessor") -> None:
+    # The 0-grid ValueError is raised at the call, before any item is streamed.
+    with pytest.raises(ValueError):
+        processor.parse_and_rederive_streaming(["NM_000088.3:c.1A>G"], max_grid_cells=0)
 
 
 def test_failed_items_carry_their_input(processor):
@@ -168,6 +230,7 @@ def test_accepts_any_iterable(processor):
 def test_empty_input_yields_nothing(processor):
     assert list(processor.parse_streaming([])) == []
     assert list(processor.parse_and_normalize_streaming([])) == []
+    assert list(processor.parse_and_rederive_streaming([])) == []
 
 
 def test_non_string_element_raises(processor):


### PR DESCRIPTION
Follow-up to #2178 (adds the Vec-based parallel `parse_and_rederive`). Implements the streaming counterpart it named as follow-up.

**Stacked on #2178** — this PR's base is #2178's branch, so its diff shows only the streaming changes. It should merge after #2178; once #2178 lands I'll rebase onto `main` and retarget the base.

## What

Adds `BatchProcessor.parse_and_rederive_streaming` (Python) and `BatchProcessor::parse_and_rederive_streaming` (Rust) — the streaming, order-preserving counterpart of `parse_and_rederive`. For a large corpus it **bounds peak memory** (one chunk of results at a time) instead of materializing one result object per input.

- **Rust** (`src/batch/processor.rs`): mirrors `parse_and_normalize_streaming`, backed by the shared `StreamingMap` engine; options built once from the processor's normalizer config.
- **Python** (`src/python.rs`): a new `StreamOp::Rederive { max_grid_cells, recommended_form }` variant drives the existing `BatchStream`; `max_grid_cells=0` raises `ValueError`, matching `parse_and_rederive`.
- Type stub in `python/ferro_hgvs/__init__.pyi`.

## Why

For a large corpus, the Vec-based batch API's dominant serial cost is result materialization — building and GIL-marshaling one result object per input. Streaming is the mitigation: it bounds peak memory and yields incrementally, so throughput isn't gated on materializing the whole result set. This mirrors why `parse_and_normalize_streaming` exists (#975).

## Tests

- Rust unit test: the Rust `_streaming` method yields exactly what the Vec `parse_and_rederive_parallel` returns, in order, across worker counts. (The Python `BatchStream` drives the Vec method per chunk, so the Rust method needs its own coverage.)
- Python (`tests/python/test_batch_streaming.py`): streaming == list API across `{0,1,2}` workers over a genome-capable provider (so successful rederivations are exercised, not only errors), `recommended_form=True` equivalence, `ValueError` on `max_grid_cells=0`, and empty-input.

Local gate green: `cargo fmt`, `cargo clippy --features dev`, `cargo clippy --features python`, the Rust rederive tests, `ruff check`, `ruff format --check`, `mypy` on the stub, and the full streaming + parallel Python suites (30 passed) against a freshly built wheel.

Representation-Change: none. New streaming entry point wrapping the existing, unchanged `Normalizer::rederive`; no normalization behavior changes.
