### PR TITLE
fix(normalize): converge CDS/3'UTR straddles to the spanning form (part of #1816)

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -114,6 +114,16 @@ enum AnchorForm {
 #[derive(Debug, Clone)]
 struct Anchor {
     region: Region,
+    /// The region naming the **end** endpoint. Equal to `region` for every
+    /// single-region member — which is all but one construction site. A member
+    /// that straddles a CDS/UTR zone seam (`c.<cds_len-1>` to `c.*2`, or `c.-1`
+    /// to `c.1`) is the exception: [`render_on_its_own_region`] sets this to the
+    /// end endpoint's own region so [`build_naedit`] can name each endpoint in
+    /// its own zone (#1816). When it differs from `region` the member is a span
+    /// (never an insertion or single-base substitution, both of which sit in one
+    /// zone), and `start`/`end` are already in flat 5'→3' order so no swap
+    /// applies.
+    end_region: Region,
     start: i64,
     end: i64,
     alt: Vec<Base>,
@@ -888,6 +898,7 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
     }
     let anchor = Anchor {
         region: body,
+        end_region: body,
         start: a_start,
         end: a_end,
         alt: alt_bases,
@@ -1056,8 +1067,10 @@ fn cis_axis_parts_on(
 /// With no `cds_end_axis` this is the identity on `body`, which is exactly the
 /// unextended behaviour.
 ///
-/// A span that *straddles* the boundary IS a real refusal, and it belongs to the
-/// caller, which holds both endpoints — see [`render_on_its_own_region`].
+/// A span that *straddles* the boundary is built one region per endpoint by the
+/// caller, which holds both — see [`render_on_its_own_region`] (#1816). This
+/// function still answers per endpoint; it is the caller that assembles the two
+/// into a straddling member rather than refusing it.
 fn unfold_extended_body(pos: i64, body: Region, cds_end_axis: Option<i64>) -> (Region, i64) {
     match cds_end_axis {
         Some(end) if pos > end => (Region::ThreePrimeUtr, pos - end),
@@ -1402,6 +1415,7 @@ fn anchor_from_loc_edit<L>(
             alternative,
         } => Some(Anchor {
             region,
+            end_region: region,
             start,
             end,
             alt: vec![*alternative],
@@ -1410,6 +1424,7 @@ fn anchor_from_loc_edit<L>(
         }),
         NaEdit::SubstitutionNoRef { alternative } => Some(Anchor {
             region,
+            end_region: region,
             start,
             end,
             alt: vec![*alternative],
@@ -1418,6 +1433,7 @@ fn anchor_from_loc_edit<L>(
         }),
         NaEdit::Deletion { .. } => Some(Anchor {
             region,
+            end_region: region,
             start,
             end,
             alt: Vec::new(),
@@ -1428,6 +1444,7 @@ fn anchor_from_loc_edit<L>(
             let bases = sequence.bases()?.to_vec();
             Some(Anchor {
                 region,
+                end_region: region,
                 start,
                 end,
                 alt: bases,
@@ -1442,6 +1459,7 @@ fn anchor_from_loc_edit<L>(
             let bases = sequence.bases()?.to_vec();
             Some(Anchor {
                 region,
+                end_region: region,
                 start: end,
                 end: start,
                 alt: bases,
@@ -1745,6 +1763,10 @@ fn build_rna_merged(template: &RnaVariant, merged: Anchor) -> RnaVariant {
 
 fn build_mt_merged(template: &MtVariant, merged: Anchor) -> MtVariant {
     debug_assert_eq!(merged.region, Region::Genome);
+    // The mito axis takes no CDS fold, so a straddle can never reach it; assert
+    // both endpoints stay single-region so a future fold that did reach here
+    // could not silently build a two-region `m.` member.
+    debug_assert_eq!(merged.region, merged.end_region);
     let (location, edit) = build_naedit(merged, |_, b| {
         GenomePos::new(u64::try_from(b).expect("mitochondrial anchor base must be non-negative"))
     });
@@ -1824,6 +1846,15 @@ fn build_naedit<P>(
     merged: Anchor,
     mut to_pos: impl FnMut(Region, i64) -> P,
 ) -> (Interval<P>, NaEdit) {
+    // A member whose two endpoints sit in different zones (`c.13`..`c.*4`)
+    // straddles a CDS/UTR seam (#1816). Its zoned positions live on independent
+    // counters, so the `start > end` insertion probe and the `end == start`
+    // substitution probe below — both comparisons of *zoned* values — are
+    // meaningless for it and must be skipped. Such a member spans two or more
+    // nucleotides across the seam, so it is always a `delins` (or, with no
+    // payload, a `del`); it is never a one-nucleotide substitution and never a
+    // boundary insertion, both of which sit within a single zone.
+    let straddles = merged.region != merged.end_region;
     // A duplication is decided by the *builder*, from the reference, not by the
     // two span lengths below — `dup` and the `ins` of the same bases have the
     // same lengths and `duplication.md:18` says only one of them is allowed.
@@ -1836,7 +1867,7 @@ fn build_naedit<P>(
             length: None,
             uncertain_extent: None,
         }
-    } else if merged.start > merged.end {
+    } else if !straddles && merged.start > merged.end {
         debug_assert_eq!(
             merged.start,
             merged.end + 1,
@@ -1870,7 +1901,7 @@ fn build_naedit<P>(
             length: None,
         }
     } else if let (true, 1, Some(reference)) = (
-        merged.end == merged.start,
+        !straddles && merged.end == merged.start,
         merged.alt.len(),
         merged.ref_base,
     ) {
@@ -1896,15 +1927,26 @@ fn build_naedit<P>(
             substitution_reference: None,
         }
     };
-    let (lo, hi) = if merged.start > merged.end {
-        (merged.end, merged.start)
+    // A straddling member is already in flat 5'→3' order (`start` in the 5'-ward
+    // zone, `end` in the 3'-ward one), so it is emitted endpoint-for-endpoint
+    // with each in its own region — no swap, which on the zoned counters would
+    // scramble `c.13_*4` into `c.*4_13`. Every single-zone member keeps the
+    // existing min/max ordering, which also carries the insertion encoding
+    // (`start > end`).
+    let interval = if straddles {
+        Interval::new(
+            to_pos(merged.region, merged.start),
+            to_pos(merged.end_region, merged.end),
+        )
     } else {
-        (merged.start, merged.end)
+        let (lo, hi) = if merged.start > merged.end {
+            (merged.end, merged.start)
+        } else {
+            (merged.start, merged.end)
+        };
+        Interval::new(to_pos(merged.region, lo), to_pos(merged.region, hi))
     };
-    (
-        Interval::new(to_pos(merged.region, lo), to_pos(merged.region, hi)),
-        edit,
-    )
+    (interval, edit)
 }
 
 /// Coalesce runs of consecutive-residue changes in a **cis protein allele**
@@ -11270,20 +11312,27 @@ pub(crate) fn denoted_bases(
 /// A no-op whenever the anchor sits inside the CDS, which is every group the
 /// extension did not admit, so this cannot move an existing row.
 ///
-/// # A straddling anchor is refused, not truncated
+/// # A straddling anchor is built, one region per endpoint (#1816)
 ///
-/// [`Anchor`] carries **one** [`Region`] for both endpoints, so a piece running
-/// from `c.<cds_len-1>` to `c.*2` has no anchor to be. Refusing hands the group
-/// back to the per-member pipeline, which is exactly what happened to it before
-/// this extension existed — so the refusal is the status quo for that shape and
-/// not a new decline. Widening `Anchor` to a region per endpoint would let it be
-/// built and is left to #1816 with the 5'UTR half, because the two want the same
-/// change and measuring them together is cheaper than twice.
+/// A piece running from `c.<cds_len-1>` to `c.*2` (or, with the 5'UTR fold,
+/// `c.-1` to `c.1`) has endpoints in two zones. [`Anchor`] now carries a
+/// [`Region`] for each — `region` for the start, `end_region` for the end — so
+/// such a member is *built* rather than declined: each endpoint keeps the zone
+/// [`unfold_extended_body`] names for it, and [`build_naedit`] renders `c.13_*4`
+/// with a `*` on the end alone. This is the `c.` half of the convergence the
+/// `g.` axis already has (`#1816`; the spelling is a rendering of one flat
+/// transcript span, `cross-zone-c-positions-order-by-transcript-coordinate`).
+/// Only the `c.` axis has a CDS/3'UTR seam to straddle — `cds_end_axis` is
+/// `Some` for `CisKind::Cds` alone (`n.` numbering is flat, with no `*` zone).
 ///
-/// The insertion form is why the endpoints are read independently rather than
-/// through an ordering test: [`Anchor`]'s insertion shape is `start > end`
-/// (`build_naedit` reads the gap from the raw endpoints), so a `start <= end`
-/// precondition would silently exclude every derived insertion.
+/// The endpoints are read independently rather than through an ordering test for
+/// two reasons that now compound: [`Anchor`]'s insertion shape is `start > end`
+/// (`build_naedit` reads the gap from the raw endpoints), and a straddling
+/// member's two zoned positions live on independent counters (`c.13` vs `c.*4`),
+/// so neither an ordering nor an equality of the *zoned* values means anything.
+/// The **flat** order is what holds: `anchor.start <= anchor.end` on the extended
+/// body by construction, so `start` is always the 5'-ward endpoint and `end` the
+/// 3'-ward one, and `build_naedit` emits them in that order without a swap.
 fn render_on_its_own_region(
     anchor: Anchor,
     body: Region,
@@ -11291,11 +11340,9 @@ fn render_on_its_own_region(
 ) -> Option<Anchor> {
     let (start_region, start) = unfold_extended_body(anchor.start, body, cds_end_axis);
     let (end_region, end) = unfold_extended_body(anchor.end, body, cds_end_axis);
-    if start_region != end_region {
-        return None;
-    }
     Some(Anchor {
         region: start_region,
+        end_region,
         start,
         end,
         ..anchor
@@ -11368,6 +11415,7 @@ fn anchor_for_piece(
         .and_then(|byte| Base::from_char(byte as char));
     Some(Anchor {
         region: body,
+        end_region: body,
         start,
         end,
         alt,
@@ -11431,6 +11479,7 @@ fn duplication_anchor(
     }
     Some(Anchor {
         region: body,
+        end_region: body,
         start: w_lo + source_start as i64,
         end: w_lo + piece.ref_start as i64 - 1,
         // A `dup` names its source bases by span; there is nothing to insert.
@@ -11499,6 +11548,7 @@ fn boundary_delins_anchor(
     let position = w_lo + offset as i64;
     Some(Anchor {
         region: body,
+        end_region: body,
         start: position,
         end: position,
         alt: bases,
@@ -11560,6 +11610,7 @@ fn cds_end_delins_anchor(
     let bases = boundary_delins_bases(ref_bytes, alt, anchor_1b, BoundarySide::ThreePrime)?;
     Some(Anchor {
         region: body,
+        end_region: body,
         start: cds_end_axis,
         end: cds_end_axis,
         alt: bases,
@@ -15776,6 +15827,7 @@ mod tests {
         // Insertion-shaped anchor (`start == end + 1`) with an empty payload.
         let anchor = Anchor {
             region: Region::Genome,
+            end_region: Region::Genome,
             start: 1010,
             end: 1009,
             alt: Vec::new(),
@@ -15797,6 +15849,7 @@ mod tests {
     fn non_empty_insertion_anchor_still_builds_an_insertion() {
         let anchor = Anchor {
             region: Region::Genome,
+            end_region: Region::Genome,
             start: 1010,
             end: 1009,
             alt: vec![Base::A],

--- a/tests/it/issue_1536_cds_boundary_delins.rs
+++ b/tests/it/issue_1536_cds_boundary_delins.rs
@@ -704,56 +704,50 @@ fn one_and_two_base_payloads() -> Vec<String> {
     payloads
 }
 
-/// The multi-member spelling of one variant does **not** yet converge with its
-/// `inv` spelling once the members straddle `cds_end` — deferred to #1816.
+/// The multi-member spelling of one variant converges with its `inv` spelling
+/// once the members straddle `cds_end` — **closed by #1816**.
 ///
-/// # RED BY DESIGN AGAINST #1816 SINCE #1703 — the canonical form flipped, and
-/// the multi-member spelling cannot yet reach it across the boundary
+/// # CLOSED BY #1816 — the straddling anchor is now built, one region per endpoint
 ///
-/// #1650 (`merge::ExtendedBody`, folding `c.*N` onto `cds_len + N`) made this
-/// converge, on the **split** — `general.md:56` ranked the two substitution
-/// competitors above the inversion, so `c.13_*4inv` reduced to
-/// `c.[13_15delinsCTA;*2T>G;*4G>T]` and the multi-member spelling was already
-/// there.
+/// #1650 (`merge::ExtendedBody`, folding `c.*N` onto `cds_len + N`) first made
+/// this converge on the **split**, because `general.md:56` then ranked the two
+/// substitution competitors above the inversion. `rulings[whole-span-reverse-
+/// complement-types-as-inv]` (`DNA/inversion.md:5`, 2026-08-13, #1703)
+/// **overturns #1230's competitor-type ranking**: an exact whole-span reverse
+/// complement is typed `inv` uniformly, so the canonical form of this variant is
+/// `c.13_*4inv`, and `the_boundary_class_converges_on_the_inv_from_a_single_block`
+/// pins the two single-block spellings reaching it.
 ///
-/// `rulings[whole-span-reverse-complement-types-as-inv]` (`DNA/inversion.md:5`,
-/// 2026-08-13, #1703) **overturns #1230's competitor-type ranking**: an exact
-/// whole-span reverse complement is typed `inv` uniformly, so the canonical form
-/// of this variant is now `c.13_*4inv`. Two spellings reach it —
-/// `c.13_*4inv` stays `inv`, and the single `c.13_*4delinsCTACGGAT` is typed
-/// `inv` by the per-member pipeline — and
-/// `the_boundary_class_converges_on_the_inv_from_a_single_block` pins that.
-///
-/// The MULTI-MEMBER spelling does not converge, and the cause is a pre-existing
-/// limitation the inversion ruling explicitly leaves untouched ("where a
-/// whole-span reverse complement's boundaries fall … untouched"). To merge the
-/// three members into one `inv`, `canonicalize_from_sequence` derives the whole
-/// block correctly — `coalesce_inversion_runs` produces the single
-/// `13_*4inv` piece — but `rebuild_members` → `render_on_its_own_region` then
-/// **refuses a straddling anchor**: `Anchor` carries one `Region` for both
-/// endpoints, and a member running from `c.<cds_len-1>` to `c.*2` has none. That
-/// refusal, and its fix (widen `Anchor` to a region per endpoint), are the
-/// deferred **#1816**. So the group falls back to the per-member pipeline, which
-/// normalizes each member in isolation and cannot merge them — leaving the split.
-///
-/// It is `#[ignore]`d, red by design against #1816, exactly like this module's
-/// other capability-gap guards (the #1536 and #1650 doc comments above). The
-/// CDS-interior twin — where no anchor straddles — DOES converge on the `inv`
-/// today and is pinned live by `the_multi_member_spelling_converges_inside_the_cds`,
-/// so the mechanism is proven and only the straddling-anchor rendering is owed.
+/// The MULTI-MEMBER spelling used to be left behind: `canonicalize_from_sequence`
+/// derives the whole block correctly (`coalesce_inversion_runs` produces the
+/// single `13_*4inv` piece), but `rebuild_members` → `render_on_its_own_region`
+/// **refused a straddling anchor** — `Anchor` carried one `Region` for both
+/// endpoints, and a member running from `c.<cds_len-1>` to `c.*2` had none. #1816
+/// gives `Anchor` a region per endpoint (`region` for the start, `end_region` for
+/// the end), so `render_on_its_own_region` now *builds* the straddling member and
+/// `build_naedit` names each endpoint in its own zone — `c.13_*4`, `*` on the end
+/// alone. The group merges, the per-member pipeline types the whole-span
+/// reverse complement as `inv`, and the two spellings converge. Its CDS-interior
+/// twin `the_multi_member_spelling_converges_inside_the_cds` remains the live
+/// control proving the merge mechanism when nothing straddles.
 #[test]
-#[ignore = "#1816: rendering a merged whole-span inv member that straddles the \
-            CDS/3'UTR boundary needs a per-endpoint-region Anchor; until then the \
-            multi-member spelling cannot converge on the c.13_*4inv the ruling makes canonical"]
 fn a_multi_member_spelling_converges_with_its_inv_spelling_across_a_boundary() {
     let provider = transcript_provider(WIDE_CORE, 11, 26);
     let allele = "NM_TEST.1:c.[13_15delinsCTA;*2T>G;*4G>T]";
     let inv = "NM_TEST.1:c.13_*4inv";
     for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        let from_allele = normalize(&provider, allele, direction);
         assert_eq!(
-            normalize(&provider, allele, direction),
+            from_allele,
             normalize(&provider, inv, direction),
             "{allele} and {inv} denote one variant and must converge"
+        );
+        // Pin the exact canonical form here, not only transitively through the
+        // sibling `the_boundary_class_...`: a mutation making both spellings equal
+        // but wrong would satisfy the convergence check above on its own.
+        assert_eq!(
+            from_allele, inv,
+            "the multi-member spelling must reach the c.13_*4inv the ruling makes canonical"
         );
     }
 }
@@ -774,10 +768,11 @@ fn a_multi_member_spelling_converges_with_its_inv_spelling_across_a_boundary() {
 /// SINGLE-BLOCK spellings reach it — `c.13_*4inv` stays `inv`, and the single
 /// `c.13_*4delinsCTACGGAT` is typed `inv` by the per-member pipeline.
 ///
-/// The MULTI-MEMBER spelling `c.[13_15delinsCTA;*2T>G;*4G>T]` is deliberately not
-/// in this set: it cannot yet reach the `inv` across the CDS/3'UTR boundary — a
-/// straddling-`Anchor` limitation deferred to #1816 — and that gap is pinned,
-/// red-by-design, by `a_multi_member_spelling_converges_with_its_inv_spelling_across_a_boundary`.
+/// The MULTI-MEMBER spelling `c.[13_15delinsCTA;*2T>G;*4G>T]` is not in this
+/// set because it has its own guard: #1816 gave `Anchor` a region per endpoint,
+/// so it now reaches the same `inv` across the CDS/3'UTR boundary, and
+/// `a_multi_member_spelling_converges_with_its_inv_spelling_across_a_boundary`
+/// pins that convergence directly.
 #[test]
 fn the_boundary_class_converges_on_the_inv_from_a_single_block() {
     let provider = transcript_provider(WIDE_CORE, 11, 26);

--- a/tests/it/issue_920_allele_sub_collapse.rs
+++ b/tests/it/issue_920_allele_sub_collapse.rs
@@ -63,21 +63,28 @@ fn tx_body_overlapping_del_ins_collapses_to_sub() {
     assert_eq!(result, "NR_TEST.1:n.8A>C");
 }
 
-/// Refusal: a group containing a 3'UTR (`c.*N`) member is outside the positive
-/// CDS body, so the whole collapse is refused (all-or-nothing) and the allele
-/// is left as its separate members rather than collapsing to a substitution.
+/// A group that straddles the CDS/3'UTR seam now derives its sequence-canonical
+/// form instead of being refused (#1816, combined with #2174's contiguous-run
+/// collapse).
 ///
 /// `core = "GGGGGGGACGCC"`, `cds_start = 1`, `cds_end = 9`: `c.1..c.9` are the
-/// CDS body and `c.*1` is the first 3'UTR base. `c.[7_8insC;*1del]` mixes a
-/// CDS-body insertion with a 3'UTR deletion — no collapse.
+/// CDS body and `c.*1` is the first 3'UTR base. `c.[7_8insC;*1del]` denotes
+/// `GGGGGGGCACCC`, whose diff against the reference is **three consecutive
+/// changed bases** at `c.8`/`c.9`/`c.*1` (`A→C`, `C→A`, `G→C`) — one spanning
+/// `delins` by `delins.md:16`, not two members separated by an unchanged base.
+///
+/// This used to be refused ("all-or-nothing, because the 3'UTR member is outside
+/// the positive CDS body"), which was the straddle-anchor limitation, not a
+/// principle: `Anchor` carried one `Region`, so a member spanning `c.9_*1` had
+/// no anchor. #1816 gives `Anchor` a region per endpoint, so the derivation
+/// renders the spanning `delins` across the seam — the same sequence-first
+/// canonical form (`canonical-form-choice-when-both-legal`) the CDS-interior
+/// twins above collapse to. Meaning-preserving: both spellings denote
+/// `GGGGGGGCACCC`. The result is a run of consecutive changes, so the
+/// separation-two-or-more census is untouched.
 #[test]
-fn utr_member_refuses_collapse() {
+fn utr_straddle_collapses_to_its_spanning_delins() {
     let p = SyntheticBuilder::cds("GGGGGGGACGCC", 1, 9, Strand::Plus).build();
     let result = normalize_to_string(p, "NM_TEST.1:c.[7_8insC;*1del]");
-    // The allele must be returned unchanged — the 3'UTR member forces the
-    // whole collapse to be refused (all-or-nothing), so both members survive
-    // verbatim rather than collapsing to a single substitution. Pin the exact
-    // string so a regression that reorders, drops, or partially collapses a
-    // member is caught (not just the presence of a `;`).
-    assert_eq!(result, "NM_TEST.1:c.[7_8insC;*1del]");
+    assert_eq!(result, "NM_TEST.1:c.8_*1delinsCAC");
 }

--- a/tests/it/merge_consecutive_edits_tests.rs
+++ b/tests/it/merge_consecutive_edits_tests.rs
@@ -859,19 +859,42 @@ fn test_merge_3utr_consecutive_subs_rna() {
 }
 
 #[test]
-fn test_no_merge_3utr_cds_boundary() {
-    // The c.40 (last CDS base) ↔ c.*1 (first 3'UTR base) crossing must
-    // NOT merge — there is no HGVS range syntax spanning the CDS/3'UTR
-    // boundary (`c.40_*1` does not exist), even though the positions are
-    // physically adjacent in the transcript. Companion to the existing
-    // `test_no_merge_utr_boundary` (5'UTR↔CDS).
+fn test_merge_3utr_cds_boundary_inv() {
+    // The c.40 (last CDS base) ↔ c.*1 (first 3'UTR base) crossing DOES merge
+    // (#1816). This test formerly asserted the opposite on the premise that
+    // "`c.40_*1` does not exist" as HGVS syntax — a premise `merge::join_pos`'s
+    // own doc records as false: `c.15_*1del` deletes across a stop codon and is
+    // "an ordinary and common real variant", and `consultation/SVD-WG001.md:37`
+    // writes out `c.-1_1`. A `c.` number is a flat transcript offset and the
+    // zone spelling is a rendering (`c-and-n-positions-are-flat-transcript-offsets`,
+    // `cross-zone-c-positions-order-by-transcript-coordinate`), so a member
+    // straddling the seam is built with `*` on the end endpoint alone.
+    //
+    // Here the pair is a whole-span reverse complement — ref `CA` (c.40=C,
+    // c.*1=A), alt `TG` = revcomp(`CA`) — so it types as one `inv`, converging
+    // with the g.-axis form. The 5'UTR companion `test_no_merge_utr_boundary`
+    // stays as-is: the 5'UTR fold is a later part of #1816.
     let result = normalize_with_provider(
         provider_with_utr_transcript(),
         "NM_TESTUTR.1:c.[40C>T;*1A>G]",
     );
-    assert!(result.contains("40C>T"), "got {}", result);
-    assert!(result.contains("*1A>G"), "got {}", result);
-    assert!(!result.contains("delins"), "got {}", result);
+    assert_eq!(result, "NM_TESTUTR.1:c.40_*1inv", "got {}", result);
+}
+
+#[test]
+fn test_merge_3utr_cds_boundary_deletion() {
+    // The deletion arm of the same #1816 straddle rendering: two adjacent
+    // single-base deletions on either side of the CDS/3'UTR seam merge into one
+    // spanning `del`, `*` on the end endpoint alone — the non-`inv` path
+    // `test_merge_3utr_cds_boundary_inv` does not exercise (that one re-types the
+    // delins to `inv`; a pure deletion has no payload to re-type). Ref at c.40 is
+    // `C` (pos 50) and at c.*1 is `A` (pos 51); the two are not part of a repeat,
+    // so the merged deletion does not shuffle off the seam.
+    let result = normalize_with_provider(
+        provider_with_utr_transcript(),
+        "NM_TESTUTR.1:c.[40del;*1del]",
+    );
+    assert_eq!(result, "NM_TESTUTR.1:c.40_*1del", "got {}", result);
 }
 
 // =====================================================================

--- a/tests/it/spec_conformance_axis.rs
+++ b/tests/it/spec_conformance_axis.rs
@@ -1054,9 +1054,25 @@ pub(crate) const THREE_PRIME: Census = Census {
     // from the branches' deltas — and the move is the same 40 families it was on
     // the pre-flip base, with the same 22 + 12 + 6 breakdown, so the flip, #1610
     // and this change reach disjoint populations.
-    converged: 11_056,
-    split_two: 652,
-    split_three: 152,
+    //
+    // # #1816 — the CDS/3'UTR straddle anchor (per-endpoint `Anchor`)
+    //
+    // `merge::render_on_its_own_region` no longer refuses a member whose two
+    // endpoints fall in different zones: `Anchor` now carries a region per
+    // endpoint, so a piece running from `c.<cds_len-1>` to `c.*2` is *built* as
+    // the spanning `c.N_*M` member the `g.` axis already produces, and the two
+    // spellings of such a variant converge. Families move out of `split_two`
+    // (-20) and `split_three` (-24) and into `converged` (+44); `split_more` is
+    // unchanged and the two decreases sum exactly to the increase. The move is
+    // meaning-preserving: `sequence_changed` holds at 4 and
+    // `outputs_denoting_no_sequence` at 10 (verified against the pre-#1816 base,
+    // identical), `coding_axis_separation_two_or_more_merges` holds at 19 (no new
+    // `general.md:34` deviation), and every moved family is a CDS/3'UTR straddle.
+    // The 5'UTR half of #1816 is a later change and moves the 5'-direction
+    // `split_more` separately.
+    converged: 11_100,
+    split_two: 632,
+    split_three: 128,
     split_more: 22,
     underdetermined: 0,
     // -- idempotency --
@@ -1187,7 +1203,14 @@ pub(crate) const FIVE_PRIME: Census = Census {
     // same reason stated there, and re-measured on each rebase rather than
     // composed — the move is the same 48 families it was on the pre-flip base,
     // with the same 22 + 26 + 0 breakdown.
-    converged: 10_805,
+    //
+    // #1816 (the CDS/3'UTR straddle anchor — see the `#1816` block on
+    // [`THREE_PRIME`]'s `converged`) moves it a further +46: the straddle families
+    // converge in the 5'-shuffle direction too. The decreases are `split_two` -22,
+    // `split_three` -22, `split_more` -2, summing exactly to +46, and the move is
+    // meaning-preserving (`sequence_changed` holds at 0,
+    // `coding_axis_separation_two_or_more_merges` at 19).
+    converged: 10_851,
     // Re-blessed by #1649, rank-2 only, same as [`THREE_PRIME`] — and measured on
     // the rebased branch rather than composed. Every moved family goes straight
     // to `converged`, so these three deltas sum exactly to `converged`'s:
@@ -1246,9 +1269,12 @@ pub(crate) const FIVE_PRIME: Census = Census {
     // gate): those two ids are the only ones removed, none added, and 3' is
     // byte-identical on the same diff (its `THREE_PRIME` pins are untouched by
     // this change).
-    split_two: 955,
-    split_three: 98,
-    split_more: 24,
+    // #1816 moves all three DOWN — `split_two` -22, `split_three` -22,
+    // `split_more` -2 — as the CDS/3'UTR straddle families converge; the three
+    // sum to `converged`'s +46 above.
+    split_two: 933,
+    split_three: 76,
+    split_more: 22,
     underdetermined: 0,
     // Re-blessed DOWN to zero by #1650, the same four `cds-end` families as at 3'.
     non_idempotent_outputs: 0,


### PR DESCRIPTION
## Summary

A cis allele whose members straddle the CDS/3'UTR seam (`c.<cds_len>_*N`) was left split while the identical block wholly inside the CDS converged — `render_on_its_own_region` refused to build a member whose two endpoints resolve to different zones, because `Anchor` carried a single `Region`. So a piece from `c.<cds_len-1>` to `c.*2` had no anchor and fell back to the per-member pipeline, leaving `[delins;inv]` where the g. axis produces one spanning `inv`.

This gives `Anchor` a `Region` per endpoint and builds the straddling member — `c.N_*M`, `*` on the end alone — the spanning form the g. axis already produces. It closes the **CDS/3'UTR straddle confluence gaps** disclosed as open in #2184 (the 76 non-confluent groups) and, more broadly, lets the sequence-first derivation produce the sequence-canonical form for every straddle-touching coding input. The 5'UTR straddle and the pure-UTR payload-coincidence merges are a follow-up.

Part of #1816.

## What changed

- `Anchor` gains `end_region` (the end endpoint's region; equals `region` for every single-region member — all but the straddle path).
- `render_on_its_own_region` builds the straddling member instead of declining on a region mismatch.
- `build_naedit` renders a straddle endpoint-for-endpoint, each in its own zone, skipping the single-zone insertion/substitution shortcuts (a straddle spans ≥2 nt across the seam → `delins`/`del`, never a 1-nt substitution or boundary insertion).

## Grounding

The spanning form is the decided canonical: a `c.` number is a flat transcript offset with the zone label a rendering (`c-and-n-positions-are-flat-transcript-offsets`, `cross-zone-c-positions-order-by-transcript-coordinate`), and a whole-span reverse complement types as one `inv` (`whole-span-reverse-complement-types-as-inv`, #1524 / `delins.md:16`). This brings c./n. into line with g.

## Tests

- Un-ignored `a_multi_member_spelling_converges_with_its_inv_spelling_across_a_boundary` (now green), strengthened to pin the exact `c.13_*4inv`.
- Flipped `test_no_merge_3utr_cds_boundary` → `test_merge_3utr_cds_boundary_inv` (its premise "`c.40_*1` does not exist" is documented-false in `merge::join_pos`); added `test_merge_3utr_cds_boundary_deletion` for the deletion arm.
- Updated `issue_920::utr_member_refuses_collapse` → `utr_straddle_collapses_to_its_spanning_delins`: with #2174's contiguous-run collapse, a UTR-straddling group now derives its sequence-canonical spanning `delins` (`c.[7_8insC;*1del]` → `c.8_*1delinsCAC`, both denote `GGGGGGGCACCC`) instead of refusing.
- Re-blessed the THREE_PRIME/FIVE_PRIME conformance censuses (ratchet-compliant, justified inline): converged +44/+46, every split figure down; `sequence_changed` and the separation-≥2 counter unchanged at 19.

## Representation-Change

Representation-Change: 1338 rows move, 0 denote different bases. All are coding-axis and touch the CDS/3'UTR seam; 843 merge (straddle members → the spanning form), 376 split (a previously-masked spanning delins re-derives to its canonical partition where the sequence has an interior unchanged base — consistent with #2174), 119 retype. 742 were previously-accepted inputs (a migration for stored strings); 596 were not previously fixed points. Zero involve a 5'UTR straddle (that fold is a follow-up). Measured with `dump_normalized_corpus --verify-spdi` over the churn-enriched corpus, so the 1.4% rate is of the affected shape families, not a library-wide figure; the three surprising re-shapes (a dup/repeat beside a 3'UTR sub re-deriving to a pure-`c.*N` delins) were hand-verified to denote identical SPDI.
