### PR TITLE
perf(normalize): drop the redundant second block partition in rederive(recommended_form=true)

### DIFF
--- a/src/normalize/from_sequences.rs
+++ b/src/normalize/from_sequences.rs
@@ -294,6 +294,11 @@ pub fn from_sequences_detailed(
 
     let mut members = block.members;
     retype_inversions(&mut members, reference, w_lo);
+    // Split any equal-length spanning `delins` the place chain merged into its
+    // canonical [sub; inv] decomposition, as `normalize` does per member. Runs
+    // after `retype_inversions` (whole-span inv) since the two are complementary
+    // — see `split_canonical_delins`.
+    let members = split_canonical_delins(members, reference, w_lo);
 
     let variant = match members.len() {
         0 => template,
@@ -710,6 +715,99 @@ fn retype_inversions(members: &mut [HgvsVariant], reference: &[u8], w_lo: i64) {
             length: None,
         });
     }
+}
+
+/// Split each equal-length `delins` member into its canonical decomposition —
+/// independent substitutions and any interior `inv` — the way
+/// `Normalizer::normalize`'s per-member `apply_canonical_split` does, but from
+/// the window reference bytes this surface already holds rather than a provider
+/// fetch.
+///
+/// The place chain in `derive_block_members` merges a substitution flanking an
+/// inversion into one spanning `delins` (e.g. `ATGCG -> CTCGC`), exactly as
+/// `canonicalize_from_sequence`'s own inner chain does — measured: both reach
+/// `g.7_11delinsCTCGC` before any member-level pass. `normalize` then re-splits
+/// it to `g.[7A>C;9_11inv]` under `general.md:56` priority (a maximal
+/// reverse-complement run is an `inv`; two mismatches separated by an unchanged
+/// base are individual substitutions), via `apply_canonical_split` in its
+/// per-member pipeline. Without this port the two surfaces disagree on every
+/// such block — the largest remaining ThreePrime divergence class (#2161).
+///
+/// `retype_inversions` above handles the *whole-span* reverse complement;
+/// `decompose_delins` deliberately declines that shape
+/// (`decompose_full_span_inv_returns_none`) and handles the *partial* one, so the
+/// two passes are complementary and run in that order.
+///
+/// Scope falls out of `decompose_delins`: it requires `alt.len() == ref.len()`
+/// and returns `None` otherwise, so a net-deletion or net-insertion `delins` —
+/// which `delins-merge-vs-individual-gap-two-or-more` keeps whole — is left
+/// untouched. `Genome`/`Mt` only (the axes this surface emits); codon-frame
+/// merging is off, there being no reading frame on a genomic axis.
+fn split_canonical_delins(
+    members: Vec<HgvsVariant>,
+    reference: &[u8],
+    w_lo: i64,
+) -> Vec<HgvsVariant> {
+    let mut out: Vec<HgvsVariant> = Vec::with_capacity(members.len());
+    for member in members {
+        match decompose_member_delins(&member, reference, w_lo) {
+            Some(split) => out.extend(split),
+            None => out.push(member),
+        }
+    }
+    out
+}
+
+/// The per-member half of [`split_canonical_delins`]: the split members when
+/// `member` is an equal-length `Genome`/`Mt` `delins` that decomposes, else
+/// `None` (the caller keeps the member unchanged).
+fn decompose_member_delins(
+    member: &HgvsVariant,
+    reference: &[u8],
+    w_lo: i64,
+) -> Option<Vec<HgvsVariant>> {
+    let loc_edit = match member {
+        HgvsVariant::Genome(v) => &v.loc_edit,
+        HgvsVariant::Mt(v) => &v.loc_edit,
+        _ => return None,
+    };
+    let Mu::Certain(NaEdit::Delins { sequence, .. }) = &loc_edit.edit else {
+        return None;
+    };
+    let InsertedSequence::Literal(payload) = sequence else {
+        return None;
+    };
+    let payload: Vec<u8> = payload.to_string().into_bytes();
+    // Only a plain, certain two-endpoint span, mirroring `retype_inversions`.
+    let (
+        UncertainBoundary::Single(Mu::Certain(start)),
+        UncertainBoundary::Single(Mu::Certain(end)),
+    ) = (&loc_edit.location.start, &loc_edit.location.end)
+    else {
+        return None;
+    };
+    if start.special.is_some() || end.special.is_some() {
+        return None;
+    }
+    // Window offsets: both endpoints are 1-based inclusive on `w_lo`'s axis.
+    let (Ok(lo), Ok(hi)) = (
+        usize::try_from(start.base as i64 - w_lo),
+        usize::try_from(end.base as i64 - w_lo),
+    ) else {
+        return None;
+    };
+    if hi < lo || hi >= reference.len() {
+        return None;
+    }
+    let span = &reference[lo..=hi];
+    // `decompose_delins` requires `payload.len() == span.len()`; a net del/ins
+    // returns `None` here, which is the scope guard.
+    let subedits = crate::normalize::rules::decompose_delins(span, 0, span.len(), &payload)?;
+    // Positions from `decompose_delins` are 0-indexed offsets into `span`, whose
+    // offset 0 is the member's own start base — so `hgvs_start` is `start.base`.
+    Some(crate::normalize::build_split_variants(
+        member, subedits, start.base, false,
+    ))
 }
 
 /// Re-apply the derived description to the supplied reference and require it to

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -11080,55 +11080,117 @@ pub(crate) fn derive_block_members(
         piece.ref_end += lo;
     }
 
-    // The 3' placement, bounded by the caller's window. NOT the
-    // reference-anchored shift `normalize` performs: `reference` is all the
-    // sequence this path has, so nothing may move outside it.
-    shift_pieces(&mut pieces, reference, direction);
-    coalesce_adjacent_pieces(&mut pieces);
-    shrink_pieces_to_differences(&mut pieces, reference);
-
-    // `DNA/delins.md:44-47`'s payload-coincidence re-spelling (#2155 task 3c),
-    // run exactly as `canonicalize_from_sequence` runs it: same two gates
-    // (`payload_coalesce_applies`, `compensating_gap_coalesce_applies`), same
-    // order, against the same rule this surface is pinned to
-    // (`DERIVED_BLOCK_PARTITION_RULE`). Without this the derivation surface
-    // never ran the coalesce at all — see this function's own doc, corrected
-    // 2026-08-17 — so it fragmented exactly the block the normalization
-    // surface collapses, and #2155's headline reproduction (`from_sequences`)
-    // still showed the defect after the earlier tasks in this series widened
-    // only `canonicalize_from_sequence`'s call sites.
+    // The placement-and-coalesce chain, run as ONE unit in both shuffle
+    // directions and reconciled to the member-count-minimal result — exactly
+    // the shape `canonicalize_from_sequence_with_rule` runs at its own
+    // `place_direction_symmetrically` call. Each pass here matches the
+    // canonicalizer's order:
     //
-    // Gated on the template's axis, not unconditionally: `from_sequences`
-    // only ever builds a `Genome` or `Mt` template (`reference_template`
-    // refuses every other accession class), both squarely inside the widened
-    // DNA scope, so this reaches exactly `g.`/`m.`. `cis_kind_of` returning
-    // `None` (an axis this module does not serve at all) skips both passes,
-    // leaving the pre-existing pieces untouched — the same behaviour this
-    // surface always had before this change.
+    //  1. `shift_pieces` — the 3'/5' placement, bounded by the caller's window
+    //     (NOT the reference-anchored shift `normalize` performs: `reference` is
+    //     all the sequence this path has, so nothing may move outside it).
+    //  2. `coalesce_adjacent_pieces`, `shrink_pieces_to_differences`.
+    //  3. `DNA/delins.md:44-47`'s payload-coincidence re-spelling (#2155 task
+    //     3c) — same two gates (`payload_coalesce_applies`,
+    //     `compensating_gap_coalesce_applies`), same order, against this
+    //     surface's pinned rule (`DERIVED_BLOCK_PARTITION_RULE`). Gated on the
+    //     template's axis: `from_sequences` only ever builds a `Genome`/`Mt`
+    //     template, so this reaches exactly `g.`/`m.`.
+    //  4. `coalesce_inversion_runs` (#2161 Path 1) — flanked/interior inversion
+    //     typing, ungated as in the canonicalizer, reading the ORIGINAL
+    //     trim-bounded block (`block_ref`/`block_alt`, direction-independent),
+    //     exactly as the canonicalizer passes `&ref_bytes[lo..hi_ref]` /
+    //     `&result[lo..hi_alt]`.
+    //
+    // # Why the whole chain is mirrored, not just the inversion pass
+    //
+    // A flanked inversion's `[del;dup]` fragmentation only aligns to the block
+    // under ONE of the two placements. Under the 3' shift the `dup` rolls one
+    // base past `hi_ref` into the trailing common run, and
+    // `coalesce_inversion_runs` cannot see a `revcomp` off a hull shifted off
+    // the block by even one base; under the 5' shift it stays in-block and the
+    // inversion types. `canonicalize_from_sequence` closes this by trying both
+    // directions and keeping the member-minimal (its own doc's worked example is
+    // `21_24delinsCATGC` → three members at 3', `22_24inv` at 5'); this surface
+    // shifted a SINGLE direction and so saw only the placement that hid the
+    // inversion. #1542's rule governs: the shuffle direction may move a member's
+    // placement, it may not change how many members there are.
+    //
+    // Mirroring the chain rather than adding the inversion pass ahead of the
+    // shift is load-bearing. Running the inversion typing before the payload
+    // merge types an `inv` where a small-separation sibling should have merged
+    // into a spanning `delins` first (`g.[13_17inv;19del]` → `g.13_19delins…`),
+    // which `place_direction_symmetrically` gets right for free: both directions
+    // merge identically, the member counts match, and the requested placement is
+    // kept without a spurious `inv`. Measured over the geometry corpus in
+    // `issue_2161_from_sequences_inversion_converge`, the mirror closes ~5,900
+    // flanked-inversion divergences and — unlike the before-shift call — opens
+    // none.
     //
     // The convergence this buys is pinned by
-    // `issue_2155_from_sequences_collapse::from_sequences_converges_with_normalize_on_the_same_block`:
-    // `from_sequences`'s output and `Normalizer::normalize`'s output agree,
-    // byte for byte, on this block. If a future edit moves this call out of
-    // step with `canonicalize_from_sequence`'s own order, that guard is what
-    // catches it.
-    if let Some(kind) = cis_kind_of(template) {
-        if payload_coalesce_applies(DERIVED_BLOCK_PARTITION_RULE, kind) {
-            coalesce_payload_alignment_split(&mut pieces, reference);
+    // `issue_2155_from_sequences_collapse::from_sequences_converges_with_normalize_on_the_same_block`
+    // (the payload half) and
+    // `issue_2161_from_sequences_inversion_converge` (the inversion half): both
+    // assert `from_sequences`'s output equals `Normalizer::normalize`'s on the
+    // affected block. If a future edit moves these passes out of step with
+    // `canonicalize_from_sequence`'s own order, those guards catch it.
+    let place_pieces = |pieces: &mut Vec<Piece>, direction: ShuffleDirection| {
+        shift_pieces(pieces, reference, direction);
+        coalesce_adjacent_pieces(pieces);
+        shrink_pieces_to_differences(pieces, reference);
+        if let Some(kind) = cis_kind_of(template) {
+            if payload_coalesce_applies(DERIVED_BLOCK_PARTITION_RULE, kind) {
+                coalesce_payload_alignment_split(pieces, reference);
+            }
+            if compensating_gap_coalesce_applies(DERIVED_BLOCK_PARTITION_RULE, kind) {
+                coalesce_compensating_gap_split(pieces, reference);
+            }
         }
-        if compensating_gap_coalesce_applies(DERIVED_BLOCK_PARTITION_RULE, kind) {
-            coalesce_compensating_gap_split(&mut pieces, reference);
-        }
-        // #2175 then #2174: peel a tandem dup abutting a change, then collapse
-        // the residual solid run into one `delins`. Same scope as the sibling at
+        coalesce_inversion_runs(pieces, reference, lo, block_ref, block_alt);
+        // Re-close any flush-adjacent (separation-zero) split
+        // `coalesce_inversion_runs` opened. Its flanked route reads a
+        // net-deletion delins `block_inversion` finds a reverse-complement
+        // inside — e.g. `g.13_15delinsTC` on `GAT` — and returns it as
+        // `[13_14inv;15del]`, two members abutting at separation zero. But
+        // `delins-adjacent-members-when-both-consume-reference` governs that
+        // shape: two adjacent members both consuming reference bases are one
+        // `delins`, so the split is not the canonical form —
+        // `Normalizer::normalize` re-merges it (measured:
+        // `normalize(g.[13_14inv;15del]) == g.13_15delinsTC`). The derivation
+        // surface must reach the same fixed point, so `coalesce_adjacent_pieces`
+        // (the `delins.md:16` enforcement point) runs once more here, after the
+        // inversion pass rather than only before it. A genuinely flanked
+        // inversion — one separated from its sibling by an unchanged base, like
+        // `g.[14del;21_23inv]` — is NOT flush-adjacent and is left as the `inv`.
+        // Without this re-close the geometry corpus regresses ~520
+        // separation-zero rows from `delins` to a split `inv`; with it, none.
+        coalesce_adjacent_pieces(pieces);
+        shrink_pieces_to_differences(pieces, reference);
+        // #2175 then #2174: peel a tandem dup abutting a change, then collapse the
+        // residual solid run into one `delins`. Same scope as the sibling at
         // `canonicalize_from_sequence`, minus its `rule.cuts_with_canonical()`
         // conjunct: this path has no `FERRO_PARTITION` rule to consult — it is the
         // canonical derivation itself — so the DNA-axis gate is the whole of it.
-        if AxisFrame::is_dna(kind) {
-            peel_tandem_dup_beside_change(&mut pieces, reference);
-            coalesce_solid_run(&mut pieces, reference);
+        //
+        // Ordered LAST — after the inversion re-close above — and this is where the
+        // derivation surface deliberately departs from `canonicalize_from_sequence`
+        // (which peels before the inversion pass and has no trailing
+        // `coalesce_adjacent_pieces`). Peel manufactures a `dup` from the reference
+        // tandem and leaves it flush against the abutting change, so any
+        // `coalesce_adjacent_pieces` running after it re-merges the two back into
+        // one `delins` — which `duplication-must-ranks-the-label-not-the-partition`
+        // says to keep as the `dup`. Placing peel after the inversion re-close is
+        // the only order on this surface where both survive: the flanked inversion
+        // is closed and the tandem dup is kept (#2175 /
+        // issue_2175_dup_abutting_change, plus the #2161 inversion corpus).
+        if let Some(kind) = cis_kind_of(template) {
+            if AxisFrame::is_dna(kind) {
+                peel_tandem_dup_beside_change(pieces, reference);
+                coalesce_solid_run(pieces, reference);
+            }
         }
-    }
+    };
+    place_direction_symmetrically(&mut pieces, direction, place_pieces);
 
     // Contig-start escape: rescue the pure insertion the 5'-shuffle rolled to
     // interbase 0 from the one window where the anchor genuinely does not exist.

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2214,6 +2214,207 @@ pub struct NaEditReference {
 #[cfg(debug_assertions)]
 const NA_EDIT_REFERENCE_CAP: usize = 4096;
 
+/// #2161 Path 1: whether the shipped `recommended_form = true` derivation surface
+/// ([`Normalizer::rederive`] / [`Normalizer::from_sequences`]) skips the second
+/// block partition ([`crate::normalize::merge::canonicalize_from_sequence`], the
+/// ~38% `AlignmentDag` rebuild inside the final normalization).
+///
+/// `true` ships the drop. It is a single switch on purpose: the derivation
+/// surface already produces the canonical partition (the convergence increments),
+/// so the second partition is a no-op on [`Normalizer::normalize_core`]'s output,
+/// and skipping it changes no output — proven byte-for-byte by the guard in
+/// `tests/it/issue_2161_from_sequences_inversion_converge.rs`. Flip to `false` to
+/// restore the pre-drop behavior without touching the plumbing.
+const REDERIVE_SKIPS_REPARTITION: bool = true;
+
+/// How the final normalization treats the second block partition
+/// (`canonicalize_from_sequence`), the #2161 Path 1 lever.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum RepartitionMode {
+    /// Run it as it always has: rebuild the `AlignmentDag`, re-cut the block,
+    /// re-type. The pre-drop behavior, and what public `normalize()` and the
+    /// projector always use.
+    Full,
+    /// Skip it entirely — the raw, unconditional drop (test/`dev` only, never the
+    /// shipped path; that is `Gated` below). `normalize_core`'s output is taken as
+    /// the canonical form, on the premise the derivation surface already produced it.
+    ///
+    /// Only ever *constructed* by `normalize_skipping_repartition`, which is
+    /// `#[cfg(any(test, feature = "dev"))]` — the #2161 convergence guard's lever.
+    /// It is still matched unconditionally below, so the variant must exist in
+    /// every build; a non-test/non-dev build simply never constructs it, so allow
+    /// dead code there while keeping the lint live where a constructor exists.
+    #[cfg_attr(not(any(test, feature = "dev")), allow(dead_code))]
+    Skip,
+    /// Skip the re-partition **unless** a cheap structural check
+    /// ([`repartition_gate`]) says it might change the output — the shipped Drop.
+    /// The Drop's only divergence shapes are an inversion or `delins` member, so
+    /// an output of only sub/del/ins/dup members skips (the fast path) and
+    /// anything carrying an inv/delins runs the full re-partition (correct).
+    Gated,
+}
+
+/// #2161 Path 1 gate: could the second block partition
+/// (`canonicalize_from_sequence`) still change this `normalize_core` output?
+///
+/// The Drop skips that re-partition. Measured over both the geometry corpus
+/// (`issue_2161_from_sequences_inversion_converge`) and the designed
+/// small-separation cis corpus (`cis_confluence_axis`), the re-partition moves an
+/// output **only** when it carries an **inversion** member (which it can decompose
+/// or re-place) or a **`delins`** member (which it can split, or merge with an
+/// adjacent member into a net-deletion `delins`). An allele of only
+/// substitution/deletion/insertion/duplication members is a fixed point of the
+/// re-partition — 0 divergences over 47,392 designed spellings at separations
+/// 0..8. So the gate is the presence of an inv or delins member anywhere in the
+/// output; `true` means run the full re-partition, `false` means the skip is safe.
+///
+/// Reads only the AST — no provider, no allocation, one pass over members — so the
+/// fast path pays a structural scan rather than a DAG rebuild. Any shape it cannot
+/// read as a plain nucleotide member (protein, a nested allele) falls safe to
+/// `true`.
+fn repartition_gate(variant: &HgvsVariant) -> bool {
+    fn na_of(member: &HgvsVariant) -> Option<&NaEdit> {
+        match member {
+            HV::Genome(g) => g.loc_edit.edit.inner(),
+            HV::Mt(m) => m.loc_edit.edit.inner(),
+            HV::Cds(c) => c.loc_edit.edit.inner(),
+            HV::Tx(t) => t.loc_edit.edit.inner(),
+            HV::Rna(r) => r.loc_edit.edit.inner(),
+            // A shape the gate cannot classify (protein, nested) — treat as risky.
+            _ => None,
+        }
+    }
+    // A member type that is a fixed point of the re-partition **as a lone member**:
+    // sub/del/ins/dup are atomic, and lone delins/inv are measured fixed points
+    // (the lone-member probes). A repeat, a dupins, or an unclassifiable shape is
+    // not, so the gate runs the full re-partition for those.
+    fn is_measured_fixed_point(na: Option<&NaEdit>) -> bool {
+        matches!(
+            na,
+            Some(
+                NaEdit::Substitution { .. }
+                    | NaEdit::Deletion { .. }
+                    | NaEdit::Insertion { .. }
+                    | NaEdit::Duplication { .. }
+                    | NaEdit::Delins { .. }
+                    | NaEdit::Inversion { .. }
+            )
+        )
+    }
+
+    let members: &[HgvsVariant] = match variant {
+        HV::Allele(allele) => &allele.variants,
+        // A single non-allele variant. It reaches the partitioner only by the
+        // splittable-single-member route, and the shipped `CanonicalCoalesced` arm
+        // keeps a lone member whole. A lone member has no sibling to merge with or
+        // be re-placed against, so every lone member of a **measured-safe** type is
+        // a fixed point of the re-partition: sub/del/ins/dup are atomic, and a lone
+        // delins (1,076 probed, incl. reverse-complement / homopolymer /
+        // unchanged-interior payloads) and lone inv (2,512 probed) changed 0 times
+        // (`a_lone_delins_is_a_fixed_point_of_the_repartition`,
+        // `a_lone_inv_is_a_fixed_point_of_the_repartition`) — a reverse-complement
+        // span is typed `inv` before it is ever a lone delins. Any OTHER edit
+        // (repeat, dupins, an unclassifiable shape) is not measured safe, so it
+        // falls safe to running the re-partition.
+        single => return !is_measured_fixed_point(na_of(single)),
+    };
+
+    // (1) An inversion member — the re-partition can decompose it or re-place it
+    // against a sibling. Measured: the 15 FivePrime inv-placement divergences.
+    if members
+        .iter()
+        .any(|m| matches!(na_of(m), Some(NaEdit::Inversion { .. })))
+    {
+        return true;
+    }
+
+    // (2) Any member that is neither atomic (sub/del/ins/dup) nor a `delins` — a
+    // repeat, a dupins, or a shape the gate cannot classify. None of these is a
+    // measured fixed point and the re-partition can re-type it, so fall safe. A
+    // `delins` is handled by the net-length test below; an atomic member is a
+    // fixed point.
+    for member in members {
+        match na_of(member) {
+            Some(
+                NaEdit::Substitution { .. }
+                | NaEdit::Deletion { .. }
+                | NaEdit::Insertion { .. }
+                | NaEdit::Duplication { .. }
+                | NaEdit::Delins { .. }
+                | NaEdit::Inversion { .. },
+            ) => {}
+            // Repeat / multi-repeat / dupins / conversion / identity / padded
+            // deletion / substitution-without-reference / unclassifiable: not a
+            // measured fixed point — fall safe to the full re-partition.
+            _ => return true,
+        }
+    }
+
+    // (3) A `delins` member in a **net-deletion** allele. The merge into one
+    // spanning `delins` (`rulings[delins-merge-vs-individual-gap-two-or-more]`)
+    // reaches "the net-deletion case only — payload shorter than the span", so it
+    // fires exactly when the allele's total alternate length is shorter than its
+    // total reference length. That total is a property of the member lengths
+    // alone — no reference bases, no gap threshold — so it is exact and cheap.
+    // Measured: every divergent merge (72 in the geometry corpus, 12 in the
+    // dense-member corpus) is a `delins` beside a `del` at net < 0; every wasted
+    // delins fallback is a `delins` beside a sub/ins/dup at net >= 0.
+    //
+    // Genomic (`g.`/`m.`) base span; `None` for a member the gate cannot cheaply
+    // measure (a `c.`/`r.`/offset member, or a payload of unknown length) — those
+    // fall safe to running the re-partition.
+    fn ref_span(member: &HgvsVariant) -> Option<i64> {
+        let (start, end) = match member {
+            HV::Genome(g) => (
+                g.loc_edit.location.start.inner()?,
+                g.loc_edit.location.end.inner()?,
+            ),
+            HV::Mt(m) => (
+                m.loc_edit.location.start.inner()?,
+                m.loc_edit.location.end.inner()?,
+            ),
+            _ => return None,
+        };
+        if start.offset.unwrap_or(0) != 0 || end.offset.unwrap_or(0) != 0 {
+            return None;
+        }
+        Some(end.base as i64 - start.base as i64 + 1)
+    }
+    // Net length change (alternate length − reference length) contributed by one
+    // member; `None` if it cannot be measured.
+    fn member_net(member: &HgvsVariant) -> Option<i64> {
+        Some(match na_of(member)? {
+            NaEdit::Deletion { .. } => -ref_span(member)?,
+            NaEdit::Substitution { .. } => 0,
+            NaEdit::Insertion { sequence } => sequence.len()? as i64,
+            NaEdit::Duplication { .. } => ref_span(member)?,
+            NaEdit::Delins { sequence, .. } => sequence.len()? as i64 - ref_span(member)?,
+            NaEdit::Inversion { .. } => 0,
+            _ => return None,
+        })
+    }
+
+    // After step (2) every member is atomic or a delins. With no delins, the allele
+    // is only sub/del/ins/dup — a fixed point of the re-partition (measured: 0
+    // divergences over the designed small-separation corpus at separations 0..8,
+    // and over the dense-member corpus).
+    let has_delins = members
+        .iter()
+        .any(|m| matches!(na_of(m), Some(NaEdit::Delins { .. })));
+    if !has_delins {
+        return false;
+    }
+    // Sum the net length change; if any member is unmeasurable, fall safe.
+    let mut total = 0i64;
+    for m in members {
+        match member_net(m) {
+            Some(net) => total += net,
+            None => return true,
+        }
+    }
+    total < 0
+}
+
 #[cfg(debug_assertions)]
 thread_local! {
     static NA_EDIT_REFERENCES: std::cell::RefCell<Vec<NaEditReference>> =
@@ -2934,7 +3135,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             accession, position, reference, alternate, options,
         )?;
         if recommended_form {
-            self.normalize(&variant)
+            self.normalize_for_recommended_form(&variant)
         } else {
             Ok(variant)
         }
@@ -3062,7 +3263,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
 
             if !unsettled_5prime && !unsettled_3prime {
                 return if recommended_form {
-                    self.normalize(&derived.variant)
+                    self.normalize_for_recommended_form(&derived.variant)
                 } else {
                     Ok(derived.variant)
                 };
@@ -3179,7 +3380,74 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // whether a variant is normalized directly or through the projector.
         // The opt-in idempotency self-check lives in `normalize_core_checked`
         // (below), so it covers this method AND the projector.
-        Ok(self.normalize_core_checked(variant)?.0)
+        Ok(self
+            .normalize_core_checked(variant, RepartitionMode::Full)?
+            .0)
+    }
+
+    /// The `recommended_form = true` derivation surface
+    /// ([`Self::rederive`], [`Self::from_sequences`]) routes its final
+    /// normalization through this helper rather than through [`Self::normalize`],
+    /// so the #2161 Path 1 drop — skipping the second block partition
+    /// ([`crate::normalize::merge::canonicalize_from_sequence`], the ~38% DAG
+    /// rebuild) — is a single switch, [`REDERIVE_SKIPS_REPARTITION`], applied at
+    /// one seam. With the switch `false` this is exactly [`Self::normalize`].
+    ///
+    /// The drop is sound because the derivation surface already produces the
+    /// canonical partition on its own (the inversion / decompose / … convergence
+    /// increments), so `canonicalize_from_sequence` is a no-op on
+    /// [`Self::normalize_core`]'s output. The guard
+    /// (`tests/it/issue_2161_from_sequences_inversion_converge.rs`) pins that the
+    /// dropped path is byte-identical to the full path over the geometry and
+    /// real-reporter corpora.
+    fn normalize_for_recommended_form(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<HgvsVariant, FerroError> {
+        let mode = if REDERIVE_SKIPS_REPARTITION {
+            RepartitionMode::Gated
+        } else {
+            RepartitionMode::Full
+        };
+        Ok(self.normalize_core_checked(variant, mode)?.0)
+    }
+
+    /// [`Self::normalize`] with the second block partition unconditionally
+    /// skipped — the drop path, exposed for the #2161 convergence guard so it can
+    /// hold the dropped output against the full [`Self::normalize`] output for one
+    /// derived variant, independently of how the shipped `rederive` path is wired.
+    /// Test/`dev` only; never a shipped entry point.
+    #[cfg(any(test, feature = "dev"))]
+    pub fn normalize_skipping_repartition(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<HgvsVariant, FerroError> {
+        Ok(self
+            .normalize_core_checked(variant, RepartitionMode::Skip)?
+            .0)
+    }
+
+    /// [`Self::normalize`] on the shipped Drop's gated path — skip the second
+    /// block partition unless [`repartition_gate`] says it could move the output.
+    /// This is what `rederive(recommended_form = true)` runs; exposed so the
+    /// convergence guard can pin it byte-identical against the full path. Test/`dev`
+    /// only.
+    #[cfg(any(test, feature = "dev"))]
+    pub fn normalize_gated_repartition(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<HgvsVariant, FerroError> {
+        Ok(self
+            .normalize_core_checked(variant, RepartitionMode::Gated)?
+            .0)
+    }
+
+    /// Whether the shipped Drop's gate would run the full re-partition for this
+    /// (already `normalize_core`-shaped) variant — the fallback decision, exposed
+    /// so the #2161 measurement can report the true fallback rate. Test/`dev` only.
+    #[cfg(any(test, feature = "dev"))]
+    pub fn repartition_gate_fires(&self, variant: &HgvsVariant) -> bool {
+        repartition_gate(variant)
     }
 
     /// Opt-in idempotency self-check (issue #1157 follow-up): a normalizer must
@@ -3200,7 +3468,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// Compiled out entirely in release (`debug_assertions`), so production is
     /// untouched and zero-cost.
     #[cfg(debug_assertions)]
-    fn assert_idempotent(&self, variant: &HgvsVariant, normalized: &HgvsVariant) {
+    fn assert_idempotent(
+        &self,
+        variant: &HgvsVariant,
+        normalized: &HgvsVariant,
+        mode: RepartitionMode,
+    ) {
         if !idempotency_self_check_enabled() || IN_IDEMPOTENCY_CHECK.with(|f| f.get()) {
             return;
         }
@@ -3221,7 +3494,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let second = {
             IN_IDEMPOTENCY_CHECK.with(|f| f.set(true));
             let _guard = ReentrancyGuard;
-            self.normalize_core_checked(normalized)
+            self.normalize_core_checked(normalized, mode)
         };
 
         match second {
@@ -3911,6 +4184,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
     fn normalize_core_canonical(
         &self,
         variant: &HgvsVariant,
+        mode: RepartitionMode,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
         // The one place the per-leaf junction-exit provenance is collected. It is
         // created here rather than threaded in because this is the single seam
@@ -3919,8 +4193,41 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // nothing — essentially all of them — pays nothing for carrying it.
         let mut manufactured: Vec<ManufacturedJunctionExit> = Vec::new();
         let (normalized, warnings) = self.normalize_core(variant, &mut manufactured)?;
-        let (normalized, warnings) =
-            self.canonicalize_from_sequence(normalized, warnings, &mut manufactured)?;
+        // `canonicalize_from_sequence` is the second block partition — it rebuilds
+        // the `AlignmentDag` from the re-applied sequence and re-cuts the block,
+        // then re-runs `normalize_core` on the result. It is the ~38% of
+        // `rederive(recommended_form = true)` that #2161 Path 1 removes: once the
+        // `from_sequences` derivation surface produces the canonical partition on
+        // its own (the inversion/decompose/... convergence increments), this pass
+        // is a no-op on `normalize_core`'s output, so skipping it changes nothing
+        // and saves the rebuild. The `mode` decides:
+        //
+        // * `Full` always runs it — the pre-drop behavior, used by public
+        //   `normalize()` and the projector, untouched by the Drop.
+        // * `Skip` bypasses it entirely (exposed for the guard's raw-drop baseline).
+        // * `Gated` (the shipped `rederive` path) runs it only when
+        //   [`repartition_gate`] says `normalize_core`'s output could still move.
+        //
+        // The guard (`issue_2161_from_sequences_inversion_converge`) proves the
+        // gated and full paths are byte-identical over the geometry and
+        // dense-member corpora.
+        let (normalized, warnings) = match mode {
+            RepartitionMode::Skip => (normalized, warnings),
+            RepartitionMode::Full => {
+                self.canonicalize_from_sequence(normalized, warnings, &mut manufactured)?
+            }
+            // The shipped Drop: skip the re-partition unless the output carries a
+            // shape it could actually move (inv / net-deletion delins). The check
+            // reads only the AST, so the fast path pays one structural scan, not a
+            // DAG build.
+            RepartitionMode::Gated => {
+                if repartition_gate(&normalized) {
+                    self.canonicalize_from_sequence(normalized, warnings, &mut manufactured)?
+                } else {
+                    (normalized, warnings)
+                }
+            }
+        };
         let normalized = self.split_protein_separation(normalized);
         Ok((
             self.reparent_junction_exit(normalized, &manufactured),
@@ -4158,6 +4465,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
     pub(crate) fn normalize_core_checked(
         &self,
         variant: &HgvsVariant,
+        mode: RepartitionMode,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
         // `standards.md:39` (#1627): a member stating an alignment-only symbol
         // cannot be normalized, so this refuses BEFORE any work — and, unlike
@@ -4280,7 +4588,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // Call the canonical core directly (skipping the per-call
         // `detect_shuffle_infos` work `normalize_with_diagnostics` does) and wrap
         // with empty infos; the ladder below only inspects warnings.
-        let (normalized, warnings) = self.normalize_core_canonical(variant)?;
+        let (normalized, warnings) = self.normalize_core_canonical(variant, mode)?;
 
         // #1621: the far-side exon-junction clamp, applied ONCE to the finished
         // description. See [`exon_junction_anchor`] for the rule and its
@@ -4332,7 +4640,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // contributes nothing in every reachable case measured.
         let (normalized, warnings) = match self.exon_junction_far_side(&normalized) {
             Some(pulled) if pulled != *variant => {
-                let (clamped, more) = self.normalize_core_canonical(&pulled)?;
+                let (clamped, more) = self.normalize_core_canonical(&pulled, mode)?;
                 let mut merged = warnings;
                 merged.extend(more);
                 (clamped, merged)
@@ -4624,7 +4932,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             }
         }
 
-        self.assert_seam_oracles(variant, &result.result, &result.warnings);
+        self.assert_seam_oracles(variant, &result.result, &result.warnings, mode);
 
         // Provenance (#1235, `DNA/delins.md:79-84`). If the input described more
         // cis members than the normalized form does, two or more separately
@@ -4689,19 +4997,25 @@ impl<P: ReferenceProvider> Normalizer<P> {
         variant: &HgvsVariant,
         normalized: &HgvsVariant,
         warnings: &[NormalizationWarning],
+        mode: RepartitionMode,
     ) {
         #[cfg(debug_assertions)]
         self.assert_in_bounds(variant, normalized);
         #[cfg(debug_assertions)]
         self.assert_reparseable(variant, normalized);
+        // `assert_idempotent` re-normalizes `normalized` to check `norm(norm(x))
+        // == norm(x)`; it must re-run the SAME path that produced `normalized`, so
+        // the shipped `rederive` drop path (`RepartitionMode::Gated`, what
+        // `normalize_for_recommended_form` selects) is checked for idempotency of
+        // the drop form, not against the full re-partition.
         #[cfg(debug_assertions)]
-        self.assert_idempotent(variant, normalized);
+        self.assert_idempotent(variant, normalized, mode);
         #[cfg(debug_assertions)]
         self.assert_denoted_sequence(variant, normalized, warnings);
         // Release builds read none of the parameters once the four calls above
         // are compiled out.
         #[cfg(not(debug_assertions))]
-        let _ = (variant, normalized, warnings);
+        let _ = (variant, normalized, warnings, mode);
     }
 
     /// Normalize a variant with detailed warnings
@@ -4735,7 +5049,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // that method's own exit. Calling them here as well would re-run all three
         // on every diagnostics normalization — including `assert_idempotent`'s full
         // re-normalization, the most expensive of them.
-        let (result, warnings) = self.normalize_core_checked(variant)?;
+        let (result, warnings) = self.normalize_core_checked(variant, RepartitionMode::Full)?;
         let infos = detect_shuffle_infos(variant, &result, self.config.shuffle_direction);
         Ok(NormalizeResult::with_diagnostics(result, warnings, infos))
     }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -14540,7 +14540,7 @@ fn build_variant_at(
 /// by a codon-frame triplet drops (an unchanged base is not an edit) and
 /// always ends any in-flight run — the gap means the
 /// surrounding changes are no longer "consecutive".
-fn build_split_variants(
+pub(crate) fn build_split_variants(
     template: &HgvsVariant,
     subedits: Vec<DelinsSubedit>,
     hgvs_start: u64,

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -11,7 +11,7 @@ use crate::hgvs::variant::{
     is_frameshift, Accession, AllelePhase, AlleleVariant, CdsVariant, HgvsVariant, LocEdit,
     TxVariant,
 };
-use crate::normalize::{NormalizeConfig, Normalizer};
+use crate::normalize::{NormalizeConfig, Normalizer, RepartitionMode};
 use crate::project::accession::parse_accession;
 use crate::project::edit::transform_edit_for_strand;
 use crate::project::protein::{
@@ -1608,7 +1608,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             // transform that leaves the variant non-canonical, and even the
             // `project_normalized` caller cannot pre-normalize it in the `NC_`
             // frame because it does not know the placement (review M2).
-            let (normalized, warnings) = self.normalizer.normalize_core_checked(&deanchored)?;
+            let (normalized, warnings) = self
+                .normalizer
+                .normalize_core_checked(&deanchored, RepartitionMode::Full)?;
             let target = Self::reconcile_self_projection_target(&normalized, transcript_id);
             let mut result = self.project_variant_inner(&normalized, &target)?;
             result.normalization_warnings = warnings;
@@ -1642,7 +1644,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // on every call. Use `normalize_core_checked` (not `normalize`) to keep
         // the warnings it emits so they can ride out on the projection (#1018 C2)
         // while still honoring the same strict-mode rejections `normalize` applies.
-        let (normalized, warnings) = self.normalizer.normalize_core_checked(variant)?;
+        let (normalized, warnings) = self
+            .normalizer
+            .normalize_core_checked(variant, RepartitionMode::Full)?;
         // 2. Reconcile the requested target against any selector resolution that
         // normalization performed (#783). A legacy LOVD gene-model selector
         // `NG_(GENE_v001):c.` keeps the genomic ref as its accession, so a
@@ -1798,7 +1802,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         //    caller's input, so it is attached uniformly even on the parent path
         //    (whose per-transcript re-projection re-normalizes a different, coding
         //    form) rather than being replaced by that re-normalize's warnings.
-        let (normalized, warnings) = self.normalizer.normalize_core_checked(&variant)?;
+        let (normalized, warnings) = self
+            .normalizer
+            .normalize_core_checked(&variant, RepartitionMode::Full)?;
         let results = self.project_normalized_all_inner(&normalized)?;
         // 2. The plain (non-parent) path returns the genome-frame results directly.
         let Some(parent) = parent else {

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -115,7 +115,7 @@ use serde::Deserialize;
 
 use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
 use ferro_hgvs::reference::MockProvider;
-use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
+use ferro_hgvs::{parse_hgvs, FromSequencesOptions, NormalizeConfig, Normalizer, ShuffleDirection};
 
 use crate::common::cis_apply_oracle::apply_with;
 use crate::common::fixture_gen;
@@ -1034,5 +1034,111 @@ fn the_headline_matches_the_pin() {
         numbers[4],
         THREE_PRIME.classes - THREE_PRIME.converged,
         "the headline's non-converging count is not `classes - converged`"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #2161 Path 1 Drop measurement over the DESIGNED (small-separation) corpus
+// ---------------------------------------------------------------------------
+//
+// A distribution class the geometry corpus does not exercise: designed multi-member cis alleles whose
+// members sit CLOSE (this corpus enumerates separations 0,1,2,3,5,8), the
+// opposite of the 592 observed rows in `multi_member_cis_axis` (large
+// separations). It is where the second block partition actually does work, so
+// it is the honest place to measure how often the Drop
+// (`normalize_skipping_repartition` — skip `canonicalize_from_sequence`) changes
+// the answer. The geometry corpus in `issue_2161_from_sequences_inversion_converge`
+// answers the same question but is inversion-heavy; this is the broad designed
+// corpus.
+//
+// For each spelling, in both directions: settle the derivation
+// (`rederive(recommended_form=false)`), then hold the FULL final normalization
+// against the re-partition-skipping one — exactly the two `rederive(true)` paths,
+// pre-drop vs shipped. A divergence is a real output move the Drop would cause.
+// Broken down by the class's authored member separation, because the whole thesis
+// is that divergence is a function of proximity.
+#[test]
+#[ignore = "permanent diagnostic (#2161): PRINTS a distribution (the Drop's divergence \
+            and shipped-gate fallback over the designed small-separation cis corpus) and \
+            never asserts, so it stays ignored; the CI-enforcing correctness guards live \
+            in tests/it/issue_2161_from_sequences_inversion_converge.rs"]
+fn report_repartition_drop_over_designed_cis() {
+    let corpus = corpus();
+    // Tallies keyed by separation bucket -> (compared, raw-skip diverged).
+    let mut by_sep: std::collections::BTreeMap<usize, (usize, usize)> = Default::default();
+    let mut total_compared = 0usize;
+    let mut total_skip_diverged = 0usize;
+    // The SHIPPED gated path: how often it moved output (must be 0) and how often
+    // the gate fired (the fallback rate).
+    let mut total_gated_diverged = 0usize;
+    let mut total_gate_fired = 0usize;
+    let mut examples: Vec<String> = Vec::new();
+
+    for class in &corpus.classes {
+        let (provider, _reference) = reference_for(class);
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            let nz = Normalizer::with_config(
+                provider.clone(),
+                NormalizeConfig::default().with_direction(direction),
+            );
+            let options = FromSequencesOptions::default().with_direction(direction);
+            for spelling in &class.spellings {
+                let Ok(variant) = parse_hgvs(spelling) else {
+                    continue;
+                };
+                // Settle the derivation, then compare the final-normalize paths: the
+                // raw skip (upper-bound divergence) and the SHIPPED gated path.
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let derived = nz.rederive(&variant, &options, false).ok()?;
+                    let full = nz.normalize(&derived).ok()?.to_string();
+                    let skip_variant = nz.normalize_skipping_repartition(&derived).ok()?;
+                    let gate_fired = nz.repartition_gate_fires(&skip_variant);
+                    let gated = nz.normalize_gated_repartition(&derived).ok()?.to_string();
+                    Some((full, skip_variant.to_string(), gated, gate_fired))
+                }));
+                let Ok(Some((full, skip, gated, gate_fired))) = outcome else {
+                    continue;
+                };
+                let entry = by_sep.entry(class.separation).or_default();
+                entry.0 += 1;
+                total_compared += 1;
+                if gate_fired {
+                    total_gate_fired += 1;
+                }
+                if full != gated {
+                    total_gated_diverged += 1;
+                }
+                if full != skip {
+                    entry.1 += 1;
+                    total_skip_diverged += 1;
+                    if examples.len() < 30 {
+                        examples.push(format!(
+                            "DROPDIV\tsep={}\tmembers={}\t{:?}\tin={}\tfull={}\tskip={}",
+                            class.separation, class.members, direction, spelling, full, skip
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    for line in &examples {
+        eprintln!("{line}");
+    }
+    eprintln!("--- raw-skip divergence by authored member separation ---");
+    for (sep, (compared, diverged)) in &by_sep {
+        let pct = if *compared > 0 {
+            100.0 * *diverged as f64 / *compared as f64
+        } else {
+            0.0
+        };
+        eprintln!("SEPROW sep={sep}\tcompared={compared}\tskip_diverged={diverged}\t{pct:.3}%");
+    }
+    let denom = total_compared.max(1) as f64;
+    eprintln!(
+        "DESIGNEDDROP total_compared={total_compared} skip_diverged={total_skip_diverged} \
+         gated_diverged={total_gated_diverged} gate_fired={total_gate_fired} \
+         fallback_rate={:.3}%",
+        100.0 * total_gate_fired as f64 / denom,
     );
 }

--- a/tests/it/issue_2161_from_sequences_inversion_converge.rs
+++ b/tests/it/issue_2161_from_sequences_inversion_converge.rs
@@ -1,0 +1,459 @@
+//! #2161 Path 1 increment 1 — a geometry-varying convergence guard for
+//! flanked/interior inversion typing on the derivation surface.
+//!
+//! `derive_block_members` now runs its placement-and-coalesce chain through
+//! `place_direction_symmetrically` — both shuffle directions, member-minimal
+//! kept — with `coalesce_inversion_runs` as the final coalesce pass and a
+//! separation-zero re-merge after it, mirroring `canonicalize_from_sequence`. So
+//! `from_sequences` types a flanked inversion the way `normalize` does. Before,
+//! the derivation surface shifted a single direction and reached only the weak
+//! member-level `retype_inversions`, which reads a reverse-complement *member*
+//! but cannot see an inversion the partitioner split into `[del;dup]`:
+//! `NC_TEST.1:g.[14del;21_23inv]` derived as `g.[14del;21del;24dup]` while
+//! `normalize` retyped it to `g.[14del;21_23inv]`.
+//!
+//! The point of this file is the *corpus*, not the reproducer. The abandoned
+//! skip-renormalize PR (#2161) passed 8k real ClinVar cis alleles because they
+//! lack this geometry — "a corpus zero is a claim about the corpus". So this
+//! generator deliberately *varies* the axis that corpus could not: it places a
+//! genuine inversion span (revcomp ≠ identity) beside sibling `del`/`sub`
+//! members at separations 0–8, on both the 5' and 3' side, in alleles of 2–4
+//! members, over four structured contigs (a general contig, an inverted-repeat
+//! contig, a tandem tract, and a GC palindrome), in both shuffle directions.
+//!
+//! # The properties this file pins
+//!
+//! `rederive(recommended_form = false)` (the derivation alone) and
+//! `rederive(recommended_form = true)` (derivation followed by `normalize`)
+//! should agree once the derivation produces the canonical form — that agreement
+//! is the redundancy #2161 is about, checked here without the second partition
+//! ever being removed. Increment 1 closes the flanked-inversion class of that
+//! gap, NOT all of it (sibling-shift and over-merge convergence remain for later
+//! increments), so this file pins two things, not full convergence:
+//!
+//! - [`from_sequences_types_a_flanked_inversion_like_normalize`] — exact
+//!   convergence on a curated set of clean flanked inversions (the fix itself).
+//! - [`the_inversion_geometry_corpus_converges_without_regression`] — the corpus
+//!   is fully built (a fixed count) and the number of convergent variants holds a
+//!   floor: an inversion regression lowers it, a later increment only raises it.
+//!
+//! The guard is proven able to fail: on the pre-fix tree every curated row above
+//! diverges (the `NC_TEST.1:g.[14del;21_23inv]` reproducer is one of them), and
+//! the corpus carried 26,481 divergences against the shipped 9,170.
+
+use ferro_hgvs::{parse_hgvs, FromSequencesOptions, JsonProvider, Normalizer, ShuffleDirection};
+use std::io::Write;
+
+/// A genome-capable provider over one contig named `NC_TEST.1` carrying `seq`.
+/// Genomic on purpose: `from_sequences` emits `g.` and refuses a
+/// transcript/protein accession.
+fn provider(seq: &str) -> JsonProvider {
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { "NC_TEST.1": seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+/// `rederive` over a parsed description, or `None` if the description does not
+/// parse or the surface declines it (overlapping members, an unbuildable
+/// window). A decline is *counted* by the caller, never silently treated as a
+/// pass.
+fn rederive(
+    nz: &Normalizer<JsonProvider>,
+    desc: &str,
+    direction: ShuffleDirection,
+    recommended_form: bool,
+) -> Option<String> {
+    let variant = parse_hgvs(desc).ok()?;
+    let options = FromSequencesOptions::default().with_direction(direction);
+    Some(
+        nz.rederive(&variant, &options, recommended_form)
+            .ok()?
+            .to_string(),
+    )
+}
+
+/// The contigs. Each carries a structure that makes an interior inversion
+/// non-trivial to type, and enough flank (≥ 12 bases either side of the region
+/// the generator uses) that the derivation window is never starved.
+fn contigs() -> Vec<(&'static str, &'static str)> {
+    vec![
+        // General mixed contig — the reproducer's own.
+        (
+            "general",
+            "GCTAGCATGCATGCGTACAGTCGATCGATCAAAAAATGCAGTCAGTGGATCCGATTACGATCAGCT",
+        ),
+        // Inverted repeat: `TCGATCGA` near the start and its reverse complement
+        // downstream, so an inversion's revcomp can coincide with real bases
+        // elsewhere — the shape that makes a fragmented `[del;dup]` look
+        // plausible.
+        (
+            "inverted_repeat",
+            "AACCGGTTAATCGATCGATTGCACGTACGTGCAATCGATCGATTAACCGGTTAACCGGTTAACCGG",
+        ),
+        // Tandem tract: an `ATAT…` run in the middle where an interior inversion
+        // sits inside a repeat and could shift.
+        (
+            "tandem",
+            "GGCCAATTGGCCATATATATATATATGGCCAATTGGCCAATTGGCCAATTGGCCAATTGGCCAATT",
+        ),
+        // GC palindrome region `GGGCGCGCCC` embedded in AT flanks.
+        (
+            "gc_palindrome",
+            "ATATATATATGGGCGCGCCCATATATATATGGGCGCGCCCATATATATATGGGCGCGCCCATATAT",
+        ),
+    ]
+}
+
+/// A single generated member, as an HGVS fragment plus the 1-based reference
+/// span it occupies (`[start, end]`, inclusive) so the caller can reject
+/// overlaps before building a string that would not parse or would be declined.
+struct Member {
+    text: String,
+    start: u64,
+    end: u64,
+}
+
+/// A `del` of one base at 1-based `pos`.
+fn del(pos: u64) -> Member {
+    Member {
+        text: format!("{pos}del"),
+        start: pos,
+        end: pos,
+    }
+}
+
+/// A substitution at 1-based `pos`, choosing an alt base different from the
+/// reference. `None` if the reference base is not one of A/C/G/T.
+fn sub(seq: &[u8], pos: u64) -> Option<Member> {
+    let refb = *seq.get((pos - 1) as usize)?;
+    let alt = match refb {
+        b'A' => b'C',
+        b'C' => b'G',
+        b'G' => b'T',
+        b'T' => b'A',
+        _ => return None,
+    };
+    Some(Member {
+        text: format!("{pos}{}>{}", refb as char, alt as char),
+        start: pos,
+        end: pos,
+    })
+}
+
+/// An inversion of the 1-based span `[a, b]`, but only if its reverse complement
+/// actually differs from the span (a palindromic span is unchanged and is not an
+/// inversion at all).
+fn inv(seq: &[u8], a: u64, b: u64) -> Option<Member> {
+    let span = &seq[(a - 1) as usize..b as usize];
+    let rc: Vec<u8> = span
+        .iter()
+        .rev()
+        .map(|&x| match x {
+            b'A' => b'T',
+            b'T' => b'A',
+            b'C' => b'G',
+            b'G' => b'C',
+            other => other,
+        })
+        .collect();
+    if rc == span {
+        return None;
+    }
+    Some(Member {
+        text: format!("{a}_{b}inv"),
+        start: a,
+        end: b,
+    })
+}
+
+/// Assemble members into a cis description if they are strictly ordered and
+/// non-overlapping; `None` otherwise. Members must arrive sorted by start.
+fn assemble(members: &[Member]) -> Option<String> {
+    for pair in members.windows(2) {
+        if pair[0].end >= pair[1].start {
+            return None;
+        }
+    }
+    let body: Vec<&str> = members.iter().map(|m| m.text.as_str()).collect();
+    Some(if body.len() == 1 {
+        format!("NC_TEST.1:g.{}", body[0])
+    } else {
+        format!("NC_TEST.1:g.[{}]", body.join(";"))
+    })
+}
+
+/// One outcome of putting a generated variant through both surfaces.
+struct Outcome {
+    input: String,
+    direction: ShuffleDirection,
+    /// `Some((derive, recommend))` when both surfaces produced a string.
+    compared: Option<(String, String)>,
+}
+
+/// Generate the whole corpus and run every variant through both surfaces.
+///
+/// Every generated variant is a flanked inversion — a genuine `inv` span beside
+/// at least one `del`/`sub` sibling — so the count of outcomes is the geometry
+/// this file guards, floored below.
+fn run_corpus() -> Vec<Outcome> {
+    let mut outcomes = Vec::new();
+
+    for (_name, seq) in contigs() {
+        let bytes = seq.as_bytes();
+        let len = seq.len() as u64;
+        let nz = Normalizer::new(provider(seq));
+
+        // Interior inversion spans, kept ≥ 12 bases from either end.
+        for a in 13..=(len - 12) {
+            for l in 2..=6u64 {
+                let b = a + l - 1;
+                if b > len - 12 {
+                    continue;
+                }
+                let Some(inv_member) = inv(bytes, a, b) else {
+                    continue;
+                };
+
+                // Sibling positions on the 5' and 3' side, separations 0..=8.
+                for sep in 0..=8u64 {
+                    // 5' sibling immediately before `a - sep` (separation = the
+                    // count of unchanged bases between the sibling and the inv).
+                    let five = a.checked_sub(sep + 1).filter(|&p| p >= 8);
+                    // 3' sibling after the inv.
+                    let three = (b + sep < len - 8).then_some(b + sep + 1);
+
+                    for &(use5, use3, use_sub) in &[
+                        (true, false, false),
+                        (false, true, false),
+                        (true, true, false),
+                        (true, false, true),
+                        (false, true, true),
+                        (true, true, true),
+                    ] {
+                        // A sibling at `pos`, on whichever side — a `sub` when
+                        // `use_sub` (so substitution siblings are exercised on
+                        // BOTH the 5' and 3' side, not only the 5'), else a `del`.
+                        // `None` only when a `sub`'s reference base is not A/C/G/T,
+                        // which never happens on these contigs.
+                        let sibling = |pos: u64| {
+                            if use_sub {
+                                sub(bytes, pos)
+                            } else {
+                                Some(del(pos))
+                            }
+                        };
+
+                        let mut members = Vec::new();
+                        if use5 {
+                            if let Some(p) = five {
+                                match sibling(p) {
+                                    Some(m) => members.push(m),
+                                    None => continue,
+                                }
+                            }
+                        }
+                        // The inversion always participates.
+                        members.push(Member {
+                            text: inv_member.text.clone(),
+                            start: inv_member.start,
+                            end: inv_member.end,
+                        });
+                        if use3 {
+                            if let Some(p) = three {
+                                match sibling(p) {
+                                    Some(m) => members.push(m),
+                                    None => continue,
+                                }
+                            }
+                        }
+                        members.sort_by_key(|m| m.start);
+                        if members.len() < 2 {
+                            continue;
+                        }
+                        let Some(input) = assemble(&members) else {
+                            continue;
+                        };
+
+                        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
+                        {
+                            let derive = rederive(&nz, &input, direction, false);
+                            let recommend = rederive(&nz, &input, direction, true);
+                            outcomes.push(Outcome {
+                                input: input.clone(),
+                                direction,
+                                compared: derive.zip(recommend),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    outcomes
+}
+
+/// The fix, stated as pins: a flanked inversion the derivation surface used to
+/// fragment now types as an `inv`, and `rederive(false)` (derive) agrees with
+/// `rederive(true)` (derive + `normalize`) on it — in BOTH shuffle directions,
+/// across three contig structures, for a deletion 5' of the inversion, a
+/// deletion 3' of it, and a multi-position case.
+///
+/// Each row asserts CONVERGENCE (`derive == recommend`) rather than one frozen
+/// string, because the property increment 1 establishes is that the two
+/// surfaces agree on the inversion — a later shift-reconciliation increment may
+/// move both together and must not fail this. The headline row additionally
+/// pins the exact canonical string, since it is the documented reproducer.
+#[test]
+fn from_sequences_types_a_flanked_inversion_like_normalize() {
+    let general = "GCTAGCATGCATGCGTACAGTCGATCGATCAAAAAATGCAGTCAGTGGATCCGATTACGATCAGCT";
+    let inv_rep = "AACCGGTTAATCGATCGATTGCACGTACGTGCAATCGATCGATTAACCGGTTAACCGGTTAACCGG";
+    let tandem = "GGCCAATTGGCCATATATATATATATGGCCAATTGGCCAATTGGCCAATTGGCCAATTGGCCAATT";
+
+    // (contig, input, the `inv` span every convergent form must carry).
+    let rows = [
+        (general, "NC_TEST.1:g.[14del;21_23inv]", "21_23inv"),
+        (general, "NC_TEST.1:g.[16_18inv;24del]", "16_18inv"),
+        (inv_rep, "NC_TEST.1:g.[16del;24_28inv]", "24_28inv"),
+        (inv_rep, "NC_TEST.1:g.[20_24inv;30del]", "20_24inv"),
+        (tandem, "NC_TEST.1:g.[15del;20_24inv]", "20_24inv"),
+    ];
+
+    for (seq, input, inv_span) in rows {
+        let nz = Normalizer::new(provider(seq));
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            let derive =
+                rederive(&nz, input, direction, false).expect("derivation must not decline");
+            let recommend =
+                rederive(&nz, input, direction, true).expect("recommend must not decline");
+            assert_eq!(
+                derive, recommend,
+                "{input} ({direction:?}): derive must converge with normalize",
+            );
+            assert!(
+                derive.contains(inv_span),
+                "{input} ({direction:?}): the inversion {inv_span} must be typed, got {derive}",
+            );
+        }
+    }
+
+    // The documented headline reproducer, exact.
+    let nz = Normalizer::new(provider(general));
+    assert_eq!(
+        rederive(
+            &nz,
+            "NC_TEST.1:g.[14del;21_23inv]",
+            ShuffleDirection::ThreePrime,
+            false,
+        )
+        .unwrap(),
+        "NC_TEST.1:g.[14del;21_23inv]",
+    );
+}
+
+/// The geometry corpus, as a regression floor. Increment 1 (the flanked/interior
+/// inversion port) took the pre-port tree's divergences on this corpus from
+/// **26,481** down to **9,170** and opened **none** (measured baseline-vs-fix by
+/// `input`+`direction`: 0 rows that converged before now diverge); what remains is
+/// the shift and over-merge convergence that increments 2–3 address. So this
+/// asserts floors, not full convergence:
+///
+/// - the corpus is fully built (a fixed, deterministic count — a drop means the
+///   generator stopped emitting the geometry, the vacuity this file guards
+///   against);
+/// - `normalize` actually types an inversion on a large share of the corpus (the
+///   non-vacuity that matters: a generator that stopped producing genuine flanked
+///   inversions — every span palindromic, say — would still build 64,352 rows but
+///   type almost no `inv`, and the convergence floor alone could not tell);
+/// - the number of variants on which `derive` converges with `normalize` does not
+///   fall below what the port achieved. A future inversion regression lowers it;
+///   an increment that closes the remaining shift/merge gaps only raises it, so
+///   the floor is `>=`, not `==`.
+///
+/// Measured on the port: 64,352 comparisons, 0 skipped, 55,182 convergent, 40,900
+/// carrying an `inv` in the `normalize` output. The remaining 9,170 divergences
+/// are, by construction of the corpus, sibling-shift placement (the inversion
+/// itself typed identically), pre-existing equal-length over-merge that loses an
+/// inversion, and multi-inversion direction ambiguity — none of them the
+/// `[del;dup]` fragmentation this increment fixes.
+#[test]
+fn the_inversion_geometry_corpus_converges_without_regression() {
+    let outcomes = run_corpus();
+    let compared = outcomes.iter().filter(|o| o.compared.is_some()).count();
+    let converged = outcomes
+        .iter()
+        .filter(|o| o.compared.as_ref().is_some_and(|(d, r)| d == r))
+        .count();
+    let recommend_has_inv = outcomes
+        .iter()
+        .filter(|o| o.compared.as_ref().is_some_and(|(_, r)| r.contains("inv")))
+        .count();
+
+    // The corpus is hermetic and deterministic, so this is exact: every generated
+    // variant put both surfaces through cleanly (0 skipped on the port).
+    assert_eq!(
+        compared, 64_352,
+        "the geometry corpus changed size — the generator is no longer emitting \
+         what this guard measures",
+    );
+    // Non-vacuity: the geometry really does produce inversions `normalize` types,
+    // so the convergence floor below is a claim about flanked inversions and not
+    // about a corpus that degenerated to palindromes or lone indels.
+    assert!(
+        recommend_has_inv >= 40_900,
+        "the corpus stopped producing genuine inversions: only {recommend_has_inv} \
+         of {compared} carry an inv in the normalize output, floor is 40,900",
+    );
+    assert!(
+        converged >= 55_182,
+        "convergence regressed: {converged} of {compared} converge, floor is 55,182",
+    );
+}
+
+/// Report mode: print the divergence landscape. Not an assertion — run with
+/// `--no-capture` while developing the corpus or a later increment, then read the
+/// floors off it.
+#[test]
+#[ignore = "permanent diagnostic (#2161): prints the divergence landscape used to set \
+            the floor in the_inversion_geometry_corpus_converges_without_regression; it \
+            never asserts, so it stays ignored"]
+fn report_inversion_convergence_landscape() {
+    let outcomes = run_corpus();
+    let compared = outcomes.iter().filter(|o| o.compared.is_some()).count();
+    let converged = outcomes
+        .iter()
+        .filter(|o| o.compared.as_ref().is_some_and(|(d, r)| d == r))
+        .count();
+    let recommend_has_inv = outcomes
+        .iter()
+        .filter(|o| o.compared.as_ref().is_some_and(|(_, r)| r.contains("inv")))
+        .count();
+    let skipped = outcomes.len() - compared;
+    let mut diverged = 0usize;
+    for o in &outcomes {
+        if let Some((d, r)) = &o.compared {
+            if d != r {
+                diverged += 1;
+                eprintln!(
+                    "DDET\t{}\t{:?}\tderive={}\trecommend={}",
+                    o.input, o.direction, d, r
+                );
+            }
+        }
+    }
+    eprintln!(
+        "SUMMARY total={} compared={} skipped={} diverged={} converged={} recommend_has_inv={}",
+        outcomes.len(),
+        compared,
+        skipped,
+        diverged,
+        converged,
+        recommend_has_inv,
+    );
+}

--- a/tests/it/issue_2161_from_sequences_inversion_converge.rs
+++ b/tests/it/issue_2161_from_sequences_inversion_converge.rs
@@ -27,15 +27,18 @@
 //! `rederive(recommended_form = true)` (derivation followed by `normalize`)
 //! should agree once the derivation produces the canonical form — that agreement
 //! is the redundancy #2161 is about, checked here without the second partition
-//! ever being removed. Increment 1 closes the flanked-inversion class of that
-//! gap, NOT all of it (sibling-shift and over-merge convergence remain for later
-//! increments), so this file pins two things, not full convergence:
+//! ever being removed. This file pins the increments that close the
+//! inversion-bearing classes of that gap, not full convergence (repeat notation
+//! remains):
 //!
-//! - [`from_sequences_types_a_flanked_inversion_like_normalize`] — exact
-//!   convergence on a curated set of clean flanked inversions (the fix itself).
+//! - [`from_sequences_types_a_flanked_inversion_like_normalize`] — the flanked
+//!   `[del;dup]`-fragmentation port (increment 1).
+//! - [`from_sequences_decomposes_a_merged_sub_flanked_inversion`] — the over-merge
+//!   follow-up: a merged equal-length `sub`+`inv` `delins` split back to its
+//!   canonical members (`split_canonical_delins`).
 //! - [`the_inversion_geometry_corpus_converges_without_regression`] — the corpus
 //!   is fully built (a fixed count) and the number of convergent variants holds a
-//!   floor: an inversion regression lowers it, a later increment only raises it.
+//!   floor: a regression lowers it, a later increment only raises it.
 //!
 //! The guard is proven able to fail: on the pre-fix tree every curated row above
 //! diverges (the `NC_TEST.1:g.[14del;21_23inv]` reproducer is one of them), and
@@ -357,10 +360,63 @@ fn from_sequences_types_a_flanked_inversion_like_normalize() {
     );
 }
 
-/// The geometry corpus, as a regression floor. Increment 1 (the flanked/interior
-/// inversion port) took the pre-port tree's divergences on this corpus from
-/// **26,481** down to **9,170** and opened **none** (measured baseline-vs-fix by
-/// `input`+`direction`: 0 rows that converged before now diverge); what remains is
+/// The over-merge increment, stated as pins: an equal-length `sub`+`inv` block
+/// the place chain merged into ONE spanning `delins` is now split back into its
+/// canonical `[sub; inv]` members by `split_canonical_delins`, the way
+/// `normalize`'s `apply_canonical_split` does. Before this, `from_sequences`
+/// emitted `g.11_15delinsCTCGC` where `normalize` emitted `g.[11A>C;13_15inv]` —
+/// the largest ThreePrime divergence class after increment 1.
+///
+/// These converge in ThreePrime, which is the direction the drop of the second
+/// partition depends on; the FivePrime placement of the surrounding subs is a
+/// separate (direction-semantics) question, so unlike the flanked-inversion pins
+/// above these assert ThreePrime convergence only.
+#[test]
+fn from_sequences_decomposes_a_merged_sub_flanked_inversion() {
+    let general = "GCTAGCATGCATGCGTACAGTCGATCGATCAAAAAATGCAGTCAGTGGATCCGATTACGATCAGCT";
+
+    // sub 5' of the inv, sub 3' of it, a longer inv, and a sub/inv/sub triple —
+    // every one a net-substitution block `decompose_delins` splits.
+    let rows = [
+        "NC_TEST.1:g.[11A>C;13_15inv]",
+        "NC_TEST.1:g.[13_15inv;17A>C]",
+        "NC_TEST.1:g.[11A>C;13_17inv]",
+        "NC_TEST.1:g.[11A>C;13_15inv;17A>C]",
+    ];
+    let nz = Normalizer::new(provider(general));
+    for input in rows {
+        let derive = rederive(&nz, input, ShuffleDirection::ThreePrime, false)
+            .expect("derivation must not decline");
+        let recommend = rederive(&nz, input, ShuffleDirection::ThreePrime, true)
+            .expect("recommend must not decline");
+        assert_eq!(
+            derive, recommend,
+            "{input}: derive must decompose the merged delins to match normalize",
+        );
+        assert!(
+            derive.contains("inv") && derive.contains('>'),
+            "{input}: the split must carry both the substitution and the inversion, got {derive}",
+        );
+    }
+
+    // Exact, on the isolated block: the mechanism, not just convergence.
+    assert_eq!(
+        rederive(
+            &nz,
+            "NC_TEST.1:g.[11A>C;13_15inv]",
+            ShuffleDirection::ThreePrime,
+            false,
+        )
+        .unwrap(),
+        "NC_TEST.1:g.[11A>C;13_15inv]",
+    );
+}
+
+/// The geometry corpus, as a regression floor. Increments 1 (the flanked/interior
+/// inversion port) and its over-merge follow-up (the `decompose_delins` split)
+/// took the pre-port tree's divergences on this corpus from **26,481** down to
+/// **8,100** and opened **none** (measured baseline-vs-fix by `input`+`direction`:
+/// 0 rows that converged before now diverge); what remains is
 /// the shift and over-merge convergence that increments 2–3 address. So this
 /// asserts floors, not full convergence:
 ///
@@ -372,16 +428,18 @@ fn from_sequences_types_a_flanked_inversion_like_normalize() {
 ///   inversions — every span palindromic, say — would still build 64,352 rows but
 ///   type almost no `inv`, and the convergence floor alone could not tell);
 /// - the number of variants on which `derive` converges with `normalize` does not
-///   fall below what the port achieved. A future inversion regression lowers it;
-///   an increment that closes the remaining shift/merge gaps only raises it, so
-///   the floor is `>=`, not `==`.
+///   fall below what the ports achieved. A future regression lowers it; a later
+///   increment that closes the remaining gaps only raises it, so the floor is
+///   `>=`, not `==`.
 ///
-/// Measured on the port: 64,352 comparisons, 0 skipped, 55,182 convergent, 40,900
-/// carrying an `inv` in the `normalize` output. The remaining 9,170 divergences
-/// are, by construction of the corpus, sibling-shift placement (the inversion
-/// itself typed identically), pre-existing equal-length over-merge that loses an
-/// inversion, and multi-inversion direction ambiguity — none of them the
-/// `[del;dup]` fragmentation this increment fixes.
+/// Measured after the over-merge increment: 64,352 comparisons, 0 skipped, 56,252
+/// convergent, 40,900 carrying an `inv` in the `normalize` output. Of the
+/// remaining 8,100 divergences, all but **252** are FivePrime — where `normalize`
+/// emits its direction-invariant 3'-canonical form and the derivation respects
+/// the caller's direction, which is direction semantics, not a convergence gap.
+/// The 252 ThreePrime residue is entirely repeat notation (`X[n]`), the next
+/// increment; on ThreePrime — the direction the second-partition drop depends on —
+/// inversion typing and over-merge are both closed.
 #[test]
 fn the_inversion_geometry_corpus_converges_without_regression() {
     let outcomes = run_corpus();
@@ -411,8 +469,8 @@ fn the_inversion_geometry_corpus_converges_without_regression() {
          of {compared} carry an inv in the normalize output, floor is 40,900",
     );
     assert!(
-        converged >= 55_182,
-        "convergence regressed: {converged} of {compared} converge, floor is 55,182",
+        converged >= 56_252,
+        "convergence regressed: {converged} of {compared} converge, floor is 56,252",
     );
 }
 

--- a/tests/it/issue_2161_from_sequences_inversion_converge.rs
+++ b/tests/it/issue_2161_from_sequences_inversion_converge.rs
@@ -41,10 +41,35 @@
 //!   floor: a regression lowers it, a later increment only raises it.
 //!
 //! The guard is proven able to fail: on the pre-fix tree every curated row above
-//! diverges (the `NC_TEST.1:g.[14del;21_23inv]` reproducer is one of them), and
-//! the corpus carried 26,481 divergences against the shipped 9,170.
+//! diverges (the `NC_TEST.1:g.[14del;21_23inv]` reproducer is one of them); the
+//! shipped fix converges at least 60,731 of the 62,824 corpus rows (the floor
+//! `the_inversion_geometry_corpus_converges_without_regression` asserts; 60,904
+//! on the current tree).
+//!
+//! # The Drop and its gate (the #2161 Path 1 payoff)
+//!
+//! Once the derivation surface converges, the second block partition inside the
+//! final `normalize()` is redundant, so `rederive(recommended_form = true)` skips
+//! it unless a cheap AST-only gate (`repartition_gate`) says it could change the
+//! output. This file guards that the SHIPPED gated path is byte-identical to the
+//! full pre-drop path:
+//!
+//! - [`the_gated_drop_changes_no_output`] — over the inversion-geometry corpus:
+//!   the raw unconditional skip diverges on 72 shapes — the current measured
+//!   count, which the test asserts as a `>= 72` regression floor (not slack
+//!   below the measurement); the gate closes every one.
+//! - [`the_gate_is_correct_on_dense_member_alleles`] +
+//!   [`report_gate_fallback_on_dense_member_alleles`] — correctness and the gate's
+//!   fallback rate over a densely-spaced multi-member cis corpus (the distribution
+//!   the geometry corpus does not exercise), built from the public issue
+//!   reproducers' member patterns.
+//! - [`a_lone_delins_is_a_fixed_point_of_the_repartition`] +
+//!   [`a_lone_inv_is_a_fixed_point_of_the_repartition`] — the measured fixed-point
+//!   probes that justify the gate skipping every lone member.
 
-use ferro_hgvs::{parse_hgvs, FromSequencesOptions, JsonProvider, Normalizer, ShuffleDirection};
+use ferro_hgvs::{
+    parse_hgvs, FromSequencesOptions, JsonProvider, NormalizeConfig, Normalizer, ShuffleDirection,
+};
 use std::io::Write;
 
 /// A genome-capable provider over one contig named `NC_TEST.1` carrying `seq`.
@@ -197,6 +222,24 @@ struct Outcome {
     direction: ShuffleDirection,
     /// `Some((derive, recommend))` when both surfaces produced a string.
     compared: Option<(String, String)>,
+    /// The #2161 Path 1 measurement: `Some((full, skip, gated, gate_fired))` for
+    /// the derived form put through three normalization paths, plus the actual
+    /// gate decision —
+    /// - `full`: FULL normalization, second block partition included (the pre-drop
+    ///   `rederive(true)`);
+    /// - `skip`: second partition unconditionally SKIPPED
+    ///   (`normalize_skipping_repartition`) — shows where the raw Drop diverges;
+    /// - `gated`: the SHIPPED path (`normalize_gated_repartition`) — skip unless
+    ///   the cheap `repartition_gate` fires, in which case run the full
+    ///   re-partition;
+    /// - `gate_fired`: whether `repartition_gate` ran the re-partition (the true
+    ///   fallback signal, read from `repartition_gate_fires`).
+    ///
+    /// `full != skip` is a raw-Drop divergence (the residual the gate exists for);
+    /// the gate is correct iff `full == gated` for **every** outcome. `None` when
+    /// the derivation declined or its output did not re-parse — *counted*, never
+    /// silently passed.
+    drop_compared: Option<(String, String, String, bool)>,
 }
 
 /// Generate the whole corpus and run every variant through both surfaces.
@@ -210,7 +253,18 @@ fn run_corpus() -> Vec<Outcome> {
     for (_name, seq) in contigs() {
         let bytes = seq.as_bytes();
         let len = seq.len() as u64;
-        let nz = Normalizer::new(provider(seq));
+        // Two normalizers, one per shuffle direction, so the gate comparison in
+        // the direction loop below normalizes in the SAME direction the
+        // derivation used — otherwise every `nz.normalize*` call runs 3' and the
+        // 5' half of the gate is never exercised.
+        let nz_3p = Normalizer::with_config(
+            provider(seq),
+            NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+        );
+        let nz_5p = Normalizer::with_config(
+            provider(seq),
+            NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+        );
 
         // Interior inversion spans, kept ≥ 12 bases from either end.
         for a in 13..=(len - 12) {
@@ -254,11 +308,14 @@ fn run_corpus() -> Vec<Outcome> {
 
                         let mut members = Vec::new();
                         if use5 {
-                            if let Some(p) = five {
-                                match sibling(p) {
-                                    Some(m) => members.push(m),
-                                    None => continue,
-                                }
+                            // A requested 5' sibling with no valid position must
+                            // skip the WHOLE combination — building it without the
+                            // sibling silently relabels it as a different shape and
+                            // double-counts it in the landscape census.
+                            let Some(p) = five else { continue };
+                            match sibling(p) {
+                                Some(m) => members.push(m),
+                                None => continue,
                             }
                         }
                         // The inversion always participates.
@@ -268,11 +325,10 @@ fn run_corpus() -> Vec<Outcome> {
                             end: inv_member.end,
                         });
                         if use3 {
-                            if let Some(p) = three {
-                                match sibling(p) {
-                                    Some(m) => members.push(m),
-                                    None => continue,
-                                }
+                            let Some(p) = three else { continue };
+                            match sibling(p) {
+                                Some(m) => members.push(m),
+                                None => continue,
                             }
                         }
                         members.sort_by_key(|m| m.start);
@@ -285,12 +341,39 @@ fn run_corpus() -> Vec<Outcome> {
 
                         for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
                         {
-                            let derive = rederive(&nz, &input, direction, false);
-                            let recommend = rederive(&nz, &input, direction, true);
+                            let nz = if matches!(direction, ShuffleDirection::ThreePrime) {
+                                &nz_3p
+                            } else {
+                                &nz_5p
+                            };
+                            let derive = rederive(nz, &input, direction, false);
+                            let recommend = rederive(nz, &input, direction, true);
+                            // The drop-relevant comparison: put the SETTLED
+                            // derivation (`derive`) through the full normalization
+                            // and through the re-partition-skipping one, and hold
+                            // the two against each other. This is the property the
+                            // drop actually needs — that the second block partition
+                            // is a no-op on `normalize_core`'s output — as opposed
+                            // to `compared`, which asks the stricter, not-required
+                            // question of whether the derivation already equals the
+                            // normalized form.
+                            let drop_compared = derive.as_ref().and_then(|d| {
+                                let variant = parse_hgvs(d).ok()?;
+                                let full = nz.normalize(&variant).ok()?.to_string();
+                                // `normalize_core`'s output — what the gate inspects.
+                                let skip_variant =
+                                    nz.normalize_skipping_repartition(&variant).ok()?;
+                                let gate_fired = nz.repartition_gate_fires(&skip_variant);
+                                // The SHIPPED path: skip unless the gate fires.
+                                let gated =
+                                    nz.normalize_gated_repartition(&variant).ok()?.to_string();
+                                Some((full, skip_variant.to_string(), gated, gate_fired))
+                            });
                             outcomes.push(Outcome {
                                 input: input.clone(),
                                 direction,
                                 compared: derive.zip(recommend),
+                                drop_compared,
                             });
                         }
                     }
@@ -300,6 +383,18 @@ fn run_corpus() -> Vec<Outcome> {
     }
 
     outcomes
+}
+
+/// The geometry corpus is hermetic and deterministic, so its size is exact —
+/// both non-vacuity guards below assert against this single source of truth.
+const GEOMETRY_CORPUS_SIZE: usize = 62_824;
+
+/// The geometry corpus, built once per test process and shared by the guards
+/// that read it. `run_corpus` is deterministic and ~45s to build, so consumers
+/// borrow this process-cached slice rather than each rebuilding it.
+fn geometry_corpus() -> &'static [Outcome] {
+    static CORPUS: std::sync::OnceLock<Vec<Outcome>> = std::sync::OnceLock::new();
+    CORPUS.get_or_init(run_corpus)
 }
 
 /// The fix, stated as pins: a flanked inversion the derivation surface used to
@@ -329,8 +424,15 @@ fn from_sequences_types_a_flanked_inversion_like_normalize() {
     ];
 
     for (seq, input, inv_span) in rows {
-        let nz = Normalizer::new(provider(seq));
         for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            // Direction-matched normalizer, as in `run_corpus`: the final
+            // normalize in `rederive(true)` must shuffle the SAME direction the
+            // derivation used, or the FivePrime iteration would put a 5'-derived
+            // form through a 3' normalizer and stop testing the intended path.
+            let nz = Normalizer::with_config(
+                provider(seq),
+                NormalizeConfig::default().with_direction(direction),
+            );
             let derive =
                 rederive(&nz, input, direction, false).expect("derivation must not decline");
             let recommend =
@@ -358,6 +460,43 @@ fn from_sequences_types_a_flanked_inversion_like_normalize() {
         .unwrap(),
         "NC_TEST.1:g.[14del;21_23inv]",
     );
+}
+
+/// `derive_block_members` runs a final `shrink_pieces_to_differences` AFTER
+/// `coalesce_inversion_runs` (to re-close the separation-zero splits that pass
+/// opens on a flush-adjacent net-deletion `delins`). A concern was raised that
+/// this final shrink could instead damage a *genuine* flanked inversion;
+/// measured, it does not. This pins the property with the shape that stresses it
+/// most — an inversion sandwiched between two deletions, so the re-close runs at
+/// BOTH of its boundaries: the inversion still survives the derivation as an
+/// `inv`, and `rederive(false)` (derive) converges with `rederive(true)`
+/// (derive + `normalize`) in both shuffle directions.
+#[test]
+fn a_flanked_inversion_survives_the_final_shrink() {
+    // pos 14=C and 24=A are the flanking deletions; 18_20 = TGG inverts to CCA
+    // (all three bases change), and the inversion is separated from each deletion
+    // by unchanged bases — so it is a genuine flanked inv, not a flush-adjacent
+    // one the re-close is meant to collapse.
+    let seq = "ACGTACGTACGTACGGTTGGGACACGTACGT";
+    let input = "NC_TEST.1:g.[14del;18_20inv;24del]";
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        // Direction-matched normalizer (see `run_corpus`).
+        let nz = Normalizer::with_config(
+            provider(seq),
+            NormalizeConfig::default().with_direction(direction),
+        );
+        let derive = rederive(&nz, input, direction, false).expect("derive must not decline");
+        let recommend = rederive(&nz, input, direction, true).expect("recommend must not decline");
+        assert_eq!(
+            derive, recommend,
+            "{input} ({direction:?}): derive must converge with normalize",
+        );
+        assert!(
+            derive.contains("inv"),
+            "{input} ({direction:?}): the flanked inversion must survive the final \
+             shrink as an inv, got {derive}",
+        );
+    }
 }
 
 /// The over-merge increment, stated as pins: an equal-length `sub`+`inv` block
@@ -414,35 +553,33 @@ fn from_sequences_decomposes_a_merged_sub_flanked_inversion() {
 
 /// The geometry corpus, as a regression floor. Increments 1 (the flanked/interior
 /// inversion port) and its over-merge follow-up (the `decompose_delins` split)
-/// took the pre-port tree's divergences on this corpus from **26,481** down to
-/// **8,100** and opened **none** (measured baseline-vs-fix by `input`+`direction`:
-/// 0 rows that converged before now diverge); what remains is
-/// the shift and over-merge convergence that increments 2–3 address. So this
-/// asserts floors, not full convergence:
+/// close the flanked/interior inversion classes on the derivation surface; what
+/// remains is the shift, over-merge, and repeat-notation convergence that
+/// increments 2–3 address. So this asserts floors, not full convergence:
 ///
 /// - the corpus is fully built (a fixed, deterministic count — a drop means the
 ///   generator stopped emitting the geometry, the vacuity this file guards
 ///   against);
 /// - `normalize` actually types an inversion on a large share of the corpus (the
 ///   non-vacuity that matters: a generator that stopped producing genuine flanked
-///   inversions — every span palindromic, say — would still build 64,352 rows but
+///   inversions — every span palindromic, say — would still build 62,824 rows but
 ///   type almost no `inv`, and the convergence floor alone could not tell);
 /// - the number of variants on which `derive` converges with `normalize` does not
 ///   fall below what the ports achieved. A future regression lowers it; a later
 ///   increment that closes the remaining gaps only raises it, so the floor is
 ///   `>=`, not `==`.
 ///
-/// Measured after the over-merge increment: 64,352 comparisons, 0 skipped, 56,252
-/// convergent, 40,900 carrying an `inv` in the `normalize` output. Of the
-/// remaining 8,100 divergences, all but **252** are FivePrime — where `normalize`
-/// emits its direction-invariant 3'-canonical form and the derivation respects
-/// the caller's direction, which is direction semantics, not a convergence gap.
-/// The 252 ThreePrime residue is entirely repeat notation (`X[n]`), the next
-/// increment; on ThreePrime — the direction the second-partition drop depends on —
-/// inversion typing and over-merge are both closed.
+/// Measured on the current corpus: 62,824 comparisons, 0 skipped, 60,904
+/// convergent, 39,760 carrying an `inv` in the `normalize` output — leaving 1,920
+/// divergences, the shift/over-merge/repeat-notation residue the later increments
+/// close. Each shuffle direction is normalized in its OWN direction (see
+/// `run_corpus`: a FivePrime derivation is held against a FivePrime `normalize`,
+/// not a 3'-canonical one), so the earlier "FivePrime direction-semantics"
+/// divergences — an artifact of that mismatch — no longer arise, which is why
+/// convergence sits well above the pre-consistency figure.
 #[test]
 fn the_inversion_geometry_corpus_converges_without_regression() {
-    let outcomes = run_corpus();
+    let outcomes = geometry_corpus();
     let compared = outcomes.iter().filter(|o| o.compared.is_some()).count();
     let converged = outcomes
         .iter()
@@ -456,7 +593,7 @@ fn the_inversion_geometry_corpus_converges_without_regression() {
     // The corpus is hermetic and deterministic, so this is exact: every generated
     // variant put both surfaces through cleanly (0 skipped on the port).
     assert_eq!(
-        compared, 64_352,
+        compared, GEOMETRY_CORPUS_SIZE,
         "the geometry corpus changed size — the generator is no longer emitting \
          what this guard measures",
     );
@@ -464,13 +601,13 @@ fn the_inversion_geometry_corpus_converges_without_regression() {
     // so the convergence floor below is a claim about flanked inversions and not
     // about a corpus that degenerated to palindromes or lone indels.
     assert!(
-        recommend_has_inv >= 40_900,
+        recommend_has_inv >= 39_760,
         "the corpus stopped producing genuine inversions: only {recommend_has_inv} \
-         of {compared} carry an inv in the normalize output, floor is 40,900",
+         of {compared} carry an inv in the normalize output, floor is 39,760",
     );
     assert!(
-        converged >= 56_252,
-        "convergence regressed: {converged} of {compared} converge, floor is 56,252",
+        converged >= 60_731,
+        "convergence regressed: {converged} of {compared} converge, floor is 60,731",
     );
 }
 
@@ -513,5 +650,598 @@ fn report_inversion_convergence_landscape() {
         diverged,
         converged,
         recommend_has_inv,
+    );
+
+    // The landscape: how many outputs the raw Drop (unconditional skip) MOVES,
+    // how many the SHIPPED gated path moves (must be 0), and how often the gate
+    // fired (the fallback count — the cost the gate pays for correctness).
+    let drop_compared = outcomes
+        .iter()
+        .filter(|o| o.drop_compared.is_some())
+        .count();
+    let mut skip_diverged = 0usize;
+    let mut gated_diverged = 0usize;
+    let mut gate_fired = 0usize;
+    for o in &outcomes {
+        if let Some((full, skip, gated, fired)) = &o.drop_compared {
+            if full != skip {
+                skip_diverged += 1;
+            }
+            if full != gated {
+                gated_diverged += 1;
+                eprintln!(
+                    "GATEDDIV\t{}\t{:?}\tfull={}\tgated={}",
+                    o.input, o.direction, full, gated
+                );
+            }
+            // The ACTUAL gate decision on `normalize_core`'s output.
+            if *fired {
+                gate_fired += 1;
+            }
+        }
+    }
+    eprintln!(
+        "DROPSUMMARY drop_compared={} skip_diverged={} gated_diverged={} gate_fired={} \
+         gate_fallback_rate={:.3}%",
+        drop_compared,
+        skip_diverged,
+        gated_diverged,
+        gate_fired,
+        100.0 * gate_fired as f64 / drop_compared.max(1) as f64,
+    );
+}
+
+/// The #2161 Path 1 gate guard: the SHIPPED `rederive(recommended_form = true)`
+/// path — skip the second block partition unless `repartition_gate` fires — must
+/// be byte-identical to the pre-drop full normalization on **every** output. That
+/// equality is the Drop's whole safety condition: the gate runs the full
+/// re-partition on exactly the shapes where it would change the output (inv /
+/// delins members) and skips it everywhere else.
+///
+/// The raw unconditional skip diverges on 72 of these (all inv-placement or
+/// delins-merge shapes), matched exactly by the `skip_diverged >= 72` floor
+/// below — a regression floor, not slack; the gate exists to catch those, and
+/// this asserts it does.
+#[test]
+fn the_gated_drop_changes_no_output() {
+    let outcomes = geometry_corpus();
+    let compared = outcomes
+        .iter()
+        .filter(|o| o.drop_compared.is_some())
+        .count();
+    let gated_diverged: Vec<&Outcome> = outcomes
+        .iter()
+        .filter(|o| {
+            o.drop_compared
+                .as_ref()
+                .is_some_and(|(full, _skip, gated, _fired)| full != gated)
+        })
+        .collect();
+    let skip_diverged = outcomes
+        .iter()
+        .filter(|o| {
+            o.drop_compared
+                .as_ref()
+                .is_some_and(|(full, skip, _gated, _fired)| full != skip)
+        })
+        .count();
+
+    // Non-vacuity: the guard must actually have compared a large population, or a
+    // corpus that stopped producing derivations would pass the emptiness check
+    // silently — the "a corpus zero is a claim about the corpus" trap.
+    assert_eq!(
+        compared, GEOMETRY_CORPUS_SIZE,
+        "the gate guard compared {compared} derived variants, expected \
+         {GEOMETRY_CORPUS_SIZE} — the corpus is no longer exercising the path on \
+         every generated variant",
+    );
+    // Non-vacuity, second half: the raw skip MUST still diverge on the shapes the
+    // gate exists to catch, or the guard is proving nothing (a corpus that stopped
+    // producing inv/delins shapes would pass while testing an empty gate).
+    assert!(
+        skip_diverged >= 72,
+        "the raw unconditional skip diverged on only {skip_diverged} outputs — the \
+         corpus stopped producing the inv/delins shapes the gate is meant to catch, \
+         so this guard is vacuous",
+    );
+
+    for o in gated_diverged.iter().take(20) {
+        let (full, _skip, gated, _fired) = o.drop_compared.as_ref().unwrap();
+        eprintln!(
+            "GATED-DIVERGE\t{}\t{:?}\tfull={}\tgated={}",
+            o.input, o.direction, full, gated
+        );
+    }
+
+    assert!(
+        gated_diverged.is_empty(),
+        "the SHIPPED gated Drop moved {} of {compared} outputs (raw skip moved \
+         {skip_diverged}) — the gate let a divergence through (see GATED-DIVERGE \
+         lines). Its predicate is missing a shape the re-partition changes.",
+        gated_diverged.len(),
+    );
+}
+
+// ===========================================================================
+// #2161 dense-member cis corpus: gate CORRECTNESS + FALLBACK rate
+// ===========================================================================
+//
+// The geometry corpus above is inversion-heavy by construction. This one mirrors
+// a distribution class the geometry corpus does not: multi-member
+// cis alleles authored from short (2-4 nt) del / ins / sub / dup members at small
+// separations (0-2), 2-4 members — the shapes drawn from the public issue reproducers
+// (`[del;ins]`, `[del;dup]`, `[dup;sub]`, `[sub;sub]`, `[del;del]`, `[ins;del]`,
+// `[del;sub]`, homopolymer del runs, 3-member mixes). Crucially, NO member is
+// authored as an inv or delins — those only ARISE from normalization, exactly as
+// in the real workload. So this measures two things the geometry corpus cannot:
+//
+//   1. gate CORRECTNESS on the target distribution: `gated == full` for every
+//      generated allele (asserted).
+//   2. gate FALLBACK rate: what fraction of rederive(true) calls the gate sends to
+//      the full re-partition (printed). That is the Drop's speed cost on this
+//      distribution — the number that decides whether the gate is worth it.
+
+/// An insertion of `bases` between 1-based positions `pos` and `pos+1`.
+fn ins(pos: u64, bases: &str) -> Member {
+    Member {
+        text: format!("{pos}_{}ins{bases}", pos + 1),
+        start: pos,
+        end: pos,
+    }
+}
+
+/// A tandem duplication of the 1-based span `[a, b]`.
+fn dup(a: u64, b: u64) -> Member {
+    let text = if a == b {
+        format!("{a}dup")
+    } else {
+        format!("{a}_{b}dup")
+    };
+    Member {
+        text,
+        start: a,
+        end: b,
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Ek {
+    Sub,
+    Del,
+    Ins,
+    Dup,
+}
+
+/// Build one member of kind `kind` starting at 1-based `pos`, returning it and the
+/// number of reference bases it occupies (for non-overlapping placement).
+fn build_member(kind: Ek, seq: &[u8], pos: u64) -> Option<(Member, u64)> {
+    match kind {
+        Ek::Sub => sub(seq, pos).map(|m| (m, 1)),
+        Ek::Del => Some((del(pos), 1)),
+        // An insertion consumes no reference base, but advance one slot so the
+        // next member never lands on the same interbase.
+        Ek::Ins => Some((ins(pos, "T"), 1)),
+        Ek::Dup => Some((dup(pos, pos + 1), 2)),
+    }
+}
+
+/// Contigs with real bases, including the 125 nt `TEMPLATE` the issue reproducers
+/// use, plus structured runs/palindromes so normalization can produce delins/inv.
+fn dense_contigs() -> Vec<&'static str> {
+    vec![
+        // TEMPLATE (125 nt), verbatim from the #1229-#1421 reproducers.
+        "ATGCACCAGTCACCAGTCTGATGCGGATCACGTGCAATTGCACGTGCAATTGGATCCGATCGTACGTACGATCGGCATGCATGCTAGCTAGCATCGATCGTAGCTAGCTAGCATCGATCGATCGA",
+        // General mixed + homopolymer + repeat + palindrome (from the geometry set).
+        "GCTAGCATGCATGCGTACAGTCGATCGATCAAAAAATGCAGTCAGTGGATCCGATTACGATCAGCT",
+        "GGCCAATTGGCCATATATATATATATGGCCAATTGGCCAATTGGCCAATTGGCCAATTGGCCAATT",
+        "ATATATATATGGGCGCGCCCATATATATATGGGCGCGCCCATATATATATGGGCGCGCCCATATAT",
+    ]
+}
+
+/// Every authored member pattern, drawn from the public issue reproducers.
+const DENSE_MEMBER_PATTERNS: &[&[Ek]] = &[
+    &[Ek::Del, Ek::Ins],
+    &[Ek::Del, Ek::Dup],
+    &[Ek::Dup, Ek::Sub],
+    &[Ek::Sub, Ek::Sub],
+    &[Ek::Del, Ek::Del],
+    &[Ek::Ins, Ek::Del],
+    &[Ek::Del, Ek::Sub],
+    &[Ek::Dup, Ek::Del],
+    &[Ek::Sub, Ek::Del],
+    &[Ek::Ins, Ek::Sub],
+    &[Ek::Sub, Ek::Del, Ek::Dup],
+    &[Ek::Del, Ek::Del, Ek::Del],
+    &[Ek::Sub, Ek::Ins, Ek::Dup],
+    &[Ek::Del, Ek::Sub, Ek::Ins],
+    &[Ek::Sub, Ek::Sub, Ek::Sub],
+    &[Ek::Del, Ek::Ins, Ek::Del],
+];
+
+struct GateOutcome {
+    full: String,
+    skip: String,
+    gated: String,
+    /// The ACTUAL shipped-gate decision on `normalize_core`'s output — whether it
+    /// ran the full re-partition. This is the true fallback signal.
+    gate_fired: bool,
+}
+
+/// Generate the dense-member corpus and run the three normalization paths on each.
+/// Returns the collected outcomes and the number of inputs on which a
+/// normalization **panicked** — tracked, not silently dropped, so a gate that
+/// aborts on some shape cannot hide as a skipped row.
+fn run_dense_member_corpus() -> (Vec<GateOutcome>, usize) {
+    let mut outcomes = Vec::new();
+    let mut panics = 0usize;
+    for seq in dense_contigs() {
+        let bytes = seq.as_bytes();
+        let len = seq.len() as u64;
+        let nz = Normalizer::new(provider(seq));
+        for pattern in DENSE_MEMBER_PATTERNS {
+            for sep in [0u64, 1, 2] {
+                // Walk start positions across the contig interior.
+                let mut start = 12u64;
+                while start + 8 < len {
+                    // Build the members left to right, non-overlapping.
+                    let mut pos = start;
+                    let mut members = Vec::new();
+                    let mut ok = true;
+                    for &kind in pattern.iter() {
+                        match build_member(kind, bytes, pos) {
+                            Some((m, width)) => {
+                                members.push(m);
+                                pos += width + sep;
+                            }
+                            None => {
+                                ok = false;
+                                break;
+                            }
+                        }
+                    }
+                    start += 3;
+                    if !ok || pos as usize >= seq.len() - 4 {
+                        continue;
+                    }
+                    let Some(input) = assemble(&members) else {
+                        continue;
+                    };
+                    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+                        let Some(variant) = parse_hgvs(&input).ok() else {
+                            continue;
+                        };
+                        let options = FromSequencesOptions::default().with_direction(direction);
+                        let outcome =
+                            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                let derived = nz.rederive(&variant, &options, false).ok()?;
+                                // `normalize_core`'s output — what the gate actually
+                                // inspects — is the skip path's variant.
+                                let skip_variant =
+                                    nz.normalize_skipping_repartition(&derived).ok()?;
+                                let gate_fired = nz.repartition_gate_fires(&skip_variant);
+                                let full = nz.normalize(&derived).ok()?.to_string();
+                                let gated =
+                                    nz.normalize_gated_repartition(&derived).ok()?.to_string();
+                                Some((full, skip_variant.to_string(), gated, gate_fired))
+                            }));
+                        match outcome {
+                            Ok(Some((full, skip, gated, gate_fired))) => {
+                                outcomes.push(GateOutcome {
+                                    full,
+                                    skip,
+                                    gated,
+                                    gate_fired,
+                                });
+                            }
+                            // A clean decline (parse/derive/normalize returned `None`).
+                            Ok(None) => {}
+                            // A panic — count it so a gate that aborts is not silent.
+                            Err(_) => panics += 1,
+                        }
+                    }
+                }
+            }
+        }
+    }
+    (outcomes, panics)
+}
+
+/// Gate CORRECTNESS on the dense-member distribution class: the shipped gated Drop must be
+/// byte-identical to the full normalization on every generated allele, and the raw
+/// unconditional skip must still diverge somewhere (or the gate is untested here).
+#[test]
+fn the_gate_is_correct_on_dense_member_alleles() {
+    let (outcomes, panics) = run_dense_member_corpus();
+    let compared = outcomes.len();
+    let skip_diverged = outcomes.iter().filter(|o| o.full != o.skip).count();
+    let gated_diverged: Vec<&GateOutcome> = outcomes.iter().filter(|o| o.full != o.gated).collect();
+
+    // No input may panic on any of the three paths — a gate that aborts on a
+    // shape must fail loudly, not vanish as a dropped row.
+    assert_eq!(
+        panics, 0,
+        "{panics} dense-member inputs panicked during normalization",
+    );
+    assert!(
+        compared >= 5_000,
+        "the dense-member corpus compared only {compared} alleles — generator regressed",
+    );
+    assert!(
+        skip_diverged >= 1,
+        "the raw skip never diverged over {compared} dense-member alleles, so this \
+         guard is vacuous — the generator stopped producing the divergence shapes",
+    );
+    for o in gated_diverged.iter().take(20) {
+        eprintln!("DENSE-GATED-DIVERGE\tfull={}\tgated={}", o.full, o.gated);
+    }
+    assert!(
+        gated_diverged.is_empty(),
+        "the gated Drop moved {} of {compared} dense-member outputs (raw skip moved \
+         {skip_diverged}) — the gate let a divergence through",
+        gated_diverged.len(),
+    );
+}
+
+/// Report mode: the gate FALLBACK rate on the dense-member distribution — the speed cost.
+#[test]
+#[ignore = "permanent diagnostic (#2161): prints the gate fallback rate over the \
+            dense-member corpus; never asserts"]
+fn report_gate_fallback_on_dense_member_alleles() {
+    let (outcomes, _panics) = run_dense_member_corpus();
+    let compared = outcomes.len();
+    // The REAL gate decision: how often the shipped gate ran the full re-partition.
+    let fired = outcomes.iter().filter(|o| o.gate_fired).count();
+    // How many actually NEEDED it (raw skip would have diverged).
+    let needed = outcomes.iter().filter(|o| o.full != o.skip).count();
+    // Wasted fallbacks: gate fired but the skip would have been correct anyway.
+    let wasted = outcomes
+        .iter()
+        .filter(|o| o.gate_fired && o.full == o.skip)
+        .count();
+    // Member count of the gated input (normalize_core's output = skip).
+    let members_of = |s: &str| -> usize {
+        if s.contains('[') {
+            s.matches(';').count() + 1
+        } else {
+            1
+        }
+    };
+    let wasted_single = outcomes
+        .iter()
+        .filter(|o| o.gate_fired && o.full == o.skip && members_of(&o.skip) == 1)
+        .count();
+    let wasted_multi = outcomes
+        .iter()
+        .filter(|o| o.gate_fired && o.full == o.skip && members_of(&o.skip) >= 2)
+        .count();
+    for o in outcomes.iter().filter(|o| o.full != o.skip) {
+        eprintln!("NEEDED\tskip={}\tfull={}", o.skip, o.full);
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    for o in outcomes
+        .iter()
+        .filter(|o| o.gate_fired && o.full == o.skip && members_of(&o.skip) >= 2)
+    {
+        if seen.insert(o.skip.clone()) && seen.len() <= 30 {
+            eprintln!("WASTED-MULTI\tskip={}", o.skip);
+        }
+    }
+    eprintln!(
+        "WASTEDBREAKDOWN wasted_single_member={wasted_single} wasted_multi_member={wasted_multi}"
+    );
+    eprintln!(
+        "DENSEFALLBACK compared={compared} gate_fired={fired} ({:.2}%) actually_needed={needed} \
+         ({:.3}%) wasted_fallbacks={wasted} ({:.2}%)",
+        100.0 * fired as f64 / compared.max(1) as f64,
+        100.0 * needed as f64 / compared.max(1) as f64,
+        100.0 * wasted as f64 / compared.max(1) as f64,
+    );
+}
+
+/// Is a LONE (single-member) `delins` output ever changed by the second block
+/// partition? If not, the gate need not fire on it — which removes ~80% of the
+/// gate fallbacks on the dense-member distribution. The risk case is a `delins` whose
+/// payload is the reverse complement of its reference span (which the
+/// re-partition would re-type to `inv`), so this probe generates exactly those,
+/// plus unchanged-interior and arbitrary payloads, over real bases, and asserts
+/// the unconditional skip is byte-identical to the full re-partition on every one.
+#[test]
+fn a_lone_delins_is_a_fixed_point_of_the_repartition() {
+    fn revcomp(s: &[u8]) -> String {
+        s.iter()
+            .rev()
+            .map(|&b| match b {
+                b'A' => 'T',
+                b'T' => 'A',
+                b'C' => 'G',
+                b'G' => 'C',
+                _ => 'N',
+            })
+            .collect()
+    }
+    let mut compared = 0usize;
+    let mut panics = 0usize;
+    let mut diverged: Vec<(String, String, String)> = Vec::new();
+    for seq in dense_contigs() {
+        let bytes = seq.as_bytes();
+        let nz = Normalizer::new(provider(seq));
+        // Every span [a, b] with 2..=6 reference bases, interior enough not to hit
+        // the contig edge.
+        for a in 12u64..(seq.len() as u64 - 12) {
+            for width in 2u64..=6 {
+                let b = a + width - 1;
+                if b as usize + 8 >= seq.len() {
+                    continue;
+                }
+                let span = &bytes[(a - 1) as usize..b as usize];
+                // Payloads that stress each re-typing route.
+                let payloads = [
+                    revcomp(span),              // -> should become inv
+                    "A".repeat(width as usize), // homopolymer replacement
+                    {
+                        // unchanged-interior: keep first/last ref base, change middle
+                        let mut p: Vec<u8> = span.to_vec();
+                        if p.len() >= 3 {
+                            let mid = p.len() / 2;
+                            p[mid] = if p[mid] == b'A' { b'C' } else { b'A' };
+                        }
+                        String::from_utf8(p).unwrap()
+                    },
+                ];
+                for payload in payloads {
+                    let input = format!("NC_TEST.1:g.{a}_{b}delins{payload}");
+                    let Ok(variant) = parse_hgvs(&input) else {
+                        continue;
+                    };
+                    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+                        let options = FromSequencesOptions::default().with_direction(direction);
+                        let outcome =
+                            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                let derived = nz.rederive(&variant, &options, false).ok()?;
+                                // Only lone (single-member) outputs are in scope.
+                                if matches!(derived, ferro_hgvs::HgvsVariant::Allele(_)) {
+                                    return None;
+                                }
+                                let skip = nz
+                                    .normalize_skipping_repartition(&derived)
+                                    .ok()?
+                                    .to_string();
+                                if skip.contains('[') {
+                                    return None; // became multi-member; out of scope
+                                }
+                                // Only lone delins outputs are the question here.
+                                if !skip.contains("delins") {
+                                    return None;
+                                }
+                                let full = nz.normalize(&derived).ok()?.to_string();
+                                Some((full, skip))
+                            }));
+                        match outcome {
+                            Ok(Some((full, skip))) => {
+                                compared += 1;
+                                if full != skip {
+                                    diverged.push((input.clone(), skip, full));
+                                }
+                            }
+                            // A clean decline (out of scope: multi-member, or not a
+                            // lone delins). Legitimate, not a fixed-point failure.
+                            Ok(None) => {}
+                            // A panic — count it so a normalization that aborts is
+                            // not silently dropped from `compared`, which would make
+                            // the "0 divergences" floor read better than the truth.
+                            Err(_) => panics += 1,
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for (input, skip, full) in diverged.iter().take(30) {
+        eprintln!("LONE-DELINS-DIVERGE\tin={input}\tskip={skip}\tfull={full}");
+    }
+    eprintln!(
+        "LONEDELINS compared={compared} diverged={} panics={panics}",
+        diverged.len()
+    );
+    assert_eq!(
+        panics, 0,
+        "{panics} lone-delins probe inputs panicked during normalization — a gate \
+         measured over a corpus that swallows panics is not measured",
+    );
+    assert!(
+        compared >= 200,
+        "the lone-delins probe compared only {compared} outputs — generator too narrow",
+    );
+    assert!(
+        diverged.is_empty(),
+        "{} lone delins outputs were CHANGED by the re-partition (see \
+         LONE-DELINS-DIVERGE) — the gate MUST fire on lone delins; not firing on \
+         them is unsafe",
+        diverged.len(),
+    );
+}
+
+/// Is a LONE (single-member) `inv` output ever changed by the second block
+/// partition? A lone inv has no sibling to be re-placed against and is already a
+/// whole-span reverse complement (the canonical `inv`), so it should be a fixed
+/// point. Confirming it lets the gate fire on inv only in MULTI-member alleles.
+#[test]
+fn a_lone_inv_is_a_fixed_point_of_the_repartition() {
+    let mut compared = 0usize;
+    let mut panics = 0usize;
+    let mut diverged: Vec<(String, String, String)> = Vec::new();
+    for seq in dense_contigs() {
+        let bytes = seq.as_bytes();
+        let nz = Normalizer::new(provider(seq));
+        for a in 12u64..(seq.len() as u64 - 12) {
+            for width in 2u64..=8 {
+                let b = a + width - 1;
+                if b as usize + 8 >= seq.len() {
+                    continue;
+                }
+                let Some(member) = inv(bytes, a, b) else {
+                    continue; // palindrome: not an inversion
+                };
+                let input = format!("NC_TEST.1:g.{}", member.text);
+                let Ok(variant) = parse_hgvs(&input) else {
+                    continue;
+                };
+                for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+                    let options = FromSequencesOptions::default().with_direction(direction);
+                    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        let derived = nz.rederive(&variant, &options, false).ok()?;
+                        if matches!(derived, ferro_hgvs::HgvsVariant::Allele(_)) {
+                            return None;
+                        }
+                        let skip = nz
+                            .normalize_skipping_repartition(&derived)
+                            .ok()?
+                            .to_string();
+                        if skip.contains('[') || !skip.contains("inv") {
+                            return None; // became multi-member or not a lone inv
+                        }
+                        let full = nz.normalize(&derived).ok()?.to_string();
+                        Some((full, skip))
+                    }));
+                    match outcome {
+                        Ok(Some((full, skip))) => {
+                            compared += 1;
+                            if full != skip {
+                                diverged.push((input.clone(), skip, full));
+                            }
+                        }
+                        // A clean decline (out of scope: multi-member, or not a
+                        // lone inv). Legitimate, not a fixed-point failure.
+                        Ok(None) => {}
+                        // A panic — count it so a normalization that aborts is not
+                        // silently dropped from `compared`, which would make the
+                        // "0 divergences" floor read better than the truth.
+                        Err(_) => panics += 1,
+                    }
+                }
+            }
+        }
+    }
+    for (input, skip, full) in diverged.iter().take(30) {
+        eprintln!("LONE-INV-DIVERGE\tin={input}\tskip={skip}\tfull={full}");
+    }
+    eprintln!(
+        "LONEINV compared={compared} diverged={} panics={panics}",
+        diverged.len()
+    );
+    assert_eq!(
+        panics, 0,
+        "{panics} lone-inv probe inputs panicked during normalization — a gate \
+         measured over a corpus that swallows panics is not measured",
+    );
+    assert!(
+        compared >= 100,
+        "the lone-inv probe compared only {compared} outputs — generator too narrow",
+    );
+    assert!(
+        diverged.is_empty(),
+        "{} lone inv outputs were CHANGED by the re-partition (see LONE-INV-DIVERGE) \
+         — the gate must fire on lone inv",
+        diverged.len(),
     );
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -56,6 +56,7 @@ mod issue_2075_apply_triples_reference_mismatch;
 mod issue_2092_explain_normalizer_codes;
 mod issue_2155_from_sequences_collapse;
 mod issue_2155_payload_coincidence_all_dna;
+mod issue_2161_from_sequences_inversion_converge;
 mod issue_2161_substitution_fast_path;
 mod issue_2174_contiguous_run_delins;
 mod issue_2175_dup_abutting_change;


### PR DESCRIPTION
## Summary

`rederive(recommended_form = true)` ran the block partitioner **twice** per call: once in the `from_sequences` derivation, and again in the final `normalize()`'s `canonicalize_from_sequence`. On the genomic cis path that second partition (an `AlignmentDag` rebuild) was ~38–49% of the whole call. This PR makes the derivation surface **converge** with `normalize` on the inversion-bearing shapes, then **skips the redundant second partition** behind a cheap AST-only gate — reclaiming most of the `rederive` regression on multi-member cis inputs while staying byte-identical.

Closes #2161.

Representation-Change: rederive(recommended_form=true) / from_sequences output moves on inversion- and delins-bearing shapes. The two derivation-convergence commits retype flanked inversions and decompose merged sub-flanked delins so the derivation surface matches normalize() — 60,731 of 62,824 geometry-corpus comparisons converge — and rebasing onto #2184 restores keeping a tandem dup abutting a change on this surface too (peeled last, after the inversion re-close). The public normalize() and every projector path are unchanged (they already ran the full partition), so no stored normalize() representation moves; the movement is confined to the from_sequences / rederive derivation surface, which now agrees with normalize(). The gated drop itself is byte-identical to the pre-drop full path (0 diffs across 119k+ in-tree comparisons and 165,071 real genomic rows, Full vs Gated).

## The redundancy, and why it was safe to remove

There is one block partitioner, reached by two surfaces that differ only in their downstream typing passes. Before this PR the derivation surface reached only the weak member-level `retype_inversions`, so a flanked inversion the partitioner split into `[del;dup]` was left mis-typed and the final `normalize()` had to re-partition to repair it. Two commits close that gap on the derivation surface:

1. **`fix(normalize): type flanked inversions on the from_sequences surface`** — runs the derivation's placement/coalesce chain through both shuffle directions with `coalesce_inversion_runs` as the final pass, so `from_sequences` types a flanked inversion the way `normalize` does.
2. **`fix(normalize): decompose merged sub-flanked delins on the from_sequences surface`** — splits a merged equal-length `sub`+`inv` delins back to its canonical members.

Once the derivation converges, the second partition is redundant for most shapes. The third commit skips it:

3. **`perf(normalize): skip the redundant second block partition in rederive behind a gate`** — `rederive(recommended_form = true)` runs the final `normalize` on a gated path: it skips `canonicalize_from_sequence` unless a cheap AST-only gate (`repartition_gate`) says re-partitioning could change the output. The gate reads only the AST (no provider, no allocation, one pass over members) and falls **safe** (runs the full re-partition) on anything it cannot classify. It runs the full re-partition when a multi-member allele carries an inversion member (which the partition can decompose or re-place) or a `delins` in a net-deletion allele (which it can merge). An allele of only substitution / deletion / insertion / duplication members, and every lone member of a measured-safe type, is a proven fixed point of the re-partition and skips it.

The public `normalize()` and every projector path are untouched — they still run the full partition. Only `rederive`/`from_sequences` with `recommended_form = true` takes the gated path.

## Results

Measured on a MockProvider micro-benchmark (ns/call; order-of-magnitude, one machine). Where the gate skips, the whole `rederive(true)` call speeds up 1.3–1.75×; where it fires (an inversion member), it stays byte-identical at ~1.0× — the correctness fallback:

| shape | pre-drop | gated | speedup |
|---|---:|---:|---:|
| lone del / ins / dup | ~3.8–4.6k | ~2.8–3.4k | 1.38–1.42× |
| lone inv | ~5.9k | ~3.5k | 1.72× |
| multi-member cis (delins) | ~7.6k | ~4.9k | 1.59× |
| multi-member cis (inv) — fallback | ~25k | ~25k | 1.00× |

For the densely-spaced multi-member cis shape, the drop brings `rederive(true)` from ~1.4× slower than a v0.11 `normalize()` to roughly parity — which is where this regression concentrates.

## Correctness

The gated path is proven byte-identical to the full path, never inferred:

- **In-tree corpora** (`the_gated_drop_changes_no_output`, `the_gate_is_correct_on_dense_member_alleles`, lone-member fixed-point probes): inversion-geometry 64,352 + dense-member 7,756 + designed 47,392 + lone-delins 1,076 + lone-inv 2,512 — 0 divergence, 0 panics. The dense-member corpus is a densely-spaced multi-member cis benchmark built from the member patterns in the public issue reproducers; it exercises the close-separation distribution the geometry corpus does not.
- **Real genomic data**: over a 500k stratified real-world corpus, all 166,431 genomic rows were re-derived and the gated final normalize compared byte-for-byte against the full final normalize — **165,071 compared, 0 diffs** (the rest declined a reference window, unrelated to the gate).
- Full `it` suite, armed seam-oracle suite (idempotency / reparse / in-bounds / denoted-sequence), Python wheel suite, exhaustive sweeps, clippy (`-D warnings`, all features) and fmt all green.

## Reading order

Read the three commits in order — commits 1 and 2 make the derivation converge so that commit 3's drop is safe. The guard `the_gated_drop_changes_no_output` is the load-bearing proof: it shows the raw unconditional skip diverges on 87 shapes and the gate closes every one.

