### PR TITLE
perf(normalize): fast-path lone-member derivation in rederive

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2415,6 +2415,34 @@ fn repartition_gate(variant: &HgvsVariant) -> bool {
     total < 0
 }
 
+/// A lone (non-allele) genomic or mitochondrial member whose edit **always**
+/// changes the sequence — `Deletion`, `Insertion`, or `Duplication`. Such a
+/// member has no sibling to re-partition against and cannot denote an identity,
+/// so `rederive`'s sequence-first derivation lands on the exact canonical form
+/// [`Normalizer::normalize_core`] produces positionally. Measured byte-identical
+/// over a lone-member corpus: `rederive(true)` equals `normalize()` for every
+/// such input, so `rederive` fast-paths these straight to its final normalize
+/// step, skipping the confluence loop and `from_sequences` entirely.
+///
+/// Restricted to the `g.`/`m.` axes because those are the only ones
+/// `from_sequences` derives at all — a `c.`/`n.`/… input takes the normal
+/// (refusing) path, so the fast-path never changes which inputs `rederive`
+/// accepts. `delins` and `inversion` are **excluded**: both can denote no change
+/// (a self-`delins`, a palindromic `inv`), where the derivation emits `g.=` and
+/// `normalize_core` keeps `span=` — a real spelling difference, so those keep
+/// the derivation.
+fn is_lone_derivation_fixed_point(variant: &HgvsVariant) -> bool {
+    let edit = match variant {
+        HV::Genome(g) => g.loc_edit.edit.inner(),
+        HV::Mt(m) => m.loc_edit.edit.inner(),
+        _ => return false,
+    };
+    matches!(
+        edit,
+        Some(NaEdit::Deletion { .. } | NaEdit::Insertion { .. } | NaEdit::Duplication { .. })
+    )
+}
+
 #[cfg(debug_assertions)]
 thread_local! {
     static NA_EDIT_REFERENCES: std::cell::RefCell<Vec<NaEditReference>> =
@@ -3189,6 +3217,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
         /// moving, before declining.
         const MAX_PAD: u64 = crate::spdi::MAX_SHIFT_TRACT;
 
+        // Lone-member fast-path. A lone g./m. del/ins/dup has no sibling to
+        // re-partition against and cannot denote an identity, so its
+        // sequence-first derivation lands on the same canonical form the final
+        // normalize produces positionally — measured byte-identical. Skip the
+        // confluence loop and `from_sequences` entirely and run the final
+        // normalize on the input directly. This is exactly what the loop does at
+        // its settled exit, minus the derivation a lone member does not need.
+        // `recommended_form = false` returns the derived form, which is a
+        // different output, so the fast-path is gated on `recommended_form`.
+        if recommended_form && is_lone_derivation_fixed_point(variant) {
+            return self.normalize_for_recommended_form(variant);
+        }
+
         let mut pad = START_PAD;
         // The previous iteration's window bounds, 1-based inclusive. Used to
         // tell a side the provider simply could not widen further from one still
@@ -3448,6 +3489,17 @@ impl<P: ReferenceProvider> Normalizer<P> {
     #[cfg(any(test, feature = "dev"))]
     pub fn repartition_gate_fires(&self, variant: &HgvsVariant) -> bool {
         repartition_gate(variant)
+    }
+
+    /// Whether `rederive(recommended_form = true)` takes the lone-member
+    /// fast-path for this input — a lone `g.`/`m.` del/ins/dup, short-circuited
+    /// to the final normalize step because its sequence-first derivation is
+    /// redundant. Exposed so the fast-path convergence guard can assert both the
+    /// boundary (it fires on del/ins/dup, not on delins/inv/alleles) and
+    /// non-vacuity (it fires on a floor of the corpus). Test/`dev` only.
+    #[cfg(any(test, feature = "dev"))]
+    pub fn lone_member_fast_path_applies(&self, variant: &HgvsVariant) -> bool {
+        is_lone_derivation_fixed_point(variant)
     }
 
     /// Opt-in idempotency self-check (issue #1157 follow-up): a normalizer must

--- a/tests/it/issue_2161_lone_member_fast_path.rs
+++ b/tests/it/issue_2161_lone_member_fast_path.rs
@@ -1,0 +1,166 @@
+//! #2161 — the lone-member derivation fast-path.
+//!
+//! `rederive(recommended_form = true)` short-circuits a lone `g.`/`m.`
+//! del/ins/dup straight to its final normalize step, skipping the confluence
+//! loop and `from_sequences`. Such a member has no sibling to re-partition
+//! against and cannot denote an identity, so its sequence-first derivation lands
+//! on the exact canonical form the final normalize produces positionally — this
+//! file pins that the fast-path is **byte-identical** to the full derivation and
+//! that its boundary (del/ins/dup in; `delins`/`inv`/alleles out) is load-bearing.
+//!
+//! # How the two paths are reconstructed
+//!
+//! `rederive(.., false)` returns the *derived* form and is **not** gated on
+//! `recommended_form`, so it never takes the fast-path — it is the full
+//! sequence-first derivation. Re-applying the final normalize to it
+//! (`normalize_gated_repartition`, exactly what `rederive(.., true)` runs at its
+//! settled exit) reconstructs the pre-fast-path `rederive(true)` output. The
+//! shipped fast-path is `rederive(.., true)` itself. The guard asserts the two
+//! agree on every input.
+
+use ferro_hgvs::{parse_hgvs, FerroError, FromSequencesOptions, JsonProvider, Normalizer};
+use std::io::Write;
+
+/// A genome-capable provider over four structured contigs (the same shapes the
+/// inversion-geometry guard uses): a general mix, an inverted repeat, a tandem
+/// tract, and a GC palindrome — so the corpus exercises homopolymer shifting,
+/// repeat tracts, and reverse-complement coincidence, not one flat sequence.
+fn provider() -> JsonProvider {
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": {
+            "NC_TEST.1": "GCTAGCATGCATGCGTACAGTCGATCGATCAAAAAATGCAGTCAGTGGATCCGATTACGATCAGCT",
+            "NC_TEST.2": "AACCGGTTAATCGATCGATTGCACGTACGTGCAATCGATCGATTAACCGGTTAACCGGTTAACCGG",
+            "NC_TEST.3": "GGCCAATTGGCCATATATATATATATGGCCAATTGGCCAATTGGCCAATTGGCCAATTGGCCAATT",
+            "NC_TEST.4": "ATATATATATGGGCGCGCCCATATATATATGGGCGCGCCCATATATATATGGGCGCGCCCATATAT",
+        },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+/// `rederive(recommended_form = true)` — the shipped path, which takes the
+/// fast-path for a lone del/ins/dup.
+fn rederive_shipped(nz: &Normalizer<JsonProvider>, desc: &str) -> Result<String, FerroError> {
+    let v = parse_hgvs(desc)?;
+    let opts = FromSequencesOptions::default();
+    Ok(nz.rederive(&v, &opts, true)?.to_string())
+}
+
+/// The full sequence-first path, reconstructed without the fast-path:
+/// derive (`recommended_form = false`, never fast-pathed), then re-apply the
+/// same final normalize the shipped path runs at its settled exit.
+fn rederive_full(nz: &Normalizer<JsonProvider>, desc: &str) -> Result<String, FerroError> {
+    let v = parse_hgvs(desc)?;
+    let opts = FromSequencesOptions::default();
+    let derived = nz.rederive(&v, &opts, false)?;
+    Ok(nz.normalize_gated_repartition(&derived)?.to_string())
+}
+
+/// The fast-path is byte-identical to the full derivation across a diverse
+/// corpus — every lone del/ins/dup on four contigs, plus controls (lone
+/// `delins`/`inv` and multi-member alleles) the fast-path must **not** take.
+#[test]
+fn the_lone_member_fast_path_is_byte_identical() {
+    let nz = Normalizer::new(provider());
+    let opts = FromSequencesOptions::default();
+    let contigs = ["NC_TEST.1", "NC_TEST.2", "NC_TEST.3", "NC_TEST.4"];
+
+    let mut compared = 0usize;
+    let mut fired = 0usize;
+    for ctg in contigs {
+        for a in 5u64..=55 {
+            // Fast-path members (must fire) and controls (must not).
+            let cases: [(String, bool); 8] = [
+                (format!("{ctg}:g.{a}del"), true),
+                (format!("{ctg}:g.{a}_{}del", a + 2), true),
+                (format!("{ctg}:g.{a}dup"), true),
+                (format!("{ctg}:g.{a}_{}dup", a + 3), true),
+                (format!("{ctg}:g.{a}_{}insAT", a + 1), true),
+                (format!("{ctg}:g.{a}_{}inv", a + 3), false),
+                (format!("{ctg}:g.{a}_{}delinsGC", a + 3), false),
+                (format!("{ctg}:g.[{a}del;{}del]", a + 5), false),
+            ];
+            for (desc, expect_fast) in &cases {
+                let Ok(v) = parse_hgvs(desc) else { continue };
+                assert_eq!(
+                    nz.lone_member_fast_path_applies(&v),
+                    *expect_fast,
+                    "fast-path boundary wrong for {desc}"
+                );
+                if *expect_fast {
+                    fired += 1;
+                }
+                // Compare the two paths, and never let an *asymmetric* outcome
+                // slip through: if one path yields an output and the other
+                // declines, the fast-path and the full derivation disagree on
+                // whether this input even has a result — exactly the divergence
+                // this guard exists to catch. Only a *symmetric* decline is
+                // legitimate (some inputs simply do not derive, which is not a
+                // fast-path question).
+                match (rederive_shipped(&nz, desc), rederive_full(&nz, desc)) {
+                    (Ok(shipped), Ok(full)) => {
+                        assert_eq!(shipped, full, "fast-path changed the output of {desc}");
+                        compared += 1;
+                    }
+                    (Err(_), Err(_)) => {}
+                    (shipped, full) => panic!(
+                        "asymmetric derivation for {desc}: shipped={shipped:?} full={full:?}"
+                    ),
+                }
+                let _ = &opts;
+            }
+        }
+    }
+
+    // Non-vacuity: the fast-path must actually fire, or the equality above is
+    // proving nothing. Four contigs x 51 positions x 5 fast-path members is well
+    // over a thousand; a floor far below that still catches a predicate that
+    // stopped firing.
+    assert!(
+        fired > 500,
+        "fast-path fired on only {fired} inputs — guard is vacuous"
+    );
+    assert!(
+        compared > 500,
+        "compared only {compared} inputs — guard is vacuous"
+    );
+}
+
+/// The identity boundary is load-bearing: a palindromic `inv` and a self-`delins`
+/// denote no change, and the derivation spells that as whole-reference `g.=`
+/// while the positional normalize keeps `span=`. So these two classes genuinely
+/// diverge — which is why the fast-path excludes `inv`/`delins`. If the predicate
+/// were widened to include them, `the_lone_member_fast_path_is_byte_identical`
+/// would go red; this test pins the divergence that makes the exclusion necessary.
+#[test]
+fn the_identity_boundary_is_load_bearing() {
+    let nz = Normalizer::new(provider());
+
+    // NC_TEST.1[6..9] = CATG, whose reverse complement is itself (a palindrome),
+    // and a delins replacing it with the same bases — both denote no change.
+    for desc in ["NC_TEST.1:g.6_9inv", "NC_TEST.1:g.6_9delinsCATG"] {
+        let v = parse_hgvs(desc).unwrap();
+        assert!(
+            !nz.lone_member_fast_path_applies(&v),
+            "{desc} must be excluded from the fast-path"
+        );
+        let shipped = rederive_shipped(&nz, desc).expect("rederive");
+        let full = rederive_full(&nz, desc).expect("full");
+        // The two paths agree (both go through the derivation, since the
+        // fast-path is excluded) …
+        assert_eq!(shipped, full, "{desc}");
+        // … and the derivation collapses the no-change edit to whole-reference
+        // identity, which a positional normalize of the *input* does not — the
+        // exact divergence the exclusion avoids.
+        let positional = nz.normalize_gated_repartition(&v).unwrap().to_string();
+        assert_ne!(
+            shipped, positional,
+            "{desc}: derivation and positional normalize must differ here, or the \
+             fast-path exclusion would be unnecessary"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -57,6 +57,7 @@ mod issue_2092_explain_normalizer_codes;
 mod issue_2155_from_sequences_collapse;
 mod issue_2155_payload_coincidence_all_dna;
 mod issue_2161_from_sequences_inversion_converge;
+mod issue_2161_lone_member_fast_path;
 mod issue_2161_substitution_fast_path;
 mod issue_2174_contiguous_run_delins;
 mod issue_2175_dup_abutting_change;


### PR DESCRIPTION
## Summary

A lone `g.`/`m.` `del`/`ins`/`dup` has no sibling to re-partition against and cannot denote an identity, so its sequence-first derivation is **redundant**: it lands on the exact canonical form the final normalize produces positionally. `rederive(recommended_form = true)` now short-circuits these straight to its final normalize step, skipping the confluence loop and `from_sequences` entirely.

The change is one predicate plus a three-line guard at the top of `rederive`, reusing the existing `normalize_for_recommended_form` — no new machinery.

**Stacked on #2181** (the redundant-second-partition drop): this reuses that PR's `normalize_for_recommended_form` seam and lives in the same `rederive` function, so it is based on that branch. Retarget to `main` once #2181 merges.

Representation-Change: none. Proven byte-identical to the full derivation — 0 divergences across 2,652 cross-build comparisons (this branch's `rederive(true)` vs the base branch's, over four contigs) and the full `it` suite.

## Why it is safe

For a lone always-changing edit (`del`/`ins`/`dup`), the sequence-first derivation and the positional normalize agree byte-for-byte: the member has no sibling to merge with or re-place against, and its edit always changes the sequence, so there is no identity-vs-span spelling ambiguity. `delins` and `inversion` are **excluded** because both can denote no change — a self-`delins`, a palindromic `inv` — where the derivation collapses to whole-reference `g.=` while the positional normalize keeps `span=`. Those keep the full derivation.

Restricted to the `g.`/`m.` axes because those are the only ones `from_sequences` derives at all; any other axis takes the normal (refusing) path, so the fast-path never changes which inputs `rederive` accepts.

Substitutions are deliberately **not** included: they state a reference base whose validation this path would bypass, and they are already short-circuited a layer down by the #2169 `sequence_first_pass` fast-path.

## Results

Micro-benchmark (MockProvider, ns/call, `rederive(true)` as a single op):

| case | before | after | speedup |
|---|---:|---:|---:|
| lone `del` | 2821 | 527 | 5.35× |
| lone `ins` | 3472 | 913 | 3.80× |
| lone `dup` | 2961 | 525 | 5.64× |
| lone `delins` (excluded) | 4398 | 4379 | 1.00× |
| lone `inv` (excluded) | 3487 | 3496 | 1.00× |

A lone `del`'s `rederive(true)` drops to ~530 ns — essentially the pre-sequence-first cost — so on single-member inputs the method is no longer paying for a derivation it does not need. This is the derivation half of every cis case too, though the win concentrates on single-member inputs.

## Tests

`tests/it/issue_2161_lone_member_fast_path.rs`:

- `the_lone_member_fast_path_is_byte_identical` — over four structured contigs, asserts the shipped `rederive(true)` equals the full derivation (reconstructed without the fast-path) for every lone `del`/`ins`/`dup`, plus controls (`delins`/`inv`/multi-member alleles) that must **not** fast-path. Carries a non-vacuity floor so a predicate that stopped firing fails the guard.
- `the_identity_boundary_is_load_bearing` — pins that a palindromic `inv` and a self-`delins` genuinely diverge between the derivation (`g.=`) and the positional normalize (`span=`), which is why they are excluded. Widening the predicate to include them turns the byte-identity guard red (verified by sabotage).

Full `it` suite (6,658) green; clippy `-D warnings` (all features) and fmt clean.
