### PR TITLE
fix(normalize): coalesce a contiguous run beside a distant cis member

### DIFF
--- a/examples/dump_normalized_corpus.rs
+++ b/examples/dump_normalized_corpus.rs
@@ -157,7 +157,7 @@
 //! ## One family knows its own ground truth, and that buys three oracles
 //!
 //! Everything above measures **movement** — two dumps, one diff — and never
-//! whether an output is *right*. Seventeen of the twenty-one families cannot be asked:
+//! whether an output is *right*. Eighteen of the twenty-two families cannot be asked:
 //! they are sets of descriptions with no record of what the description was meant
 //! to denote. `separated_revcomp_runs` is built the other way round, choosing the
 //! alternate first and deriving the reference around it, so `(reference,
@@ -349,7 +349,7 @@ enum SpdiVerdict {
 /// one panicking row must not take the whole dump with it.
 ///
 /// The provider is built from [`Row::core`] and **not** from `Row::reference`
-/// (#1624). Those two are the same string for seventeen of the twenty-one families,
+/// (#1624). Those two are the same string for eighteen of the twenty-two families,
 /// which is what made reading the wrong one survive review: the two families
 /// whose `reference` column is a *label* — `long_block_inversion` and
 /// `separated_revcomp_runs` — were verified against the label itself. On the
@@ -519,7 +519,7 @@ fn report_partition_declines() {
 /// re-running the old code.
 struct Row {
     /// The dump's `reference` column, and part of the row's identity. For
-    /// seventeen of the twenty-one families this **is** the reference sequence; for
+    /// eighteen of the twenty-two families this **is** the reference sequence; for
     /// the two that bring their own designed references it is a label, because a
     /// kilobase core repeated on every row is not a column anyone can read.
     reference: String,
@@ -672,6 +672,24 @@ const FAMILIES: &[(&str, &str)] = &[
         "#1946 — an authored repeat that survives as one member of a two-member allele, \
          which is the only shape that reaches `lower_repeat_edits`",
     ),
+    // Another instance of the corpus-blindness class, and the one #2192 hit. Every
+    // family above pairs members so that no single member is a **multi-column
+    // contiguous run** that the solid-run collapse would coalesce: the multi-member
+    // ones are lone substitutions (`three_member_allele`), disjoint spans
+    // (`nested_spans`, `partial_overlap_spans`) or a span beside a point change
+    // (`del_plus_sub`, `dup_plus_sub`). So no row in this corpus has ever placed a
+    // coalescible run beside a **distant** cis member, which is exactly the geometry
+    // #2192 is about: a second member stretches the whole-variant hull across a gap,
+    // the changed-column set goes non-contiguous, and `coalesce_solid_run`'s
+    // contiguity gate declines — the #2174 collapse reaching only single-run
+    // alleles. Measuring `0 moved` off a corpus that cannot build run-count >= 2
+    // would have been a claim about the corpus.
+    (
+        "run_beside_a_distant_member",
+        "#2192 — a contiguous coalescible run (adjacent changes) beside a distant cis member \
+         the whole-hull collapse cannot reach; the run coalesces per-run once a sibling \
+         makes the hull non-contiguous",
+    ),
 ];
 
 /// The shape families drawn against the **protein** cores (#1606).
@@ -716,7 +734,7 @@ const PROTEIN_FAMILIES: &[(&str, &str)] = &[
 /// The family drawn against the **long** cores, and the one shape in this file
 /// whose point is its size rather than its geometry (#1460).
 ///
-/// Kept out of `FAMILIES` on purpose. The seventeen families there are crossed with
+/// Kept out of `FAMILIES` on purpose. The eighteen families there are crossed with
 /// every short core, and crossing a kilobase core with all of them would multiply
 /// the dump cost while adding no coverage: `MAX_SPLIT_BLOCK` gates on the *length*
 /// of the block being partitioned, not on how its members are arranged.
@@ -2410,6 +2428,65 @@ fn inputs_for(family: &str, axis: &str, core: &str) -> Vec<String> {
                     ));
                 }
             }
+            // A contiguous coalescible run beside a DISTANT cis member (#2192).
+            // The run is a four-base LEFT ROTATION spelled in its fragmented
+            // `[del; ins]` form: deleting `core[a]` and re-inserting it 3' of the
+            // window denotes `core[a..a+4]` rotated one place, an equal-length,
+            // all-columns-changed block that `coalesce_solid_run` collapses to one
+            // `delins`. A distant substitution at the far end of the core stretches
+            // the whole-variant hull across a wide gap, so baseline's whole-hull
+            // collapse sees a non-contiguous changed-column set and declines —
+            // keeping the rotation fragmented — while the per-run pass coalesces it.
+            //
+            // Built at a FIXED four-base window rather than the sliding `s..s+4`
+            // one: the left rotation changes every column only when no cyclically
+            // adjacent pair of the window is equal (`ATAT` qualifies with two
+            // distinct bases, `AATA` does not), and the distant member needs a gap
+            // wider than the five-base window can express. Emits nothing for a core
+            // with no such window — reported honestly rather than as a zero (see the
+            // family's comment in `FAMILIES`).
+            "run_beside_a_distant_member" => {
+                if s != 0 {
+                    continue;
+                }
+                // A left rotation of `core[a..a+4]` changes column `j` iff
+                // `core[a+j] != core[a+(j+1)%4]`, so every column changes exactly
+                // when no cyclically adjacent pair is equal.
+                let clean_rotation =
+                    |a: usize| (0..4).all(|j| bytes[a + j] != bytes[a + (j + 1) % 4]);
+                // Room for the four-base window and a distant member past a gap.
+                if let Some(a) = (0..bytes.len().saturating_sub(6)).find(|&a| clean_rotation(a)) {
+                    let dist = bytes.len() - 1;
+                    out.push(format!(
+                        "{prefix}[{}del;{}_{}ins{};{}{}>{}]",
+                        p(a),
+                        p(a + 3),
+                        p(a + 4),
+                        base(a),
+                        p(dist),
+                        base(dist),
+                        other(dist)
+                    ));
+                    // The already-coalesced spelling of the same variant beside the
+                    // same distant member. On `main` this ALSO fragments — the
+                    // whole-hull collapse re-derives it as `[del; dup]` — so it is a
+                    // second moving row, not a fixed point; its value is that the fix
+                    // keeps an input already written as one `delins` coalesced rather
+                    // than re-fragmenting it.
+                    let rot: String = (1..4)
+                        .map(|i| base(a + i))
+                        .chain(std::iter::once(base(a)))
+                        .collect();
+                    out.push(format!(
+                        "{prefix}[{}_{}delins{rot};{}{}>{}]",
+                        p(a),
+                        p(a + 3),
+                        p(dist),
+                        base(dist),
+                        other(dist)
+                    ));
+                }
+            }
             _ => unreachable!("unknown family {family}"),
         }
     }
@@ -2791,7 +2868,7 @@ fn compare(before: &PathBuf, after: &PathBuf) -> Result<String, String> {
 mod tests {
     use super::*;
 
-    /// A row of one of the seventeen sequence-keyed families, where the
+    /// A row of one of the eighteen sequence-keyed families, where the
     /// `reference` column and the sequence are the same string.
     fn row(axis: &'static str, reference: &str, input: &str, output: &str) -> Row {
         Row {
@@ -2889,7 +2966,7 @@ mod tests {
     /// Every row carries the reference **sequence** it was drawn against, which
     /// for two families is not what its `reference` column says (#1624).
     ///
-    /// The two views agree on seventeen of the twenty-one families, and that is
+    /// The two views agree on eighteen of the twenty-two families, and that is
     /// precisely what made the verify pass's confusion of them survive review —
     /// a bug that only manifests on `long_block_inversion` and
     /// `separated_revcomp_runs` is a bug in 286 rows out of 78,298. So this pins
@@ -4469,6 +4546,64 @@ mod tests {
         );
     }
 
+    /// `run_beside_a_distant_member` accounts for the cores it drops.
+    ///
+    /// The arm emits a pair of rows only for a core carrying a clean four-base left
+    /// rotation with room for a distant member — a window `core[a..a+4]` with no
+    /// cyclically adjacent pair equal, `a` in `0..len-6`. It emits **nothing** for a
+    /// core with no such window (homopolymer-heavy cores have none). Nothing else
+    /// records that drop, so without this guard a generator or seed change that
+    /// shrank the covered set would leave the family measuring a smaller population
+    /// while its `0 moved` still read as a fixed-point measurement — the exact
+    /// structural-zero trap the generator doctrine names. Both numbers are pinned so
+    /// a shift in either direction fails here rather than passing silently.
+    #[test]
+    fn the_distant_member_family_accounts_for_the_cores_it_drops() {
+        let has_clean_rotation = |core: &str| {
+            let b = core.as_bytes();
+            (0..b.len().saturating_sub(6)).any(|a| (0..4).all(|j| b[a + j] != b[a + (j + 1) % 4]))
+        };
+        let (mut emitted, mut dropped) = (0, 0);
+        for core in corpus_sequences(24) {
+            let rows = inputs_for("run_beside_a_distant_member", "g", &core);
+            if has_clean_rotation(&core) {
+                emitted += 1;
+                assert_eq!(
+                    rows.len(),
+                    2,
+                    "{core} has a clean rotation window but did not emit both rows"
+                );
+                for row in &rows {
+                    // Each row carries the distant member (`;` … `>`) beside the run,
+                    // which is the whole geometry the family exists to measure.
+                    assert!(
+                        row.contains(';') && row.contains('>'),
+                        "the distant member is what makes this family the #2192 shape: {row}"
+                    );
+                }
+            } else {
+                dropped += 1;
+                assert!(
+                    rows.is_empty(),
+                    "{core} has no clean rotation window yet emitted {rows:?}"
+                );
+            }
+        }
+        assert_eq!(
+            emitted, 43,
+            "clean-rotation coverage moved; the generator or seed count changed"
+        );
+        assert_eq!(
+            dropped, 5,
+            "the dropped-core count moved; a core gained or lost a clean rotation window"
+        );
+        assert_eq!(
+            emitted + dropped,
+            corpus_sequences(24).len(),
+            "every core is either covered or accounted as dropped"
+        );
+    }
+
     /// `delins_hiding_an_inversion` emits both spellings, with the trailing piece an
     /// exact reverse complement of its own span.
     ///
@@ -4813,7 +4948,7 @@ mod tests {
     //
     // Everything above measures *movement*: two dumps, one diff, "did this change
     // the output". Nothing above ever asks whether an output is **right**, and for
-    // seventeen of the twenty-one families it cannot — they are sets of descriptions,
+    // eighteen of the twenty-two families it cannot — they are sets of descriptions,
     // with no record of what the description was meant to denote.
     //
     // `separated_revcomp_runs` is built the other way round: the generator picks

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3848,9 +3848,10 @@ fn canonicalize_from_sequence_with_rule<P: ReferenceProvider>(
     }
 
     // Which rule cuts the block. `FERRO_PARTITION` unset — the only configuration
-    // that ships — takes the `Live` arm, so this is `partition_block` and nothing
-    // else. The other arms fall back to it when their splitter declines, rather
-    // than abandoning the canonicalization, so a bake-off run measures the
+    // that ships — takes the `CanonicalCoalesced` arm ([`DEFAULT_PARTITION_RULE`]),
+    // so this is `partition_block_canonical`, falling back to `partition_block`
+    // when its splitter declines. Every non-`Live` arm falls back the same way
+    // rather than abandoning the canonicalization, so a bake-off run measures the
     // partitioners and not their decline rates — and every such fallback is
     // counted, so the run can tell "the candidate agreed" from "the candidate
     // was not asked" (see `PartitionDeclineCounts`).
@@ -4222,8 +4223,10 @@ fn canonicalize_from_sequence_with_rule<P: ReferenceProvider>(
         // survives), then collapse the residual solid run into one `delins`.
         // Same scope as the sibling above (canonical arms, DNA axis).
         if rule.cuts_with_canonical() && AxisFrame::is_dna(kind) {
-            peel_tandem_dup_beside_change(pieces, &ref_bytes);
-            coalesce_solid_run(pieces, &ref_bytes);
+            coalesce_by_run(pieces, &ref_bytes, |run, reference| {
+                peel_tandem_dup_beside_change(run, reference);
+                coalesce_solid_run(run, reference);
+            });
         }
         // The whole-block rule generalised to every maximal run of consecutive
         // pieces, plus the flanked shape a whole-block test cannot express. Route 0
@@ -7198,6 +7201,152 @@ fn coalesce_solid_run(pieces: &mut Vec<Piece>, reference: &[u8]) {
         ref_end: start + hi + 1,
         alt: payload[lo..=hi].to_vec(),
     }];
+}
+
+/// Partition `pieces` into maximal runs of consecutive pieces and run `pass` on
+/// each run's sub-slice independently, reassembling the results in order.
+///
+/// # Why the coalesce passes must reason per-run, not per-hull (#2192)
+///
+/// [`peel_tandem_dup_beside_change`] and [`coalesce_solid_run`] both start from
+/// [`block_hull_and_payload`], which spans `pieces.first().ref_start ..
+/// pieces.last().ref_end` — the **whole-variant** hull. For a single contiguous
+/// run that hull *is* the run, and the collapse fires. But a second cis member
+/// (or a second run of change in one member) stretches the hull across the gap:
+/// the changed-column set becomes non-contiguous and [`coalesce_solid_run`]'s
+/// contiguity gate declines, so the run stays fragmented — the #2174 fix reaching
+/// only single-run alleles. This generalises it across BOTH run-count and arity
+/// (a member is just a run) by handing each pass one run at a time, which is the
+/// same shape [`coalesce_inversion_runs`] already applies to inversion typing
+/// ("the whole-block rule generalised to every maximal run of consecutive
+/// pieces").
+///
+/// # What a run boundary is
+///
+/// `general.md:34` keeps two variants individual when an *unchanged* reference
+/// base lies between them, and a base is a genuine separator only if it survives
+/// at its own coordinate — a **zero-shift fixed point**, the very notion
+/// [`coalesce_solid_run`] reads *within* a hull. A reference base in the gap
+/// between piece `i` and piece `i+1` is a zero-shift fixed point iff the running
+/// net length change of pieces `0..=i` is **zero** there. A non-zero running
+/// delta means a compensating indel has shifted the gap bases, so they match
+/// only under that shift and are not separators: `GACT -> ACTG` fragments to
+/// `[11del;14_15insG]`, whose interior `ACT` sits under a running delta of `-1`
+/// and so is correctly not a boundary, while the distant `27C>A` sits past a gap
+/// where the delta is back to `0` and so is. A block with no boundary is one
+/// run, so `pass` sees the whole piece list and behaviour is byte-identical to
+/// calling it directly — additive by construction, like Route 0 of
+/// [`coalesce_inversion_runs`].
+///
+/// # The one exception: a trailing tandem-dup insertion is not a boundary start
+///
+/// The zero-shift test is purely a *length* test, and it has one blind spot that
+/// a naive split gets wrong. A tandem duplication abutting a change reaches these
+/// passes 3'-most, as a net-positive insertion whose SOURCE TRACT sits in the
+/// unchanged reference immediately 5' of it — so `c.[10_11dup;13A>C]` arrives as
+/// `[13A>C-substitution; dup-insertion]`, with the two duplicated bases reading as
+/// a zero-shift gap between them. Split there, the dup-insertion lands in a
+/// singleton run where [`peel_tandem_dup_beside_change`] can no longer fold it, and
+/// it renders as a raw `ins` — a `dup` destroyed, the exact inverse of #2192.
+///
+/// So before cutting in front of a net-positive incoming piece, the grouping asks
+/// peel itself: if folding `current + [piece]` yields a `dup`, the gap is a
+/// duplication source and not a separator, and the cut is suppressed. This
+/// delegates the decision to peel's own one-mismatch discriminator rather than
+/// re-deriving it: a genuinely separate run (a distant member's `dup` sitting past
+/// a spanning change) mismatches peel's clean-dup hypothesis in many columns and is
+/// refused, so two real runs are never merged. The probe — and its clone — are paid
+/// only at a net-positive boundary candidate, which is rare.
+///
+/// # What this still does NOT generalise (deferred to a segment-first partition)
+///
+/// The probe rescues a dup that abuts its OWN change. It does not bank a `dup`
+/// sitting 5' of a *separate* downstream run: such a `dup` keeps the running delta
+/// non-zero across the gap, so no boundary is drawn and the following run is swept
+/// into one group where the collapse passes leave it whole (matching today's
+/// behaviour, not fragmenting it). Isolating each `dup` from an unrelated neighbour
+/// needs the content-aware segment-first partition (the report's Category 1, tracked
+/// by #2194), not a piece-length grouping; the single-run `dup` peel (#2175) is
+/// unchanged.
+fn coalesce_by_run(
+    pieces: &mut Vec<Piece>,
+    reference: &[u8],
+    pass: impl Fn(&mut Vec<Piece>, &[u8]),
+) {
+    // Fewer than two pieces cannot span a separator, so there is one run; run the
+    // pass directly and skip the grouping allocation.
+    if pieces.len() < 2 {
+        pass(pieces, reference);
+        return;
+    }
+    let mut groups: Vec<Vec<Piece>> = Vec::new();
+    let mut current: Vec<Piece> = Vec::new();
+    // Running net length change of the pieces placed so far. A split is taken
+    // only where this is zero, so each run resumes from zero and the test stays a
+    // zero-shift test whether or not it is reset.
+    let mut delta: i64 = 0;
+    for piece in pieces.iter() {
+        if let Some(prev) = current.last() {
+            // A gap of >=1 unchanged reference base is a boundary only at a
+            // zero-shift fixed point (`delta == 0`); a non-zero delta means the
+            // gap bases are a compensating-shift artefact, not a separator, so the
+            // run continues. See the doc comment.
+            let mut boundary = piece.ref_start > prev.ref_end && delta == 0;
+            // …with one exception. A tandem-dup insertion parks its SOURCE TRACT
+            // in the unchanged bases 5' of it: those bases read as a zero-shift gap
+            // at the piece level while being the duplication's origin, so
+            // `peel_tandem_dup_beside_change` must see the insertion together with
+            // the change it abuts (`c.[10_11dup;13A>C]` arrives as
+            // `[13A>C-sub; dup-insertion]` and must fold, not split — #2192). Ask
+            // peel itself: if folding `current + [piece]` yields a `dup`, the gap is
+            // a dup source and not a separator. Only a net-positive incoming piece
+            // can be a dup, so the probe — and its clone — are paid only there, and
+            // peel's own one-mismatch gate refuses a genuinely separate run (a
+            // distant member's dup abutting a spanning change mismatches in many
+            // columns), so this cannot merge two real runs.
+            if boundary && piece.alt.len() as i64 - (piece.ref_end - piece.ref_start) as i64 > 0 {
+                let mut probe = current.clone();
+                probe.push(piece.clone());
+                let unfolded = probe.clone();
+                peel_tandem_dup_beside_change(&mut probe, reference);
+                if probe != unfolded {
+                    boundary = false;
+                }
+            }
+            if boundary {
+                groups.push(std::mem::take(&mut current));
+            }
+        }
+        delta += piece.alt.len() as i64 - (piece.ref_end - piece.ref_start) as i64;
+        current.push(piece.clone());
+    }
+    groups.push(current);
+    let mut out: Vec<Piece> = Vec::with_capacity(pieces.len());
+    for mut run in groups {
+        pass(&mut run, reference);
+        out.append(&mut run);
+    }
+    // Reassembly must preserve ascending, non-overlapping offset order — every
+    // downstream consumer relies on it: `rebuild_members`'s dup-disjointness walk
+    // debug-asserts `ref_start >= previous_ref_end`, and `shift_pieces` reads
+    // `pieces[i-1].ref_end` as the 5' bound of piece `i`. The only pass that can
+    // disturb it is `peel_tandem_dup_beside_change`, which widens its search 5'
+    // across a reference tandem tract (`tandem_tract_start`, #2175) that may reach
+    // before the run's own hull — and so, in principle, before an EARLIER run.
+    // It does not: the duplication is placed 3'-most over a *perfect* reference
+    // tract, so its emitted `[dup; sub]` sit at or 3' of the run's changed columns,
+    // which are themselves 3' of every earlier run's pieces. Clamping the widened
+    // window to the run's `[hs, he]` (the review's literal suggestion) would defeat
+    // #2175 instead — the source copies of a tandem dup legitimately live in
+    // unchanged reference 5' of the hull. So the invariant is asserted at the root
+    // rather than assumed, which turns any escape the 512-case `fuzz_the_cross_product`
+    // (or the whole debug suite) can reach into a failure here, next to its cause,
+    // instead of a silent reorder a distant consumer trips over.
+    debug_assert!(
+        out.windows(2).all(|w| w[0].ref_end <= w[1].ref_start),
+        "coalesce_by_run reassembled pieces out of ascending offset order: {out:?}"
+    );
+    *pieces = out;
 }
 
 // ----------------------------------------------------------------------------
@@ -11185,8 +11334,10 @@ pub(crate) fn derive_block_members(
         // issue_2175_dup_abutting_change, plus the #2161 inversion corpus).
         if let Some(kind) = cis_kind_of(template) {
             if AxisFrame::is_dna(kind) {
-                peel_tandem_dup_beside_change(pieces, reference);
-                coalesce_solid_run(pieces, reference);
+                coalesce_by_run(pieces, reference, |run, reference| {
+                    peel_tandem_dup_beside_change(run, reference);
+                    coalesce_solid_run(run, reference);
+                });
             }
         }
     };

--- a/tests/it/fragmentation_corpus.rs
+++ b/tests/it/fragmentation_corpus.rs
@@ -23,8 +23,10 @@
 //! keep a dup-that-extends-a-reference-tandem out of a spanning `delins` on each
 //! path. The censuses stay per-surface so a regression on either is caught alone.
 
-use crate::common::cis_apply_oracle::{apply, normalize};
-use ferro_hgvs::{from_sequences, FromSequencesOptions};
+use crate::common::cis_apply_oracle::{apply, normalize, normalize_in, provider};
+use ferro_hgvs::spdi::hgvs_to_spdi;
+use ferro_hgvs::{from_sequences, parse_hgvs, FromSequencesOptions, HgvsVariant, ShuffleDirection};
+use proptest::prelude::*;
 
 struct Case {
     issue: &'static str,
@@ -342,6 +344,522 @@ const CONVERGENCE: &[(&str, &str, &[&str])] = &[
         &["TEMPLATE:g.[11_12dup;17_18del]", "TEMPLATE:g.17_18delinsCA"],
     ),
 ];
+
+// ============================================================================
+// #2192 — the anti-narrowness cross-product corpus (generated, no fixtures)
+//
+// The #2174 corpus above pins single-member runs one shape at a time; that is
+// exactly the blindness #2192 lived in. This section GENERATES a cross-product
+// of {run shape} x {run count} x {member count} x {both shuffle directions} on
+// BOTH surfaces, and asserts each cell reaches the same recommended form its
+// runs reach in ISOLATION. A fix scoped to single-run or single-member fails
+// loudly on the multi cells (on `origin/main` every multi-run cell fragments);
+// this is the signal the #2174 corpus lacked.
+// ============================================================================
+
+/// A run template: a local `ref_seg -> alt_seg` edit, plus the member count its
+/// recommended (non-fragmented) single-run form has. The counts are the #2174 /
+/// #2175 results (a balanced equal-length run is one spanning `delins`; a
+/// reference-tandem expansion abutting a substitution is a `dup` plus that
+/// `sub`) and are asserted independently below, so a run that fragments in
+/// isolation fails here rather than passing this corpus vacuously.
+struct RunTemplate {
+    name: &'static str,
+    ref_seg: &'static str,
+    alt_seg: &'static str,
+    members: usize,
+}
+
+/// Net-length-preserving run templates: a balanced equal-length rotation is one
+/// spanning `delins` (#2174), a point substitution is one `sub`. Each is one
+/// member, and each returns the running length delta to zero, so the per-run
+/// grouping isolates any number of them in any order (`coalesce_by_run`'s
+/// zero-shift boundary). These fill the cross-product's run slots.
+const BASE_TEMPLATES: &[RunTemplate] = &[
+    RunTemplate {
+        name: "balanced4",
+        ref_seg: "GACT",
+        alt_seg: "ACTG",
+        members: 1,
+    },
+    RunTemplate {
+        name: "balanced3",
+        ref_seg: "ATA",
+        alt_seg: "TAC",
+        members: 1,
+    },
+    RunTemplate {
+        name: "sub",
+        ref_seg: "C",
+        alt_seg: "A",
+        members: 1,
+    },
+];
+
+/// A reference tandem (`AGAG`) expanded by one unit beside a substitution ->
+/// `[dup; sub]`, TWO members (#2175). This is the member-count (arity) axis: one
+/// run that is two members. A `dup` is net-imbalanced and content-defined, so the
+/// zero-shift grouping isolates it only when nothing follows it (see
+/// `coalesce_by_run`'s deferral note); the cross-product therefore places it only
+/// as the FINAL run. `dup`-before-another-run is deferred to a segment-first
+/// partition and is asserted UNCHANGED (still fragmenting) by
+/// `a_dup_before_another_run_is_left_for_category_one` below, so the boundary is
+/// pinned rather than silent.
+const TRAILING_DUP: RunTemplate = RunTemplate {
+    name: "dupsub",
+    ref_seg: "AGAGC",
+    alt_seg: "AGAGAGA",
+    members: 2,
+};
+
+/// Flanks and separators. The pads give the shuffle room to move at both ends;
+/// the spacer is long enough (>= 2 unchanged bases, `general.md:33`) that the
+/// runs it separates never interact, so a cell's runs are genuinely independent.
+const PAD: &str = "CACGTACGTC";
+const SPACER: &str = "TCGGATCAG";
+
+/// One generated cell: the template filling each run slot, left to right.
+struct Cell {
+    templates: Vec<&'static RunTemplate>,
+}
+
+impl Cell {
+    /// The reference, and the 0-based offset at which each run's `ref_seg` sits.
+    fn reference(&self) -> (String, Vec<usize>) {
+        let mut reference = String::from(PAD);
+        let mut offsets = Vec::new();
+        for (i, template) in self.templates.iter().enumerate() {
+            if i > 0 {
+                reference.push_str(SPACER);
+            }
+            offsets.push(reference.len());
+            reference.push_str(template.ref_seg);
+        }
+        reference.push_str(PAD);
+        (reference, offsets)
+    }
+
+    /// The reference with `which` run slots applied (all of them for the multi
+    /// case, exactly one for an isolated per-run derivation). Built left to
+    /// right so the offsets stay valid whatever the length changes.
+    fn applied(&self, reference: &str, offsets: &[usize], which: impl Fn(usize) -> bool) -> String {
+        let bytes = reference.as_bytes();
+        let mut out = String::with_capacity(bytes.len());
+        let mut cursor = 0usize;
+        for (i, template) in self.templates.iter().enumerate() {
+            let start = offsets[i];
+            out.push_str(&reference[cursor..start]);
+            if which(i) {
+                out.push_str(template.alt_seg);
+            } else {
+                out.push_str(template.ref_seg);
+            }
+            cursor = start + template.ref_seg.len();
+        }
+        out.push_str(&reference[cursor..]);
+        out
+    }
+}
+
+/// `from_sequences` for the `TEMPLATE` accession in one shuffle direction.
+fn from_seq_dir(reference: &str, resulting: &str, direction: ShuffleDirection) -> HgvsVariant {
+    from_sequences(
+        "TEMPLATE",
+        1,
+        reference,
+        resulting,
+        &FromSequencesOptions::default().with_direction(direction),
+    )
+    .unwrap_or_else(|e| panic!("from_sequences({reference}, {resulting}): {e}"))
+}
+
+/// The members of a rendered description, each as `(interbase_start, body)`
+/// where `body` is the spelling without the `TEMPLATE:g.` prefix, sorted into
+/// the ascending interbase order both surfaces render in (#1098). Comparing
+/// these makes a single-member `TEMPLATE:g.X` and a one-member allele equal, and
+/// is independent of how the members happened to be grouped.
+fn member_bodies(reference: &str, desc: &str) -> Vec<String> {
+    let template = provider(reference);
+    let parsed = parse_hgvs(desc).unwrap_or_else(|e| panic!("parse {desc}: {e:?}"));
+    let members: Vec<HgvsVariant> = match parsed {
+        HgvsVariant::Allele(allele) => allele.variants.clone(),
+        single => vec![single],
+    };
+    let mut keyed: Vec<(u64, String)> = members
+        .iter()
+        .map(|member| {
+            let start = hgvs_to_spdi(member, &template)
+                .unwrap_or_else(|e| panic!("{desc}: member {member} has no SPDI: {e}"))
+                .position;
+            let rendered = member.to_string();
+            let body = rendered
+                .strip_prefix("TEMPLATE:g.")
+                .unwrap_or(&rendered)
+                .to_string();
+            (start, body)
+        })
+        .collect();
+    keyed.sort_by_key(|(start, _)| *start);
+    keyed.into_iter().map(|(_, body)| body).collect()
+}
+
+/// Every tuple of `len` base templates, in base-`n` counting order (so every
+/// shape mix, with repetition, appears).
+fn base_tuples(len: u32) -> Vec<Vec<&'static RunTemplate>> {
+    let n = BASE_TEMPLATES.len();
+    let count = n.pow(len);
+    (0..count)
+        .map(|mut code| {
+            (0..len)
+                .map(|_| {
+                    let idx = code % n;
+                    code /= n;
+                    &BASE_TEMPLATES[idx]
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// The largest run count the exhaustive cross-product enumerates. Five net-zero
+/// runs (and a sixth when a trailing `dup` is appended) exercises the four- and
+/// five-member alleles #2192 is about at full arity, in every ordering — the whole
+/// point being that the per-run coalesce must not depend on how many members
+/// precede or follow a run.
+const MAX_RUNS: u32 = 5;
+
+/// Enumerate every cell of the cross-product:
+///
+/// - all base-template tuples of length `1..=MAX_RUNS` (run count and member count
+///   both `1..=5`, every shape mix and ordering), and
+/// - all base-template tuples of length `0..MAX_RUNS` with a `TRAILING_DUP`
+///   appended (the member-count axis: the two-member `dup` run raises member count
+///   as high as six while run count stays `1..=5`, `dup` always last so the
+///   zero-shift grouping isolates it).
+fn cells() -> Vec<Cell> {
+    let mut cells = Vec::new();
+    for len in 1..=MAX_RUNS {
+        for templates in base_tuples(len) {
+            cells.push(Cell { templates });
+        }
+    }
+    for len in 0..MAX_RUNS {
+        for mut templates in base_tuples(len) {
+            templates.push(&TRAILING_DUP);
+            cells.push(Cell { templates });
+        }
+    }
+    cells
+}
+
+/// Sort member bodies into the ascending interbase order both surfaces render
+/// in, so a per-run combination can be compared to a whole-allele output.
+fn sort_bodies(reference: &str, mut bodies: Vec<String>) -> Vec<String> {
+    // Build the provider once, and cache each member's key so it is parsed and
+    // resolved once per body rather than once per comparison (`sort_by_key` may
+    // call its closure `O(n log n)` times).
+    let provider = provider(reference);
+    bodies.sort_by_cached_key(|body| {
+        hgvs_to_spdi(
+            &parse_hgvs(&format!("TEMPLATE:g.{body}")).expect("parse member"),
+            &provider,
+        )
+        .expect("member spdi")
+        .position
+    });
+    bodies
+}
+
+/// Wrap member bodies back into a `TEMPLATE:g.` description (an allele when there
+/// is more than one member).
+fn wrap_members(bodies: &[String]) -> String {
+    if bodies.len() == 1 {
+        format!("TEMPLATE:g.{}", bodies[0])
+    } else {
+        format!("TEMPLATE:g.[{}]", bodies.join(";"))
+    }
+}
+
+/// The cross-product's core assertion, run per shuffle direction and judged
+/// PER SURFACE: each surface's multi-run output must equal that same surface's
+/// per-run ISOLATED outputs combined. That is #2192's property — every run
+/// derived independently of its neighbours — stated without coupling the two
+/// surfaces to each other, since `from_sequences` and `normalize` may
+/// legitimately place a `dup` at different shuffle anchors (an orthogonal
+/// question, visible only on the 5' surface). A fix scoped to single-run or
+/// single-member fails here: the multi output fragments while the isolated
+/// per-run outputs do not, so the two stop being equal.
+fn assert_cross_product(direction: ShuffleDirection) {
+    for cell in cells() {
+        assert_cell(&cell, direction);
+    }
+}
+
+/// One cell's per-surface, per-run assertion — factored out of
+/// [`assert_cross_product`] so the exhaustive enumeration and the proptest fuzzer
+/// (`fuzz_the_cross_product`) check the identical property on their respective
+/// corpora.
+fn assert_cell(cell: &Cell, direction: ShuffleDirection) {
+    let (reference, offsets) = cell.reference();
+    let label: Vec<&str> = cell.templates.iter().map(|t| t.name).collect();
+    let context = format!("cell {label:?} {direction:?}");
+    let resulting = cell.applied(&reference, &offsets, |_| true);
+
+    // Per-run isolated forms, on each surface. `from_sequences` derives from
+    // the single-run sequence; `normalize` re-derives that run's own
+    // recommended form. The per-template member-count floor is an independent
+    // anti-fragmentation check: a run that fragments in isolation fails here
+    // rather than letting the equality below pass vacuously.
+    let mut expected_from_seq: Vec<String> = Vec::new();
+    let mut expected_normalize: Vec<String> = Vec::new();
+    for (i, template) in cell.templates.iter().enumerate() {
+        let single = cell.applied(&reference, &offsets, |j| j == i);
+        let fs = member_bodies(
+            &reference,
+            &from_seq_dir(&reference, &single, direction).to_string(),
+        );
+        assert_eq!(
+            fs.len(),
+            template.members,
+            "{context}: run {i} ({}) fragmented in ISOLATION into {fs:?} — the per-template \
+                 floor is wrong or #2174/#2175 regressed",
+            template.name
+        );
+        let run = member_bodies(
+            &reference,
+            &normalize_in(&reference, &wrap_members(&fs), direction),
+        );
+        expected_from_seq.extend(fs);
+        expected_normalize.extend(run);
+    }
+    let expected_from_seq = sort_bodies(&reference, expected_from_seq);
+    let expected_normalize = sort_bodies(&reference, expected_normalize);
+
+    // from_sequences surface: the multi-run derivation equals the per-run one.
+    let multi = from_seq_dir(&reference, &resulting, direction).to_string();
+    assert_eq!(
+            member_bodies(&reference, &multi),
+            expected_from_seq,
+            "{context}: from_sequences fragmented the multi-run allele\n  got:      {multi}\n  expected: {expected_from_seq:?}"
+        );
+
+    // normalize surface: normalizing the whole recommended allele equals
+    // normalizing each run's recommended form on its own.
+    let recommended = wrap_members(&expected_from_seq);
+    let normalized = normalize_in(&reference, &recommended, direction);
+    assert_eq!(
+            member_bodies(&reference, &normalized),
+            expected_normalize,
+            "{context}: normalize fragmented the multi-run allele\n  input:    {recommended}\n  expected: {expected_normalize:?}"
+        );
+
+    // meaning preservation on ALL THREE surfaces — the member-body equality above
+    // only proves the spellings match, not that they denote the resulting sequence.
+    // A per-run coalesce that drops or duplicates a base the SAME way in the
+    // multi-run allele and in each isolated run passes the equality yet corrupts
+    // the sequence, so normalize's own output must reach the apply oracle too.
+    assert_eq!(
+        apply(&reference, &recommended).as_deref(),
+        Some(resulting.as_str()),
+        "{context}: recommended form does not denote the resulting sequence\n  form: {recommended}"
+    );
+    assert_eq!(
+        apply(&reference, &multi).as_deref(),
+        Some(resulting.as_str()),
+        "{context}: from_sequences output does not denote the resulting sequence\n  out: {multi}"
+    );
+    assert_eq!(
+        apply(&reference, &normalized).as_deref(),
+        Some(resulting.as_str()),
+        "{context}: normalize output does not denote the resulting sequence\n  out: {normalized}"
+    );
+}
+
+/// The cross-product reaches its recommended form on the 3' surface.
+#[test]
+fn the_cross_product_reaches_the_recommended_form_three_prime() {
+    assert_cross_product(ShuffleDirection::ThreePrime);
+}
+
+/// The cross-product reaches its recommended form on the 5' surface.
+#[test]
+fn the_cross_product_reaches_the_recommended_form_five_prime() {
+    assert_cross_product(ShuffleDirection::FivePrime);
+}
+
+/// The three reproductions from issue #2192, verbatim — accession `CONTIG1`,
+/// sequences and coordinates exactly as the issue states them — pinned on BOTH
+/// surfaces the issue names. Each is a contiguous run beside a non-contiguous
+/// member that fragmented before this fix: Ex1 a `del+ins` rotation, Ex2 a
+/// `del+dup` (the dup smeared 3' to `g.15`), Ex3 a run with its sibling on the 5'
+/// side. This is the guard a reviewer looks for — the exact strings from the
+/// report, not a paraphrase of their geometry.
+#[test]
+fn the_issue_2192_reprexes_reach_the_recommended_form() {
+    struct Reprex {
+        name: &'static str,
+        reference: &'static str,
+        resulting: &'static str,
+        recommended: &'static str,
+        // The fragmented 3'-shuffled output the issue records for `main`, fed back
+        // through the normalize surface to prove it coalesces (not merely that the
+        // recommended form is a fixed point).
+        fragmented: &'static str,
+    }
+    let reprexes = [
+        Reprex {
+            name: "Ex1 del+ins",
+            reference: "ACGTTCAGGTGACTTTAGCTAGCTAGCTAGCTAG",
+            resulting: "ACGTTCAGGTACTGTTAGCTAGCTAGATAGCTAG",
+            recommended: "g.[11_14delinsACTG;27C>A]",
+            fragmented: "g.[11del;14_15insG;27C>A]",
+        },
+        Reprex {
+            name: "Ex2 del+dup",
+            reference: "ACGTTCAGGTGACTTAGCTAGCTAGCTAGCTAG",
+            resulting: "ACGTTCAGGTACTTTAGCTAGCTAGCGAGCTAG",
+            recommended: "g.[11_13delinsACT;27T>G]",
+            fragmented: "g.[11del;15dup;27T>G]",
+        },
+        Reprex {
+            name: "Ex3 5'-side change",
+            reference: "ACGTTCAGGTATATTAGCTAGCTAGCTAGCTAG",
+            resulting: "ACGTGCAGGTTACTTAGCTAGCTAGCTAGCTAG",
+            recommended: "g.[5T>G;11_13delinsTAC]",
+            fragmented: "g.[5T>G;11del;13_14insC]",
+        },
+    ];
+    for r in reprexes {
+        // Surface 1 — from_sequences, the issue's own reproducer, under CONTIG1 and
+        // in BOTH shuffle directions. The recommended form is direction-independent
+        // here (no run 3'-shifts across its sibling), so both must reach it.
+        for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+            let got = from_sequences(
+                "CONTIG1",
+                1,
+                r.reference,
+                r.resulting,
+                &FromSequencesOptions::default().with_direction(direction),
+            )
+            .unwrap_or_else(|e| panic!("{}: from_sequences: {e}", r.name))
+            .to_string();
+            assert_eq!(
+                got,
+                format!("CONTIG1:{}", r.recommended),
+                "{}: from_sequences {direction:?} fragmented",
+                r.name
+            );
+        }
+        // Surface 2 — normalize/rederive (the issue's `rederive(recommended_form=…)`
+        // path). Driven through the TEMPLATE-keyed helper on the identical bytes, so
+        // the coordinates match. The fragmented `main` output must coalesce, and the
+        // recommended form must be a fixed point.
+        let templated = |body: &str| format!("TEMPLATE:{body}");
+        assert_eq!(
+            normalize(r.reference, &templated(r.fragmented)),
+            templated(r.recommended),
+            "{}: normalize did not de-fragment the main output",
+            r.name
+        );
+        assert_eq!(
+            normalize(r.reference, &templated(r.recommended)),
+            templated(r.recommended),
+            "{}: recommended form is not a normalize fixed point",
+            r.name
+        );
+        // Every spelling denotes the same bases as the resulting sequence.
+        for body in [r.recommended, r.fragmented] {
+            assert_eq!(
+                apply(r.reference, &templated(body)).as_deref(),
+                Some(r.resulting),
+                "{}: {body} does not denote the resulting sequence",
+                r.name
+            );
+        }
+    }
+}
+
+proptest! {
+    // Randomised extension of the exhaustive cross-product: a cell of 1..=6 net-zero
+    // runs in any order, with an optional trailing `dup`, in either shuffle
+    // direction. It samples the same shape `cells()` enumerates but out to higher
+    // arity and beyond what an exhaustive `MAX_RUNS` can reach, so a fragmentation
+    // that only appears at some member count or ordering the fixed set happens to
+    // miss still fails. `assert_cell` is the identical property the two exhaustive
+    // tests check. The strategy draws only from known-good templates, so every cell
+    // is well-formed — a failure is a real fragmentation, never a malformed input.
+    #![proptest_config(ProptestConfig::with_cases(512))]
+    #[test]
+    fn fuzz_the_cross_product(
+        base_idx in proptest::collection::vec(0usize..BASE_TEMPLATES.len(), 1..=6),
+        trailing_dup in any::<bool>(),
+        five_prime in any::<bool>(),
+    ) {
+        let mut templates: Vec<&'static RunTemplate> =
+            base_idx.iter().map(|&i| &BASE_TEMPLATES[i]).collect();
+        if trailing_dup {
+            templates.push(&TRAILING_DUP);
+        }
+        let direction = if five_prime {
+            ShuffleDirection::FivePrime
+        } else {
+            ShuffleDirection::ThreePrime
+        };
+        assert_cell(&Cell { templates }, direction);
+    }
+}
+
+/// The one shape the per-run grouping deliberately does NOT reach: a
+/// net-imbalanced `dup` sitting 5' of another run. The `dup`'s length change is
+/// banked but content-defined, so the zero-shift grouping cannot isolate it from
+/// what follows (see `coalesce_by_run`'s deferral note), and both the `dup` and
+/// the trailing run fragment. This is the Track-2 / segment-first-partition work
+/// tracked by #2194. This pins that boundary — asserting the DEFECT, in the manner
+/// of `issue_1610`'s `a_lone_unequal_length_delins_is_not_split` — so a future
+/// segment-first partition that closes it flips this test loudly rather than
+/// moving the row in silence. The output still denotes the right sequence.
+#[test]
+fn a_dup_before_another_run_is_left_for_category_one() {
+    // A `dup` run (`AGAGC -> AGAGAGA`, positions 11-15) 5' of a balanced4 run
+    // (`GACT -> ACTG`, positions 25-28).
+    let reference = "CACGTACGTCAGAGCTCGGATCAGGACTCACGTACGTC";
+    let resulting = "CACGTACGTCAGAGAGATCGGATCAGACTGCACGTACGTC";
+    let recommended = "TEMPLATE:g.[13_14dup;15C>A;25_28delinsACTG]";
+    // Meaning-preserving sanity: the recommended form denotes what the runs make.
+    assert_eq!(
+        apply(reference, recommended).as_deref(),
+        Some(resulting),
+        "recommended form must denote the resulting sequence"
+    );
+    for (direction, deferred) in [
+        (
+            ShuffleDirection::ThreePrime,
+            "TEMPLATE:g.[15delinsAGA;25del;28_29insG]",
+        ),
+        (
+            ShuffleDirection::FivePrime,
+            "TEMPLATE:g.[15delinsAGA;24del;28_29insG]",
+        ),
+    ] {
+        let got = from_seq_dir(reference, resulting, direction).to_string();
+        assert_ne!(
+            got, recommended,
+            "{direction:?}: dup-before-run unexpectedly reached the recommended form — \
+             if a segment-first partition now closes this, move the cell into the \
+             cross-product above"
+        );
+        assert_eq!(
+            got, deferred,
+            "{direction:?}: deferred fragmentation form moved"
+        );
+        // Whatever it emits, it still denotes the resulting sequence.
+        assert_eq!(
+            apply(reference, &got).as_deref(),
+            Some(resulting),
+            "{direction:?}: the deferred output changed the sequence"
+        );
+    }
+}
 
 /// Every spelling of each variant converges on the one pinned form.
 ///


### PR DESCRIPTION
Track 1 of #2192: the low-risk, per-run generalisation of the contiguous-run coalesce, so multi-member cis alleles stop over-fragmenting.

## The bug

The v0.17.0 fix reached only single-member alleles. When a contiguous run of altered bases shares a cis allele with a distant member, the whole-variant hull spans both, the changed-column set becomes non-contiguous, and the post-partition solid-run collapse declines — so the run stays fragmented as `[del; dup/ins]` beside its sibling.

## The fix

`coalesce_by_run` groups the partition's pieces into maximal runs at each zero-shift fixed point and collapses each run on its own, so a distant member no longer blocks the collapse — at any member count or run count, and on both derivation surfaces (`normalize`/`rederive` and `from_sequences`).

A tandem-dup insertion parks its source tract in the unchanged bases 5' of it, so a naive zero-shift split would strand it in its own run where peel can no longer fold it into a `dup`. Before cutting in front of a net-positive piece the grouping probes peel itself: if folding the run-so-far plus that piece yields a `dup`, the gap is a duplication source and the cut is suppressed. Peel's one-mismatch gate refuses a genuinely separate run, so two real runs are never merged.

## Scope — this does NOT fully close #2192

All three of the issue's reprexes are fixed, and so is the general case of a run beside net-zero members (substitutions, balanced runs). One shape from #2192's general phenomenon remains: a run sitting 3' of a **net-imbalanced `dup` member** still fragments, because the dup's non-zero running delta prevents a run boundary from being drawn after it.

```
reference CACGTACGTCAGAGCTCGGATCAGGACTCACGTACGTC
resulting CACGTACGTCAGAGAGATCGGATCAGACTGCACGTACGTC
  got         : g.[15delinsAGA;25del;28_29insG]        (the 25_28 GACT->ACTG run still fragments)
  recommended : g.[13_14dup;15C>A;25_28delinsACTG]
```

That case needs the content-aware segment-first partition and is tracked as **#2194** (Track 2), pinned here by a tripwire test (`a_dup_before_another_run_is_left_for_category_one`) so it cannot close silently. #2192 should stay open until #2194 lands — hence `Refs`, not `Closes`, below.

## Verification

- All three reprexes from the issue reach the recommended form on both surfaces (`the_issue_2192_reprexes_reach_the_recommended_form`).
- Exhaustive cross-product over run shape × member count (1..=5) × run count × ordering × both directions × both surfaces, plus a proptest fuzzer out to seven runs. Every case is meaning-checked via the independent apply/SPDI path.
- Full local gate green: `cargo ta` 11,472 passed; oracle suite (4 armed) 11,294; cis sweeps (full) 54; Python 1,152; clippy/fmt clean.

## Representation-Change

Representation-Change: 152 of 228 rows move on the run_beside_a_distant_member disclosure family; 0 on every other shape family. coalesce_by_run coalesces previously-fragmented multi-run cis alleles per contiguous run, so a run beside a distant member renders as one delins instead of [del;dup/ins;...] — on the default CanonicalCoalesced path and via from_sequences. Meaning-preserving (SPDI-identical). Rate is of the affected family. Previously-accepted inputs, so a real migration for consumers of multi-member cis-allele normalization.

Refs #2192


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of fragmented sequence runs, including cases with distant substitutions and tandem duplications.
  * Preserved duplication boundaries while coalescing compatible edits.
  * Fixed inconsistent results between per-run and whole-input normalization.

* **Tests**
  * Added comprehensive regression coverage for mixed run shapes, ordering, directions, and sequence preservation.
  * Expanded corpus coverage to include an additional sequence-keyed family.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->