### PR TITLE
chore: release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.17.0...v0.17.1) - 2026-08-24
+
+### Representation changes
+
+- *(normalize)* equal-length all-differing run is a spanning delins, not an outside-anchored dup ([#2193](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2193)) ([#2200](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2200))
+- *(normalize)* coalesce a run beside a net-imbalanced cis member ([#2194](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2194)) ([#2199](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2199))
+- *(normalize)* coalesce a contiguous run beside a distant cis member ([#2195](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2195))
+
 ## [0.17.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.16.0...v0.17.0) - 2026-08-20
 
 ### Representation changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Representation changes
 
 - *(normalize)* equal-length all-differing run is a spanning delins, not an outside-anchored dup ([#2193](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2193)) ([#2200](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2200))
+  > An equal-length contiguous run where every base
+  > differs and a sub-piece coincidentally matches a flanking reference
+  > tandem moves from a `[dup;del]`/`[del;dup]` (dup anchored outside the
+  > changed span) to the spanning delins (#2193, #422). The direction is
+  > away from the already-shipped form — a genuine output change for these
+  > inputs, not a re-normalization to the form a second normalize already
+  > produced. `dump_normalized_corpus` measures 0 of 96698 rows moved, but
+  > that is a STRUCTURAL ZERO (#1517: the synthetic corpus cannot construct
+  > this coincidental-tandem-inside-an-equal-length-run geometry), not a
+  > bound. Movement is confirmed on the #422 fixture
+  > (`NC_000022.10:g.[10_11del;16_17dup]` → `g.10_15delinsTACGTA`); exactly
+  > one pinned regression test moved suite-wide. Previously-accepted inputs,
+  > so a migration for any consumer that stored the `[dup;del]` spelling;
+  > the shape is rare in real corpora.
 - *(normalize)* coalesce a run beside a net-imbalanced cis member ([#2194](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2194)) ([#2199](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2199))
+  > moves 181 of 44,020 derived outputs on a
+  > 22,010-pair aggregate corpus (net-imbalanced-5′-member + run geometry,
+  > fragmented → coalesced), all meaning-preserving and idempotent — ~90
+  > coalesce a run to one delins, ~82 expose a duplication.md:18-mandated
+  > dup a delins/ins was hiding (#2175), 0 alter an inversion. The repo's
+  > confluence (separations 0–8) and spec-conformance censuses are unchanged
+  > (0 rows move there); this geometry is not in those corpora.
 - *(normalize)* coalesce a contiguous run beside a distant cis member ([#2195](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2195))
+  > 152 of 228 rows move on the
+  > run_beside_a_distant_member disclosure family; 0 on every other shape
+  > family. coalesce_by_run coalesces previously-fragmented multi-run cis
+  > alleles per contiguous run, so a run beside a distant member renders as
+  > one delins instead of [del;dup/ins;...] — on the default
+  > CanonicalCoalesced path and via from_sequences. Meaning-preserving
+  > (SPDI-identical). Rate is of the affected family. Previously-accepted
+  > inputs, so a real migration for consumers of multi-member cis-allele
+  > normalization.
+  >
+  > Refs #2192
 
 ## [0.17.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.16.0...v0.17.0) - 2026-08-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]


### PR DESCRIPTION
## Representation stability

Any PR that moves a normalized output should carry a `Representation-Change:`
trailer (see CONTRIBUTING.md). Those are collected into the **Representation
changes** section of the changelog below, and each entry's trailer text is
attached under its bullet by `scripts/inject_representation_disclosure.py`.

Reviewer checklist:

- [ ] Either that section lists every output-moving change in this cycle, or
      there were none and it is absent.
- [ ] Nothing in it merely *declined*. A decline reads `Representation-Change:
      none`, optionally followed by a reason, and belongs under its own type —
      not here. Spot-check two entries against their PR descriptions.
- [ ] Every entry carries its trailer's own text, quoted under the bullet, and
      that text says whether the affected inputs were previously **rejected**
      (no stored string, so free) or previously **accepted** (a real migration
      for the consumer). release-plz writes the bullet from the commit subject
      alone; `python scripts/inject_representation_disclosure.py` attaches the
      rest, and CI's `Changelog grouping audit` fails until it has been run.
      Re-run it after any push that regenerates this section — it is idempotent.

A commit under `src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`,
`src/reference/` or `src/error_handling/` that moved output without declaring it
means the trailer is missing. Fix that before releasing, not after.

---


### [0.17.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.17.0...v0.17.1) - 2026-08-24
### Representation changes

- *(normalize)* equal-length all-differing run is a spanning delins, not an outside-anchored dup ([#2193](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2193)) ([#2200](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2200))
- *(normalize)* coalesce a run beside a net-imbalanced cis member ([#2194](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2194)) ([#2199](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2199))
- *(normalize)* coalesce a contiguous run beside a distant cis member ([#2195](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2195))


#### cargo-semver-checks

compatible


