### PR TITLE
fix(normalize): coalesce a run beside a net-imbalanced cis member (#2194)

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -7226,48 +7226,54 @@ fn coalesce_solid_run(pieces: &mut Vec<Piece>, reference: &[u8]) {
 /// `general.md:34` keeps two variants individual when an *unchanged* reference
 /// base lies between them, and a base is a genuine separator only if it survives
 /// at its own coordinate — a **zero-shift fixed point**, the very notion
-/// [`coalesce_solid_run`] reads *within* a hull. A reference base in the gap
-/// between piece `i` and piece `i+1` is a zero-shift fixed point iff the running
-/// net length change of pieces `0..=i` is **zero** there. A non-zero running
-/// delta means a compensating indel has shifted the gap bases, so they match
-/// only under that shift and are not separators: `GACT -> ACTG` fragments to
-/// `[11del;14_15insG]`, whose interior `ACT` sits under a running delta of `-1`
-/// and so is correctly not a boundary, while the distant `27C>A` sits past a gap
-/// where the delta is back to `0` and so is. A block with no boundary is one
-/// run, so `pass` sees the whole piece list and behaviour is byte-identical to
-/// calling it directly — additive by construction, like Route 0 of
-/// [`coalesce_inversion_runs`].
+/// [`coalesce_solid_run`] reads *within* a hull. That collapse is position-wise
+/// and so valid only inside a NET-ZERO (equal-length) frame, which means a gap's
+/// running delta must be read against the run's own baseline, not against zero. A
+/// net-imbalanced member shifts the frame: `GACT -> ACTG`'s interior `ACT` sits
+/// under a *temporary* `-1` the run rebalances (not a boundary), while the
+/// `TCGGATCAG` tract 5' of a downstream run sits under a *permanent* `+2` a
+/// preceding `dup` established (a boundary). A bare `delta == 0` test cannot tell
+/// these apart.
+///
+/// A gap is a separator under either of two **licenses**, tracked against a STACK
+/// of frame baselines seeded with `0`:
+///
+/// 1. **Pop** — the delta returns to a stacked baseline. `0` is pinned at the
+///    stack bottom and never removed, so the license set subsumes the old
+///    `delta == 0` test: every wall the zero-shift rule drew is still licensed,
+///    and the licenses only ADD walls. A licensed wall can still be withdrawn by
+///    the tandem-dup suppression below, which applies to a `d == 0` pop wall too,
+///    so the pass is not byte-identical on those gaps.
+/// 2. **Closure** — no stacked baseline recurs at this gap or any later one (the
+///    downstream cumulative-delta set includes the variant end), so this excursion
+///    provably cannot close and is a permanent frame shift. This isolates the run
+///    sitting 3' of a `dup`/`del` whose shift never returns — the #2194 residual.
 ///
 /// # The one exception: a trailing tandem-dup insertion is not a boundary start
 ///
-/// The zero-shift test is purely a *length* test, and it has one blind spot that
-/// a naive split gets wrong. A tandem duplication abutting a change reaches these
-/// passes 3'-most, as a net-positive insertion whose SOURCE TRACT sits in the
-/// unchanged reference immediately 5' of it — so `c.[10_11dup;13A>C]` arrives as
-/// `[13A>C-substitution; dup-insertion]`, with the two duplicated bases reading as
-/// a zero-shift gap between them. Split there, the dup-insertion lands in a
-/// singleton run where [`peel_tandem_dup_beside_change`] can no longer fold it, and
-/// it renders as a raw `ins` — a `dup` destroyed, the exact inverse of #2192.
+/// A tandem duplication abutting a change reaches these passes 3'-most, as a
+/// net-positive insertion whose SOURCE TRACT sits in the unchanged reference
+/// immediately 5' of it — so `c.[10_11dup;13A>C]` arrives as `[13A>C-substitution;
+/// dup-insertion]`, with the two duplicated bases reading as a gap between them.
+/// Split there, the dup-insertion lands in a singleton run where
+/// [`peel_tandem_dup_beside_change`] can no longer fold it and it renders as a raw
+/// `ins` — a `dup` destroyed, the exact inverse of #2192. So before cutting in
+/// front of a net-positive incoming piece — under EITHER license — the grouping
+/// asks peel itself: if folding `current + [piece]` yields a `dup`, the gap is a
+/// duplication source and not a separator, and the cut is suppressed. Peel's own
+/// one-mismatch gate refuses a genuinely separate run (a distant member's `dup`
+/// mismatches in many columns), so two real runs are never merged, and the probe
+/// is paid only at a net-positive candidate.
 ///
-/// So before cutting in front of a net-positive incoming piece, the grouping asks
-/// peel itself: if folding `current + [piece]` yields a `dup`, the gap is a
-/// duplication source and not a separator, and the cut is suppressed. This
-/// delegates the decision to peel's own one-mismatch discriminator rather than
-/// re-deriving it: a genuinely separate run (a distant member's `dup` sitting past
-/// a spanning change) mismatches peel's clean-dup hypothesis in many columns and is
-/// refused, so two real runs are never merged. The probe — and its clone — are paid
-/// only at a net-positive boundary candidate, which is rare.
+/// # The residual this does NOT reach (accepted)
 ///
-/// # What this still does NOT generalise (deferred to a segment-first partition)
-///
-/// The probe rescues a dup that abuts its OWN change. It does not bank a `dup`
-/// sitting 5' of a *separate* downstream run: such a `dup` keeps the running delta
-/// non-zero across the gap, so no boundary is drawn and the following run is swept
-/// into one group where the collapse passes leave it whole (matching today's
-/// behaviour, not fragmenting it). Isolating each `dup` from an unrelated neighbour
-/// needs the content-aware segment-first partition (the report's Category 1, tracked
-/// by #2194), not a piece-length grouping; the single-run `dup` peel (#2175) is
-/// unchanged.
+/// An imbalanced member compensated by a *distant* opposite imbalance closes its
+/// own excursion (a stacked baseline recurs downstream), so the closure license
+/// does not fire and the run is swept in: the group declines and the output is
+/// exactly today's baseline — never wrong, just unfixed. The delta profile alone
+/// cannot rescue it (it is identical to a scrambled equal-length block that
+/// *should* stay whole, e.g. `(+2,-1,+1,-2)`); isolating it needs the byte content
+/// the profile cannot see, which is deferred rather than guessed here.
 fn coalesce_by_run(
     pieces: &mut Vec<Piece>,
     reference: &[u8],
@@ -7279,69 +7285,154 @@ fn coalesce_by_run(
         pass(pieces, reference);
         return;
     }
+    // Net length change of one piece, and the cumulative profile: `cum[i]` is the
+    // delta of `pieces[0..=i]`, i.e. the delta at the gap that may follow piece `i`.
+    let net = |p: &Piece| -> i64 { p.alt.len() as i64 - (p.ref_end - p.ref_start) as i64 };
+    let cum: Vec<i64> = pieces
+        .iter()
+        .scan(0i64, |acc, p| {
+            *acc += net(p);
+            Some(*acc)
+        })
+        .collect();
+    // Greatest index at which each cumulative value occurs. The closure test in
+    // the loop asks whether any stacked baseline recurs in the tail `cum[i..]`,
+    // i.e. whether its last occurrence is at index `>= i`. Precomputing that index
+    // (rather than a suffix `contains` scan, which is O(n) per baseline and O(n^3)
+    // over the loop on a strictly increasing profile) lets each `Frame` below carry
+    // a running max, so the whole grouping pass is O(n).
+    let last_cum_index: std::collections::HashMap<i64, usize> = {
+        let mut m = std::collections::HashMap::with_capacity(cum.len());
+        for (j, &d) in cum.iter().enumerate() {
+            m.insert(d, j); // a later `j` overwrites, leaving the greatest index
+        }
+        m
+    };
+    // The last index at which baseline `v` recurs in `cum`, or `-1` if it never does
+    // (`0` is a baseline but need not appear in `cum` at all). `i` starts at 1, so a
+    // `-1` sentinel is always `< i` and reads as "never recurs".
+    let recur_of = |v: i64| -> i64 { last_cum_index.get(&v).map_or(-1, |&j| j as i64) };
     let mut groups: Vec<Vec<Piece>> = Vec::new();
     let mut current: Vec<Piece> = Vec::new();
-    // Running net length change of the pieces placed so far. A split is taken
-    // only where this is zero, so each run resumes from zero and the test stays a
-    // zero-shift test whether or not it is reset.
-    let mut delta: i64 = 0;
-    for piece in pieces.iter() {
-        if let Some(prev) = current.last() {
-            // A gap of >=1 unchanged reference base is a boundary only at a
-            // zero-shift fixed point (`delta == 0`); a non-zero delta means the
-            // gap bases are a compensating-shift artefact, not a separator, so the
-            // run continues. See the doc comment.
-            let mut boundary = piece.ref_start > prev.ref_end && delta == 0;
-            // …with one exception. A tandem-dup insertion parks its SOURCE TRACT
-            // in the unchanged bases 5' of it: those bases read as a zero-shift gap
-            // at the piece level while being the duplication's origin, so
-            // `peel_tandem_dup_beside_change` must see the insertion together with
-            // the change it abuts (`c.[10_11dup;13A>C]` arrives as
-            // `[13A>C-sub; dup-insertion]` and must fold, not split — #2192). Ask
-            // peel itself: if folding `current + [piece]` yields a `dup`, the gap is
-            // a dup source and not a separator. Only a net-positive incoming piece
-            // can be a dup, so the probe — and its clone — are paid only there, and
-            // peel's own one-mismatch gate refuses a genuinely separate run (a
-            // distant member's dup abutting a spanning change mismatches in many
-            // columns), so this cannot merge two real runs.
-            if boundary && piece.alt.len() as i64 - (piece.ref_end - piece.ref_start) as i64 > 0 {
+    // Frame baselines, as a max-stack. `0` stays at the bottom forever, which is what
+    // keeps every old `delta == 0` wall firing (the pop clause) and the change
+    // monotone. Each frame also carries `max_recur`, the greatest `recur_of` over the
+    // baselines at or below it — a prefix max, so the top frame's is the max over the
+    // whole stack. That turns the closure test into an O(1) read of the top instead of
+    // a scan, and it is maintainable in O(1) because pushes only append.
+    struct Frame {
+        baseline: i64,
+        max_recur: i64,
+    }
+    let mut stack: Vec<Frame> = vec![Frame {
+        baseline: 0,
+        max_recur: recur_of(0),
+    }];
+    // Membership mirror of `stack`, so the pop test is O(1). A baseline is pushed only
+    // when absent, so its values stay distinct and this is a faithful set.
+    let mut in_stack: std::collections::HashSet<i64> = std::collections::HashSet::from([0]);
+    for (i, piece) in pieces.iter().enumerate() {
+        let gap = current
+            .last()
+            .is_some_and(|prev| piece.ref_start > prev.ref_end);
+        if gap {
+            // Delta at this gap, i.e. after the previous piece (`i - 1`; a gap
+            // implies `current` is non-empty, so `i >= 1`).
+            let d = cum[i - 1];
+            // Pop: the delta returned to a stacked baseline (subsumes `delta == 0`).
+            let pop = in_stack.contains(&d);
+            // Closure: no stacked baseline recurs at this gap or any later one (the
+            // tail `cum[i..]` includes the variant end), so this excursion is a
+            // permanent frame shift and the run 3' of it is separate. A baseline
+            // recurs in `cum[i..]` iff its last occurrence is at or after `i`, so no
+            // baseline recurs iff the top frame's running max is `< i`. The stack
+            // always holds the bottom `0`, so `last()` is never `None`.
+            let closure = !pop && stack.last().is_some_and(|f| f.max_recur < i as i64);
+            let mut wall = pop || closure;
+            // Suppression (#2175): a net-positive incoming piece folding into a dup
+            // WITH `current` is a dup abutting its own change — keep them together so
+            // peel can fold, whatever the licenses said. Only a net-positive piece
+            // can be a dup, so the probe is paid only there, and peel's one-mismatch
+            // gate refuses a genuinely separate run, so two real runs never merge.
+            if wall && net(piece) > 0 {
                 let mut probe = current.clone();
                 probe.push(piece.clone());
                 let unfolded = probe.clone();
                 peel_tandem_dup_beside_change(&mut probe, reference);
                 if probe != unfolded {
-                    boundary = false;
+                    wall = false;
                 }
             }
-            if boundary {
+            if wall {
+                if pop {
+                    // Resume from the run's baseline; `0` (the bottom) is never
+                    // removed, so a later `delta == 0` gap still walls. Each frame is
+                    // popped at most once over the run, so this is amortized O(1).
+                    while stack.last().is_some_and(|f| f.baseline != d) {
+                        if let Some(f) = stack.pop() {
+                            in_stack.remove(&f.baseline);
+                        }
+                    }
+                } else {
+                    // Push the new baseline, carrying the running max of `recur_of`.
+                    let max_recur = stack.last().map_or(-1, |f| f.max_recur).max(recur_of(d));
+                    in_stack.insert(d);
+                    stack.push(Frame {
+                        baseline: d,
+                        max_recur,
+                    });
+                }
                 groups.push(std::mem::take(&mut current));
             }
         }
-        delta += piece.alt.len() as i64 - (piece.ref_end - piece.ref_start) as i64;
         current.push(piece.clone());
     }
     groups.push(current);
-    let mut out: Vec<Piece> = Vec::with_capacity(pieces.len());
-    for mut run in groups {
-        pass(&mut run, reference);
-        out.append(&mut run);
-    }
-    // Reassembly must preserve ascending, non-overlapping offset order — every
+    // Run the pass per group, then merge any adjacent groups whose OUTPUTS overlap.
+    //
+    // The reassembly must preserve ascending, non-overlapping offset order — every
     // downstream consumer relies on it: `rebuild_members`'s dup-disjointness walk
     // debug-asserts `ref_start >= previous_ref_end`, and `shift_pieces` reads
-    // `pieces[i-1].ref_end` as the 5' bound of piece `i`. The only pass that can
-    // disturb it is `peel_tandem_dup_beside_change`, which widens its search 5'
-    // across a reference tandem tract (`tandem_tract_start`, #2175) that may reach
-    // before the run's own hull — and so, in principle, before an EARLIER run.
-    // It does not: the duplication is placed 3'-most over a *perfect* reference
-    // tract, so its emitted `[dup; sub]` sit at or 3' of the run's changed columns,
-    // which are themselves 3' of every earlier run's pieces. Clamping the widened
-    // window to the run's `[hs, he]` (the review's literal suggestion) would defeat
-    // #2175 instead — the source copies of a tandem dup legitimately live in
-    // unchanged reference 5' of the hull. So the invariant is asserted at the root
-    // rather than assumed, which turns any escape the 512-case `fuzz_the_cross_product`
-    // (or the whole debug suite) can reach into a failure here, next to its cause,
-    // instead of a silent reorder a distant consumer trips over.
+    // `pieces[i-1].ref_end` as the 5' bound of piece `i`. The pass that can disturb
+    // it is `peel_tandem_dup_beside_change`, which widens its search across a
+    // reference tandem tract (`tandem_tract_start`/`tandem_tract_end`, #2175) that
+    // reaches OUTSIDE the group's own hull — so when a wall (a closure/content wall
+    // especially) falls inside such a tract, one group's `[dup; sub]` output can
+    // land at or past a neighbouring group's pieces. Those two groups are one run
+    // for peel's purposes, so the wall between them was spurious: merge their
+    // ORIGINAL pieces and re-derive. This converges (each merge strictly reduces the
+    // group count) and preserves a genuine isolation — a real run separated by
+    // unchanged reference has no tract bridging the gap, so its pass output stays
+    // within its hull and never overlaps its neighbour.
+    let mut outs: Vec<Vec<Piece>> = groups
+        .iter()
+        .map(|group| {
+            let mut g = group.clone();
+            pass(&mut g, reference);
+            g
+        })
+        .collect();
+    let mut k = 0;
+    while k + 1 < outs.len() {
+        let overlaps = match (outs[k].last(), outs[k + 1].first()) {
+            (Some(a), Some(b)) => a.ref_end > b.ref_start,
+            _ => false,
+        };
+        if overlaps {
+            let mut merged = std::mem::take(&mut groups[k]);
+            merged.append(&mut groups[k + 1]);
+            groups.remove(k + 1);
+            groups[k] = merged.clone();
+            pass(&mut merged, reference);
+            outs[k] = merged;
+            outs.remove(k + 1);
+            // A merge can create a new overlap with the group before it.
+            k = k.saturating_sub(1);
+        } else {
+            k += 1;
+        }
+    }
+    let out: Vec<Piece> = outs.into_iter().flatten().collect();
     debug_assert!(
         out.windows(2).all(|w| w[0].ref_end <= w[1].ref_start),
         "coalesce_by_run reassembled pieces out of ascending offset order: {out:?}"

--- a/tests/it/cis_confluence_2192.rs
+++ b/tests/it/cis_confluence_2192.rs
@@ -1,0 +1,327 @@
+//! #2192 / #2194 confluence corpus — generated spellings, one canonical output.
+//!
+//! The fragmentation family (#2155 / #2174 / #2175 / #2194) is about a contiguous
+//! run, or a run beside a net-imbalanced cis member, coalescing to one `delins`
+//! instead of fragmenting. The property that matters is **confluence**: every legal
+//! spelling of one `(reference, resulting)` pair must normalize to the SAME form.
+//!
+//! This builds synthetic multi-member patterns from typed members whose equivalent
+//! spellings are known by construction (a run as `delins`, as position-wise
+//! substitutions, or as `del`+`ins`; a tandem `dup` as `dup` or as `ins`), takes
+//! the cross-product of per-member spellings and member orderings (cis members are
+//! order-independent), and **filters every candidate through the independent
+//! `apply` oracle** — so a candidate that does not genuinely denote the pair is
+//! discarded rather than counted as a confluence failure. The survivors (20–100+
+//! per pattern) must all normalize to one output, in both shuffle directions.
+//!
+//! It complements `fragmentation_corpus` (which pins the recommended FORM) by
+//! attacking the CONVERGENCE of many spellings onto whatever that form is, without
+//! pinning the string — a spelling-diversity test, not an output pin.
+
+use crate::common::cis_apply_oracle::{apply, normalize_in};
+use ferro_hgvs::ShuffleDirection;
+use std::collections::BTreeSet;
+
+const PAD: &str = "CACGTACGTC";
+/// >= 2 unchanged bases so `general.md:33` keeps flanking members individual.
+const SPACER: &str = "TCGGATCAG";
+
+/// A member of a synthetic pattern. Each knows the reference bases it sits on, the
+/// bases it contributes to the resulting sequence, and every equivalent HGVS body
+/// (sans the `TEMPLATE:g.` prefix) for its own locus.
+#[derive(Clone, Copy)]
+enum Member {
+    /// Equal-length replacement `ref_seg -> alt_seg` (a run). Spellings: one
+    /// spanning `delins`, the position-wise per-column substitutions, and — when it
+    /// is a single-rotation — a `del`+`ins`. All are apply-filtered.
+    Run {
+        ref_seg: &'static str,
+        alt_seg: &'static str,
+    },
+    /// A tandem duplication of `unit` (>= 2 bases): the reference carries `unit`
+    /// once, the result twice. Spellings: `dup` and the equivalent `ins`.
+    Dup { unit: &'static str },
+    /// A plain deletion of `seg`.
+    Del { seg: &'static str },
+    /// A single substitution `from -> to`.
+    Sub { from: char, to: char },
+}
+
+impl Member {
+    fn ref_seg(&self) -> String {
+        match self {
+            Member::Run { ref_seg, .. } => (*ref_seg).to_string(),
+            Member::Dup { unit } => (*unit).to_string(),
+            Member::Del { seg } => (*seg).to_string(),
+            Member::Sub { from, .. } => from.to_string(),
+        }
+    }
+
+    /// Bases this member contributes to the resulting sequence.
+    fn alt_seg(&self) -> String {
+        match self {
+            Member::Run { alt_seg, .. } => (*alt_seg).to_string(),
+            Member::Dup { unit } => format!("{unit}{unit}"),
+            Member::Del { .. } => String::new(),
+            Member::Sub { to, .. } => to.to_string(),
+        }
+    }
+
+    /// Every equivalent HGVS body for this member placed with 1-based reference
+    /// start `p`. Candidates only — the caller apply-filters, so a body that does
+    /// not denote the pair is dropped rather than trusted.
+    fn spellings(&self, p: usize) -> Vec<String> {
+        match self {
+            Member::Run { ref_seg, alt_seg } => {
+                let len = ref_seg.len();
+                let end = p + len - 1;
+                let mut out = vec![format!("{p}_{end}delins{alt_seg}")];
+                // Position-wise substitutions: one `X>Y` per differing column. Always
+                // a legal spelling of an equal-length block (replace each column).
+                let subs: Vec<String> = ref_seg
+                    .bytes()
+                    .zip(alt_seg.bytes())
+                    .enumerate()
+                    .filter(|(_, (r, a))| r != a)
+                    .map(|(i, (r, a))| format!("{}{}>{}", p + i, r as char, a as char))
+                    .collect();
+                if subs.len() >= 2 {
+                    out.push(subs.join(";"));
+                }
+                // A single left/right rotation reads as one `del` plus one `ins`.
+                if len >= 2 {
+                    let last = alt_seg.as_bytes()[len - 1] as char;
+                    out.push(format!("{p}del;{end}_{}ins{last}", end + 1));
+                    let first = alt_seg.as_bytes()[0] as char;
+                    out.push(format!("{p}_{p}ins{first};{end}del"));
+                }
+                out
+            }
+            Member::Dup { unit } => {
+                let len = unit.len();
+                let end = p + len - 1;
+                vec![
+                    format!("{p}_{end}dup"),
+                    format!("{end}_{}ins{unit}", end + 1),
+                ]
+            }
+            Member::Del { seg } => {
+                let len = seg.len();
+                let end = p + len - 1;
+                if len == 1 {
+                    vec![format!("{p}del")]
+                } else {
+                    vec![format!("{p}_{end}del")]
+                }
+            }
+            Member::Sub { from, to } => vec![format!("{p}{from}>{to}")],
+        }
+    }
+}
+
+/// A pattern: members laid out left to right in a padded reference, separated by an
+/// unchanged spacer. Returns `(reference, resulting, one_based_start_per_member)`.
+fn build(members: &[Member]) -> (String, String, Vec<usize>) {
+    let mut reference = String::from(PAD);
+    let mut resulting = String::from(PAD);
+    let mut starts = Vec::new();
+    for (i, m) in members.iter().enumerate() {
+        if i > 0 {
+            reference.push_str(SPACER);
+            resulting.push_str(SPACER);
+        }
+        starts.push(reference.len() + 1); // 1-based reference coordinate
+        reference.push_str(&m.ref_seg());
+        resulting.push_str(&m.alt_seg());
+    }
+    reference.push_str(PAD);
+    resulting.push_str(PAD);
+    (reference, resulting, starts)
+}
+
+/// Bounded permutations of `0..n` (member orderings), capped so a wide pattern does
+/// not blow up. Cis members are order-independent, so every ordering is a spelling.
+fn orderings(n: usize, cap: usize) -> Vec<Vec<usize>> {
+    let mut out = Vec::new();
+    let mut cur: Vec<usize> = (0..n).collect();
+    // Identity first, then a bounded set of rotations + swaps — enough diversity
+    // without factorial blow-up.
+    out.push(cur.clone());
+    for shift in 1..n {
+        cur.rotate_left(1);
+        out.push(cur.clone());
+        if out.len() >= cap {
+            return out;
+        }
+        let _ = shift;
+    }
+    // Adjacent-swap variants of the identity.
+    for i in 0..n.saturating_sub(1) {
+        let mut v: Vec<usize> = (0..n).collect();
+        v.swap(i, i + 1);
+        out.push(v);
+        if out.len() >= cap {
+            break;
+        }
+    }
+    out
+}
+
+/// Every apply-verified spelling of a pattern: cross-product of per-member spellings
+/// and member orderings, wrapped as an allele, kept only if it denotes the pair.
+fn spellings_of(
+    members: &[Member],
+    reference: &str,
+    resulting: &str,
+    starts: &[usize],
+) -> Vec<String> {
+    let per_member: Vec<Vec<String>> = members
+        .iter()
+        .zip(starts)
+        .map(|(m, &p)| m.spellings(p))
+        .collect();
+    // Cross-product of one spelling choice per member.
+    let mut choices: Vec<Vec<String>> = vec![Vec::new()];
+    for opts in &per_member {
+        let mut next = Vec::new();
+        for prefix in &choices {
+            for o in opts {
+                let mut c = prefix.clone();
+                c.push(o.clone());
+                next.push(c);
+            }
+        }
+        choices = next;
+        if choices.len() > 4096 {
+            choices.truncate(4096);
+        }
+    }
+    let mut spellings: BTreeSet<String> = BTreeSet::new();
+    for choice in &choices {
+        for ord in orderings(members.len(), 8) {
+            let bodies: Vec<&str> = ord.iter().map(|&i| choice[i].as_str()).collect();
+            // Each body may itself carry `;` (a run's del+ins / subs), so joining
+            // yields a flat member list — exactly what a cis allele is.
+            let inner = bodies.join(";");
+            let desc = if members.len() == 1 && !inner.contains(';') {
+                format!("TEMPLATE:g.{inner}")
+            } else {
+                format!("TEMPLATE:g.[{inner}]")
+            };
+            if apply(reference, &desc).as_deref() == Some(resulting) {
+                spellings.insert(desc);
+            }
+        }
+    }
+    spellings.into_iter().collect()
+}
+
+/// The synthetic #2192/#2194 corpus: net-imbalanced members (`dup`, `del`) beside
+/// equal-length runs and substitutions, in the orderings the family stresses.
+fn corpus() -> Vec<Vec<Member>> {
+    let run4 = Member::Run {
+        ref_seg: "GACT",
+        alt_seg: "ACTG",
+    };
+    let run3 = Member::Run {
+        ref_seg: "ATA",
+        alt_seg: "TAC",
+    };
+    let dup = Member::Dup { unit: "AG" };
+    let del = Member::Del { seg: "T" };
+    let del2 = Member::Del { seg: "GT" };
+    let sub = Member::Sub { from: 'C', to: 'A' };
+    vec![
+        // Single runs (the #2174 base case).
+        vec![run4],
+        vec![run3],
+        // Run beside a substitution (#2192 Ex1/Ex3 shape).
+        vec![sub, run4],
+        vec![run4, sub],
+        // Dup 5' of a run (#2194 — the fix under test).
+        vec![dup, run4],
+        vec![dup, run3, sub],
+        // Del 5' of a run (the broader net-imbalanced-5'-member class).
+        vec![del, run4],
+        vec![del2, run4, sub],
+        // Runs on both sides of a net-imbalanced member.
+        vec![run4, dup, run3],
+        vec![run3, del, run4],
+        // Denser mixes.
+        vec![sub, run4, dup, run3],
+        vec![dup, sub, run4, del, run3],
+    ]
+}
+
+fn assert_confluent(members: &[Member], direction: ShuffleDirection) {
+    let (reference, resulting, starts) = build(members);
+    let spellings = spellings_of(members, &reference, &resulting, &starts);
+    // Non-vacuity: the generator must have produced a real spread of spellings, or a
+    // silent zero would pass while testing nothing (the "a corpus zero is a claim
+    // about the corpus" trap).
+    // A lone run still yields three genuinely different spellings (spanning
+    // `delins`, position-wise substitutions, and `del`+`ins`); a multi-member
+    // pattern yields many more (per-member forms x orderings).
+    let floor = if members.len() == 1 { 3 } else { 6 };
+    assert!(
+        spellings.len() >= floor,
+        "only {} apply-verified spellings for {members:?}-shaped pattern (floor {floor}) — \
+         the generator is not exercising the confluence it claims to",
+        spellings.len(),
+    );
+    // Every spelling normalizes to ONE canonical form.
+    let mut outputs: BTreeSet<String> = BTreeSet::new();
+    let mut first: Option<(String, String)> = None;
+    for s in &spellings {
+        let out = normalize_in(&reference, s, direction);
+        // Meaning preservation: the normalized output still denotes the pair.
+        assert_eq!(
+            apply(&reference, &out).as_deref(),
+            Some(resulting.as_str()),
+            "{direction:?}: normalized output does not denote the pair\n  spelling: {s}\n  output:   {out}"
+        );
+        if first.is_none() {
+            first = Some((s.clone(), out.clone()));
+        }
+        outputs.insert(out);
+    }
+    assert_eq!(
+        outputs.len(),
+        1,
+        "{direction:?}: {} spellings did NOT converge — {} distinct outputs:\n{}",
+        spellings.len(),
+        outputs.len(),
+        outputs
+            .iter()
+            .take(8)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+}
+
+// Debug is needed for the assertion messages above.
+impl std::fmt::Debug for Member {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Member::Run { ref_seg, alt_seg } => write!(f, "Run({ref_seg}->{alt_seg})"),
+            Member::Dup { unit } => write!(f, "Dup({unit})"),
+            Member::Del { seg } => write!(f, "Del({seg})"),
+            Member::Sub { from, to } => write!(f, "Sub({from}>{to})"),
+        }
+    }
+}
+
+#[test]
+fn generated_spellings_converge_three_prime() {
+    for members in corpus() {
+        assert_confluent(&members, ShuffleDirection::ThreePrime);
+    }
+}
+
+#[test]
+fn generated_spellings_converge_five_prime() {
+    for members in corpus() {
+        assert_confluent(&members, ShuffleDirection::FivePrime);
+    }
+}

--- a/tests/it/fragmentation_corpus.rs
+++ b/tests/it/fragmentation_corpus.rs
@@ -398,14 +398,12 @@ const BASE_TEMPLATES: &[RunTemplate] = &[
 
 /// A reference tandem (`AGAG`) expanded by one unit beside a substitution ->
 /// `[dup; sub]`, TWO members (#2175). This is the member-count (arity) axis: one
-/// run that is two members. A `dup` is net-imbalanced and content-defined, so the
-/// zero-shift grouping isolates it only when nothing follows it (see
-/// `coalesce_by_run`'s deferral note); the cross-product therefore places it only
-/// as the FINAL run. `dup`-before-another-run is deferred to a segment-first
-/// partition and is asserted UNCHANGED (still fragmenting) by
-/// `a_dup_before_another_run_is_left_for_category_one` below, so the boundary is
-/// pinned rather than silent.
-const TRAILING_DUP: RunTemplate = RunTemplate {
+/// run that is two members. A `dup` is net-imbalanced and content-defined; since
+/// #2194 the suffix-closure grouping in `coalesce_by_run` isolates it wherever it
+/// sits — its permanent length shift earns a closure/content wall regardless of
+/// what follows — so the cross-product places it at EVERY position, the
+/// `dup`-before-a-run shape included (`a_dup_before_another_run_reaches_the_recommended_form`).
+const DUPSUB: RunTemplate = RunTemplate {
     name: "dupsub",
     ref_seg: "AGAGC",
     alt_seg: "AGAGAGA",
@@ -522,7 +520,7 @@ fn base_tuples(len: u32) -> Vec<Vec<&'static RunTemplate>> {
 }
 
 /// The largest run count the exhaustive cross-product enumerates. Five net-zero
-/// runs (and a sixth when a trailing `dup` is appended) exercises the four- and
+/// runs (and a sixth when a `dup` is inserted) exercises the four- and
 /// five-member alleles #2192 is about at full arity, in every ordering — the whole
 /// point being that the per-run coalesce must not depend on how many members
 /// precede or follow a run.
@@ -532,10 +530,11 @@ const MAX_RUNS: u32 = 5;
 ///
 /// - all base-template tuples of length `1..=MAX_RUNS` (run count and member count
 ///   both `1..=5`, every shape mix and ordering), and
-/// - all base-template tuples of length `0..MAX_RUNS` with a `TRAILING_DUP`
-///   appended (the member-count axis: the two-member `dup` run raises member count
-///   as high as six while run count stays `1..=5`, `dup` always last so the
-///   zero-shift grouping isolates it).
+/// - all base-template tuples of length `0..MAX_RUNS` with a `DUPSUB` inserted at
+///   EVERY position (the member-count axis: the two-member `dup` run raises member
+///   count as high as six while run count stays `1..=5`; since #2194 the grouping
+///   isolates the `dup` at any index, so it is enumerated at each — the
+///   `dup`-before-a-run shape that used to be deferred is now covered here).
 fn cells() -> Vec<Cell> {
     let mut cells = Vec::new();
     for len in 1..=MAX_RUNS {
@@ -544,9 +543,14 @@ fn cells() -> Vec<Cell> {
         }
     }
     for len in 0..MAX_RUNS {
-        for mut templates in base_tuples(len) {
-            templates.push(&TRAILING_DUP);
-            cells.push(Cell { templates });
+        for templates in base_tuples(len) {
+            for pos in 0..=templates.len() {
+                let mut with_dup = templates.clone();
+                with_dup.insert(pos, &DUPSUB);
+                cells.push(Cell {
+                    templates: with_dup,
+                });
+            }
         }
     }
     cells
@@ -781,24 +785,25 @@ fn the_issue_2192_reprexes_reach_the_recommended_form() {
 
 proptest! {
     // Randomised extension of the exhaustive cross-product: a cell of 1..=6 net-zero
-    // runs in any order, with an optional trailing `dup`, in either shuffle
-    // direction. It samples the same shape `cells()` enumerates but out to higher
-    // arity and beyond what an exhaustive `MAX_RUNS` can reach, so a fragmentation
-    // that only appears at some member count or ordering the fixed set happens to
-    // miss still fails. `assert_cell` is the identical property the two exhaustive
-    // tests check. The strategy draws only from known-good templates, so every cell
-    // is well-formed — a failure is a real fragmentation, never a malformed input.
+    // runs in any order, with an optional `dup` inserted at ANY position, in either
+    // shuffle direction. It samples the same shape `cells()` enumerates but out to
+    // higher arity and beyond what an exhaustive `MAX_RUNS` can reach, so a
+    // fragmentation that only appears at some member count or ordering the fixed set
+    // happens to miss still fails. `assert_cell` is the identical property the two
+    // exhaustive tests check. The strategy draws only from known-good templates, so
+    // every cell is well-formed — a failure is a real fragmentation, never a
+    // malformed input.
     #![proptest_config(ProptestConfig::with_cases(512))]
     #[test]
     fn fuzz_the_cross_product(
         base_idx in proptest::collection::vec(0usize..BASE_TEMPLATES.len(), 1..=6),
-        trailing_dup in any::<bool>(),
+        dup_pos in proptest::option::of(0usize..=6),
         five_prime in any::<bool>(),
     ) {
         let mut templates: Vec<&'static RunTemplate> =
             base_idx.iter().map(|&i| &BASE_TEMPLATES[i]).collect();
-        if trailing_dup {
-            templates.push(&TRAILING_DUP);
+        if let Some(pos) = dup_pos {
+            templates.insert(pos.min(templates.len()), &DUPSUB);
         }
         let direction = if five_prime {
             ShuffleDirection::FivePrime
@@ -809,17 +814,17 @@ proptest! {
     }
 }
 
-/// The one shape the per-run grouping deliberately does NOT reach: a
-/// net-imbalanced `dup` sitting 5' of another run. The `dup`'s length change is
-/// banked but content-defined, so the zero-shift grouping cannot isolate it from
-/// what follows (see `coalesce_by_run`'s deferral note), and both the `dup` and
-/// the trailing run fragment. This is the Track-2 / segment-first-partition work
-/// tracked by #2194. This pins that boundary — asserting the DEFECT, in the manner
-/// of `issue_1610`'s `a_lone_unequal_length_delins_is_not_split` — so a future
-/// segment-first partition that closes it flips this test loudly rather than
-/// moving the row in silence. The output still denotes the right sequence.
+/// The exact #2194 reprex, now CLOSED: a net-imbalanced `dup` sitting 5' of another
+/// run. Before the suffix-closure grouping the `dup`'s banked length shift starved
+/// the downstream run of its zero-shift wall, so both fragmented; now the closure
+/// license (a permanent shift never returns to baseline) and the content license (a
+/// group that peels to a `dup` cannot collapse anyway) isolate the `dup`, so BOTH it
+/// and the run reach their recommended forms. Kept as a named guard for the exact
+/// strings from the report, alongside the generalised cross-product that now
+/// enumerates a `dup` in every position. Direction-independent: the `dup` places
+/// 3'-most and the run is a full-span `delins`, so both surfaces reach one form.
 #[test]
-fn a_dup_before_another_run_is_left_for_category_one() {
+fn a_dup_before_another_run_reaches_the_recommended_form() {
     // A `dup` run (`AGAGC -> AGAGAGA`, positions 11-15) 5' of a balanced4 run
     // (`GACT -> ACTG`, positions 25-28).
     let reference = "CACGTACGTCAGAGCTCGGATCAGGACTCACGTACGTC";
@@ -831,32 +836,50 @@ fn a_dup_before_another_run_is_left_for_category_one() {
         Some(resulting),
         "recommended form must denote the resulting sequence"
     );
-    for (direction, deferred) in [
-        (
-            ShuffleDirection::ThreePrime,
-            "TEMPLATE:g.[15delinsAGA;25del;28_29insG]",
-        ),
-        (
-            ShuffleDirection::FivePrime,
-            "TEMPLATE:g.[15delinsAGA;24del;28_29insG]",
-        ),
-    ] {
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
         let got = from_seq_dir(reference, resulting, direction).to_string();
-        assert_ne!(
-            got, recommended,
-            "{direction:?}: dup-before-run unexpectedly reached the recommended form — \
-             if a segment-first partition now closes this, move the cell into the \
-             cross-product above"
-        );
         assert_eq!(
-            got, deferred,
-            "{direction:?}: deferred fragmentation form moved"
+            got, recommended,
+            "{direction:?}: dup-before-run did not reach the recommended form"
         );
-        // Whatever it emits, it still denotes the resulting sequence.
+        // The output still denotes the resulting sequence.
         assert_eq!(
             apply(reference, &got).as_deref(),
             Some(resulting),
-            "{direction:?}: the deferred output changed the sequence"
+            "{direction:?}: the output changed the sequence"
+        );
+    }
+}
+
+/// The del-analogue of #2194: a plain deletion (net -1) 5' of a separate run
+/// starved the downstream run of its zero-shift wall in the same way — the residual
+/// class is "any net-imbalanced 5' member", not only a `dup` (per the #2195
+/// gauntlet). The closure license (a permanent shift that never returns to
+/// baseline) isolates the del so the run collapses. Named guard for the del case,
+/// which no `BASE_TEMPLATE` carries and the cross-product therefore cannot reach.
+#[test]
+fn a_del_before_another_run_reaches_the_recommended_form() {
+    // A single-base del (`A` at position 11) 5' of a balanced4 run (`GACT -> ACTG`,
+    // positions 21-24). The `A` is unique in its neighbourhood, so the del is
+    // unambiguous and direction-independent.
+    let reference = "CACGTACGTCATCGGATCAGGACTCACGTACGTC";
+    let resulting = "CACGTACGTCTCGGATCAGACTGCACGTACGTC";
+    let recommended = "TEMPLATE:g.[11del;21_24delinsACTG]";
+    assert_eq!(
+        apply(reference, recommended).as_deref(),
+        Some(resulting),
+        "recommended form must denote the resulting sequence"
+    );
+    for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime] {
+        let got = from_seq_dir(reference, resulting, direction).to_string();
+        assert_eq!(
+            got, recommended,
+            "{direction:?}: del-before-run did not reach the recommended form"
+        );
+        assert_eq!(
+            apply(reference, &got).as_deref(),
+            Some(resulting),
+            "{direction:?}: the output changed the sequence"
         );
     }
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -93,6 +93,7 @@ mod cds_utr3_crossing_shift_idempotency;
 mod census_filter_invariant;
 mod cis_adjudication_enumeration;
 mod cis_allele_confluence_proptest;
+mod cis_confluence_2192;
 mod cis_confluence_adjudication;
 mod cis_confluence_axis;
 mod cis_confluence_nr_axis;


### PR DESCRIPTION
Closes #2194.

`coalesce_by_run` split runs only at a zero-shift fixed point (running net-length delta `== 0` at a gap), so a net-imbalanced 5′ member — a `dup` or a plain `del` — kept the running delta non-zero across the gap to a *separate* downstream run, sweeping it into one group where the collapse pass declined and left it fragmented. This was #2194, the deferred residual of #2192.

## The fix

Replace the single zero-shift test with a two-license stack rule:

- **pop** — delta returns to a stacked baseline (`0` is pinned at the bottom, so every prior wall still fires byte-identically);
- **closure** — no stacked baseline recurs downstream, so the excursion is a *permanent* frame shift and the run 3′ of it is separate.

A downstream equal-length run is then isolated into its own group and collapses to one `delins` per #2174, whether the 5′ member is a `dup` or a `del`. Reassembly re-runs the pass per group and merges any adjacent groups whose outputs overlap (peel's tandem-tract widening can legitimately cross a wall inside a reference tandem), so the ascending-offset invariant holds by construction.

## Tests

The fragmentation cross-product now places the `dup` at every position (not only last), a del-5′ guard is added, and the deferred #2194 tripwire becomes a positive guard. A second commit adds a generated-spelling confluence corpus (`cis_confluence_2192`): synthetic patterns → many apply-verified spellings (`delins` / position-wise subs / `del+ins` / `dup`/`ins` × member orderings) → assert all converge to one form, both shuffle directions.

## Scope

**Accepted residual:** an imbalanced member compensated by a *distant* opposite imbalance (`[dup+2]…[del−2]`, delta returns to 0) still declines — never wrong, just uncoalesced; the delta profile can't tell it from a scrambled equal-length block that must stay whole.

**Two dense re-derivations** move to an insertion-only form over a `[sub;dup]` baseline. These are ledger-consistent: the baseline describes a base every minimal alignment leaves unchanged as changed, which `unchanged-is-read-over-every-minimal-alignment` refutes (cf. open #2158, #2193). Flagged for reviewer visibility.

This is an incremental post-partition coalesce, in the family @msto's [root-cause comment](https://github.com/fulcrumgenomics/ferro-hgvs/issues/2192#issuecomment-5371597856) discusses; its frame-baseline/position-wise mechanism imports the live-partitioning insight into the pass, but the residual and #2193 remain the signal for the architectural fix (live partitioning for equal-length blocks).

Representation-Change: moves 181 of 44,020 derived outputs on a 22,010-pair aggregate corpus (net-imbalanced-5′-member + run geometry, fragmented → coalesced), all meaning-preserving and idempotent — ~90 coalesce a run to one delins, ~82 expose a duplication.md:18-mandated dup a delins/ins was hiding (#2175), 0 alter an inversion. The repo's confluence (separations 0–8) and spec-conformance censuses are unchanged (0 rows move there); this geometry is not in those corpora.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved normalization of complex runs containing duplications, deletions, and substitutions.
  - Preserved meaningful boundaries while identifying additional run boundaries.
  - Improved handling of overlapping or adjacent variant groups for ordered, non-overlapping results.
  - Equivalent cis spellings now converge more reliably under three-prime and five-prime shuffling.
  - Fixed ordering cases involving duplications or deletions before other variant runs while preserving sequence meaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->