### PR TITLE
perf(ci): reduce CI wall-time via test slicing, job splits, and shard rebalance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,7 +857,10 @@ jobs:
       #   `test-build` (`CARGO_PROFILE_TEST_DEBUG=0`) serving each other useless
       #   trees. `rust-cache` keys per job by default; `key` below only adds a
       #   legible name, so `gh api .../actions/caches` stays diagnosable — which
-      #   is how #1218 was diagnosed in the first place.
+      #   is how #1218 was diagnosed in the first place. The one deliberate
+      #   exception is the `build-lint` / `build-release-check` pair below, which
+      #   DO share one entry via `shared-key: build-release` — safe there, and only
+      #   there, because one job's deps are a strict superset of the other's.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           # Save a new cache generation ONLY from `main` (#1218 redux). `rust-cache`
@@ -1469,7 +1472,7 @@ jobs:
   # stable as tests are added. Verified even on this suite: 8646 tests split
   # 2148 / 2181 / 2162 / 2155 across four shards.
   test:
-    name: Test (${{ matrix.shard }}/6)
+    name: Test (${{ matrix.shard }}/8)
     needs: [test-build, spec-fixtures, fixtures]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1478,7 +1481,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -1547,7 +1550,7 @@ jobs:
         if: matrix.shard == 1
         run: |
           echo "::notice title=Reference-aware tests skipped on PR CI::PR CI does not provision FERRO_MANIFEST; the mutalyzer / biocommons reference-aware test suites silently skip, and nextest reports that skip path as PASS rather than SKIP. No gating job runs those axes, so a denoted-sequence violation on them still cannot redden a required check (#1815). The nightly nightly-mutalyzer.yml workflow runs the full suite against a real manifest, non-gating."
-      - name: Run Rust tests (shard ${{ matrix.shard }} of 6)
+      - name: Run Rust tests (shard ${{ matrix.shard }} of 8)
         env:
           # Absence of a bulk fixture must FAIL here, never skip. The bulk and
           # exhaustive suites `return` early on a missing file, so without this
@@ -1560,14 +1563,14 @@ jobs:
         # archive from `test-build-soak` is reserved for `soak` and `sweeps`.
         #
         # Proptests are excluded here and owned entirely by the `soak` job,
-        # which runs them at 125k cases per shard instead of 12k. Leaving them
+        # which runs them at 100k cases per shard instead of 12k. Leaving them
         # in would run the same properties twice at strictly lower depth AND
         # wreck shard balance: measured locally, the shard holding them took
         # 66.6s against 8.8-13.5s for its siblings.
         run: |
           scripts/run_nextest_archive.sh --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
-            --partition hash:${{ matrix.shard }}/6 \
+            --partition hash:${{ matrix.shard }}/8 \
             -E "not test(proptest) and not ($SWEEP_FILTER) and not ($CENSUS_FILTER) and not ($ORACLE_ONLY_FILTER)"
 
   # The idempotency oracle re-run. Deliberately EXCLUDES the proptest modules:
@@ -1607,11 +1610,34 @@ jobs:
   # that was the right price: a negation is stable under a re-roll and a shard
   # count is not.
   #
-  # N stays at 4. Nothing now depends on which shard a particular test lands in,
-  # so the number is once again merely conventional; it is left alone because
-  # changing it re-rolls every assignment for no measured gain.
+  # N is 10. The "no measured gain" that kept it at 4 held only while this job was
+  # NOT the whole workflow's critical path. Once the sharded test binaries stopped
+  # having a single multi-minute dominator, this job's max shard became the pole
+  # that sets the run's wall time, and lowering that pole IS a measured gain.
+  #
+  # `--partition hash` balances test COUNTS and is blind to cost, and cost is what
+  # sets the wall. A shard runs its tests ~4-up on the 4-vCPU runner, so its wall
+  # is (sum of its tests' seconds) / ~3.8 — a LOAD figure, not a slowest-test one.
+  # After #01 sliced the former heaviest censuses into per-slice tests, no single
+  # test is a hard floor, so the pole is pure load imbalance across the bins.
+  #
+  # Measured at N=4 the shards ran ~2825 tests each (balanced to 0.5%) carrying a
+  # 3.1x test-seconds spread set only by which heavy tests co-hashed. N=6 bought
+  # ~12s of whole-run wall; N=8 topped out near 107s on its heaviest shard; N=10
+  # spreads the heavy load-chunks across more bins, dropping the pure-partition
+  # max toward ~90s/shard. Past ~10 the fixed per-shard prefix (archive download
+  # ~24s) and rising cross-shard download contention stop the marginal shard from
+  # helping. One shard additionally carries the un-partitioned
+  # SEQUENCE_ORACLE_EXCLUDE step (5 tests, ~27s); it is deliberately placed on a
+  # light partition shard (see that step) so it does not become the pole — the
+  # pole is the heaviest pure-partition shard, set by hash clustering.
+  #
+  # So the number is chosen against wall time now, not left conventional. If a
+  # future test's own seconds ever approach a per-shard budget, the stable fix is
+  # to SLICE it (as #01 sliced the geometry corpus) or carve it into its own job
+  # (as CENSUS_FILTER did) — never a shard-count bump chased against one snapshot.
   test-oracle:
-    name: Test oracle (${{ matrix.shard }}/4)
+    name: Test oracle (${{ matrix.shard }}/10)
     needs: [test-build, spec-fixtures, fixtures]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1620,7 +1646,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -1849,7 +1875,7 @@ jobs:
         run: |
           scripts/run_nextest_archive.sh --archive-file nextest.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite \
-            --partition hash:${{ matrix.shard }}/4 \
+            --partition hash:${{ matrix.shard }}/10 \
             -E "not test(proptest) and not ($SWEEP_FILTER) and not ($ORACLE_EXCLUDE) and not ($CENSUS_FILTER) and not ($SEQUENCE_ORACLE_EXCLUDE)"
       # The other half of the trade, and the reason arming the flag above costs no
       # coverage: the rows `SEQUENCE_ORACLE_EXCLUDE` withholds from the armed step
@@ -1858,23 +1884,30 @@ jobs:
       # four — three oracles surrendered to gain one.
       #
       # Runs on ONE shard and UN-partitioned, deliberately. It selects 5 tests, so
-      # `--partition hash:K/4` would leave some shards selecting none, and neither
+      # `--partition hash:K/10` would leave some shards selecting none, and neither
       # answer to that is acceptable: `--no-tests=fail` would redden a shard for
       # doing its job, and `--no-tests=pass` would be a step that goes green having
       # run nothing — the vacuous pass this repository keeps meeting. Un-partitioned
-      # on shard 1 with `--no-tests=fail` instead, so a rename that empties the
+      # on ONE shard with `--no-tests=fail` instead, so a rename that empties the
       # filter is loud rather than silent. These rows ran exactly once per CI run
       # before this change too, spread across the shards, so nothing runs twice and
       # nothing runs less.
       #
-      # It carries no `if: always()`, so a red armed step on shard 1 skips it. That
+      # It rides shard 3, not shard 1: this ~27s step stacks onto whichever shard
+      # runs it, so it belongs on a light one rather than adding to a heavy one and
+      # becoming the oracle's straggler. Shard 3 is a historically light partition;
+      # the choice is not load-bearing (the whole-run wall is bounded by the release
+      # build, and the pole among the pure-partition shards sits above this step
+      # either way), only a smaller-is-better placement.
+      #
+      # It carries no `if: always()`, so a red armed step on shard 3 skips it. That
       # is the intended reading: the job is already failing and the useful signal is
       # the armed step's own failure, not a further confirmation that five withheld
       # rows still pass. Nothing here can turn a red job green — the concern the
       # `.github/workflows/**` review rule raises about a skipped step is coverage
       # lost on a PASSING run, and on a passing run this step always executes.
       - name: Run the sequence-oracle exclusions under the other three oracles
-        if: matrix.shard == 1
+        if: matrix.shard == 3
         env:
           FERRO_ASSERT_IDEMPOTENT: "1"
           FERRO_ASSERT_REPARSE: "1"
@@ -1885,7 +1918,7 @@ jobs:
             --extract-to . --extract-overwrite --no-tests=fail \
             -E "$SEQUENCE_ORACLE_EXCLUDE"
 
-  # 1,000,000-case idempotency soak on every PR, split 8 ways.
+  # 1,000,000-case idempotency soak on every PR, split 10 ways.
   #
   # Why this job exists: PR CI's ordinary 12k-case run has never caught one of
   # this campaign's idempotency defects. #1210 first reproduced at ~150,000
@@ -1903,14 +1936,14 @@ jobs:
   # Why sharding the SEED and not the test list: `--partition` splits at test
   # granularity, and the cost here sits inside a handful of property functions
   # that each run their cases serially. Partitioning bottoms out at the slowest
-  # single property. Eight shards of 125k cases under eight distinct seeds cover
+  # single property. Ten shards of 100k cases under ten distinct seeds cover
   # the same 1M cases in a fraction of the wall time, and decorrelated streams
   # are if anything better coverage than one stream of 1M.
   #
   # The nightly counterpart (nightly-soak.yml) runs the same depth UNSEEDED, so
   # new territory still gets explored — it just reports instead of blocking.
   soak:
-    name: Idempotency soak (${{ matrix.shard }}/8)
+    name: Idempotency soak (${{ matrix.shard }}/10)
     # Only the optimized archive, NOT `test-build`. Every test the selection
     # below reaches lives in `tests/it/{cis_allele_confluence,
     # from_sequences, minimal_alignment_enumeration,
@@ -1934,9 +1967,10 @@ jobs:
     # re-checked rather than assumed: its eight properties are pure functions of
     # a generated `(reference, alternate)` byte pair, reading no provider and no
     # fixture. Its cost was measured too, because the enumerator it exercises is
-    # exponential in block length — `PROPTEST_CASES=125000` over the module
-    # costs 56.7 s wall in the *test* profile, i.e. before this job's ~5.4x
-    # optimization. That is bounded by its own `MAX_BLOCK_LEN` of 6; raising it
+    # exponential in block length — at the former `PROPTEST_CASES=125000` the
+    # module cost 56.7 s wall in the *test* profile (before this job's ~5.4x
+    # optimization); the 100k setting here scales to ~45 s. Bounded by its own
+    # `MAX_BLOCK_LEN` of 6; raising it
     # is a soak-cost decision, not only a coverage one.
     needs: test-build-soak
     runs-on: ubuntu-latest
@@ -1946,7 +1980,7 @@ jobs:
       matrix:
         # Distinct arbitrary seeds; the values matter only in that they differ
         # and are fixed. Changing one changes which cases that shard explores.
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         include:
           - { shard: 1, seed: 1000001 }
           - { shard: 2, seed: 2000003 }
@@ -1956,6 +1990,8 @@ jobs:
           - { shard: 6, seed: 6000023 }
           - { shard: 7, seed: 7000003 }
           - { shard: 8, seed: 8000009 }
+          - { shard: 9, seed: 9000011 }
+          - { shard: 10, seed: 10000019 }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -1972,10 +2008,10 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: nextest-archive-soak
-      - name: Soak 125k cases (seed ${{ matrix.seed }})
+      - name: Soak 100k cases (seed ${{ matrix.seed }})
         env:
-          # 8 shards x 125k = 1,000,000 cases per property.
-          PROPTEST_CASES: "125000"
+          # 10 shards x 100k = 1,000,000 cases per property.
+          PROPTEST_CASES: "100000"
           PROPTEST_RNG_SEED: ${{ matrix.seed }}
           # `core_strategy`'s body-length filter rejects a steady ~6.7% of
           # draws, so proptest's absolute 65_536 local-reject cap aborts a long
@@ -2110,31 +2146,36 @@ jobs:
             --extract-to . --extract-overwrite --no-tests=fail \
             -E "$SWEEP_FILTER + test(issue_1615_denoted_sequence_oracle)"
 
-  # `CENSUS_FILTER`'s modules, moved off the `test` / `test-oracle` partitions
-  # and onto the optimized archive. See that filter's own comment for why they
-  # moved; this one is about how the job preserves what they were doing.
+  # The ARMED half of `CENSUS_FILTER`'s modules, moved off the `test` /
+  # `test-oracle` partitions and onto the optimized archive. See that filter's
+  # own comment for why they moved; this one is about how the job preserves what
+  # they were doing.
   #
-  # TWO STEPS, because the modules do not agree about the oracles and the
-  # difference is not a detail:
+  # This job runs ONLY the armed census. The un-armed half —
+  # `spec_conformance_axis`, which must NOT be armed — runs in the separate
+  # `censuses-plain` job below, split out so the two halves run in PARALLEL
+  # rather than as two serial steps of one job (see that job's header for the
+  # wall-time measurement). They are split because the modules do not agree
+  # about the oracles:
   #
-  #   * ARMED runs what `test-oracle` ran, with the same three flags and no
-  #     fourth. An armed run strictly subsumes the un-armed one — the oracles
+  #   * ARMED (here) runs what `test-oracle` ran, with the same three flags and
+  #     no fourth. An armed run strictly subsumes the un-armed one — the oracles
   #     add assertions at `normalize_core_checked`'s exit and change no
   #     behaviour — which is the same argument `sweeps` makes, so dropping the
-  #     plain-`test` copy of these two modules loses nothing.
-  #   * UN-ARMED runs `spec_conformance_axis`, which is in `ORACLE_EXCLUDE` and
-  #     must stay that way: it COUNTS the non-idempotent outputs
-  #     `FERRO_ASSERT_IDEMPOTENT` panics on, and a panicking row is filed
+  #     plain-`test` copy of these modules loses nothing.
+  #   * UN-ARMED (`censuses-plain`) runs `spec_conformance_axis`, which is in
+  #     `ORACLE_EXCLUDE` and must stay that way: it COUNTS the non-idempotent
+  #     outputs `FERRO_ASSERT_IDEMPOTENT` panics on, and a panicking row is filed
   #     `declined` and never reaches the family's output set — which does not
   #     redden the census, it FLATTERS it. That module ran only in the plain
-  #     `test` job before, so this step reproduces it exactly.
+  #     `test` job before, so `censuses-plain` reproduces it exactly.
   #
-  # `FERRO_ASSERT_SEQUENCE` is set by NEITHER step, which is what makes this a
+  # `FERRO_ASSERT_SEQUENCE` is set by NEITHER job, which is what makes this a
   # move rather than a change of instrument. `sweeps` does set it, so these
   # modules could not simply be appended there.
   #
-  # #1815 armed that flag in `test-oracle`, so this job's armed step no longer
-  # mirrors that job's flag set — it is now a strict SUBSET of it, deliberately.
+  # #1815 armed that flag in `test-oracle`, so this job's armed flag set no
+  # longer mirrors that job's — it is now a strict SUBSET of it, deliberately.
   # Arming a fourth oracle here would be exactly the change of instrument the
   # paragraph above refuses, and it has NOT been measured over
   # `ORACLE_ONLY_FILTER`'s modules. Do not "restore parity" by copying the flag
@@ -2201,12 +2242,39 @@ jobs:
           scripts/run_nextest_archive.sh --archive-file nextest-soak.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite --no-tests=fail \
             -E "test(issue_1542_direction_symmetry) + test(normalize_axis_preserving) + test(clinvar_hgvs_tests)"
+
+  # The un-armed half of the censuses, split into its OWN job so it runs in
+  # PARALLEL with the armed half above rather than after it. On the optimized
+  # soak archive the two halves measured 43s (armed) and 50s (un-armed), so a
+  # single job spent ~93s of nextest serially and completed ~+4:05 from run
+  # start — over the 4-minute target. As two jobs the wall is the slower half,
+  # ~+3:30. This job carries NO bulk fixtures (its modules build their corpus in
+  # code, `conformance::spec_corpus`, and read nothing from disk), so it also
+  # skips that 156 MB download. Both jobs gate the merge through `test-required`.
+  censuses-plain:
+    name: Slow censuses plain (optimized)
+    # Only the optimized archive. NOT spec-fixtures: the two modules below build
+    # their corpus in code (`conformance::spec_corpus`) and read no fixture, and
+    # neither is named in the `pregenerate-spec-fixtures` nextest setup-script
+    # filter (`.config/nextest.toml`), so the script never fires here either.
+    # Depending on spec-fixtures would only serialize this job behind that build.
+    needs: test-build-soak
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: nextest-archive-soak
       - name: Run the censuses that may not be measured with an oracle armed
         # No `FERRO_ASSERT_*` here, deliberately, and no bulk fixtures: these
         # modules build their corpus in code (`conformance::spec_corpus`) and
         # read nothing from disk. `conformance_census_runs` (#2094) joins
         # `spec_conformance_axis` here because `run_census` refuses outright
-        # with a seam oracle armed, which would fail the armed step below.
+        # with a seam oracle armed, which would fail an armed run.
         run: |
           scripts/run_nextest_archive.sh --archive-file nextest-soak.tar.zst --workspace-remap . \
             --extract-to . --extract-overwrite --no-tests=fail \
@@ -2314,7 +2382,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [test, test-oracle, soak, sweeps, censuses, hgvs-rs-tests]
+    needs: [test, test-oracle, soak, sweeps, censuses, censuses-plain, hgvs-rs-tests]
     # `always()` so a failed or cancelled dependency still reports a conclusion
     # rather than leaving the required context pending forever.
     if: always()
@@ -2326,12 +2394,14 @@ jobs:
           echo "soak            = ${{ needs.soak.result }}"
           echo "sweeps          = ${{ needs.sweeps.result }}"
           echo "censuses        = ${{ needs.censuses.result }}"
+          echo "censuses-plain  = ${{ needs.censuses-plain.result }}"
           echo "hgvs-rs-tests   = ${{ needs.hgvs-rs-tests.result }}"
           if [ "${{ needs.test.result }}" != "success" ] \
             || [ "${{ needs.test-oracle.result }}" != "success" ] \
             || [ "${{ needs.soak.result }}" != "success" ] \
             || [ "${{ needs.sweeps.result }}" != "success" ] \
             || [ "${{ needs.censuses.result }}" != "success" ] \
+            || [ "${{ needs.censuses-plain.result }}" != "success" ] \
             || [ "${{ needs.hgvs-rs-tests.result }}" != "success" ]; then
             echo "::error::one or more test jobs did not succeed"
             exit 1
@@ -2451,8 +2521,18 @@ jobs:
           --rootdir=/tmp
           "$GITHUB_WORKSPACE/tests/python/" -v
 
-  build:
-    name: Build
+  # The Build gate is two parallel jobs behind a `Build` rollup. It used to be one
+  # job running ~47s of release-clippy + default-feature guard IN SERIES ahead of
+  # the release build. Split, `build-release-check` (release build + size) runs
+  # alongside `build-lint` (clippy --release + featureless guard) rather than
+  # behind it, and the rollup reports the required `Build` context (the
+  # `test-required` pattern). NO new rust-cache key is added: both jobs
+  # `shared-key: build-release` (see each block) so they share ONE entry — which
+  # matters near the 10 GiB cap (#1218), and is why the sharing had to be
+  # `shared-key`, not `key` (`key` appends the job id, giving two cold per-job
+  # entries).
+  build-lint:
+    name: Build lint
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -2463,36 +2543,41 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
-          # For the release-profile lint below. The two `clippy` jobs request the
-          # component the same way; without it `cargo clippy` is not installed.
+          # For the release-profile lint below; without it `cargo clippy` is not
+          # installed.
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
-          # Save only from `main` — see the note on the first
-          # `rust-cache` block in this file.
+          # This job OWNS one shared cache entry that `build-release-check`
+          # restores read-only. `shared-key` (NOT `key`) is load-bearing:
+          # `key` appends `GITHUB_JOB`, so two jobs passing the same `key` get
+          # SEPARATE entries and never share — `shared-key` omits the job id, so
+          # both land on one `build-release` entry. Sharing is sound HERE (unlike
+          # the per-job caches above — see the note on the first rust-cache block)
+          # precisely because this job's deps are the SUPERSET: clippy `--release`
+          # builds the release deps and the featureless guard below builds the
+          # debug/test deps, while `build-release-check` needs only the release
+          # half, which the shared entry always carries. `save-if: main` plus a
+          # single saver (this job) means no race over the entry, and no new key
+          # near the 10 GiB cap (#1218).
           save-if: ${{ github.ref == 'refs/heads/main' }}
-          key: build-release
-      # The release-profile lint (#1383). It lives in THIS job on purpose: the two
-      # `clippy` jobs both lint the debug profile, so nothing checked the release
-      # profile, and the normalization oracles are required by convention to
-      # compile out of release entirely (`#[cfg(debug_assertions)]` on
-      # `assert_in_bounds`, `assert_reparseable`, `assert_idempotent` and their
-      # `*_self_check_enabled` flags). An oracle helper left ungated becomes dead
-      # code in release, and `dead_code` is warn-by-default, so nothing went red:
-      # #1366's pre-review head failed this command with three such errors while
-      # all three CI clippy jobs were green on the same commit.
+          shared-key: build-release
+      # The release-profile lint (#1383). The two `clippy` jobs both lint the debug
+      # profile, so nothing else checks the release profile, and the normalization
+      # oracles are required by convention to compile out of release entirely
+      # (`#[cfg(debug_assertions)]` on `assert_in_bounds`, `assert_reparseable`,
+      # `assert_idempotent` and their `*_self_check_enabled` flags). An oracle
+      # helper left ungated becomes dead code in release, and `dead_code` is
+      # warn-by-default, so nothing went red: #1366's pre-review head failed this
+      # command with three such errors while all three CI clippy jobs were green on
+      # the same commit.
       #
-      # Here rather than in a job of its own because the repository sits near the
-      # 10 GiB Actions cache cap and #1218 records two cache generations reaching
-      # 13.61 GiB, evicting by LRU and destroying the nightly's 3.25 GiB
-      # `ferro-manifest-v3` as collateral damage. This job already builds the
-      # release profile and already owns a `rust-cache` entry (`build-release`),
-      # so the lint adds no new cache KEY — only clippy's own fingerprints to an
-      # entry that already exists. (The +30 MB / +1.6% this was measured at
-      # originally was against the hand-rolled whole-`target/` entries that #1370
-      # retired; `rust-cache` stores dependency artifacts only, so the marginal
-      # cost is smaller still.) `Build` is also already a required check, so a
-      # failure blocks a merge rather than only turning a non-required job red.
+      # It stays a `cargo clippy` step (not folded into the release build via
+      # `RUSTFLAGS=-D warnings`) because RUSTFLAGS is part of cargo's build
+      # fingerprint, so setting it busts the whole dependency cache — ~400 crates
+      # rebuild cold, the same trap the `CARGO_INCREMENTAL` note in `CLAUDE.md`
+      # records. `clippy -- -D warnings` passes the flag as a clippy ARG instead,
+      # leaving dependencies `--cap-lints=allow` and their fingerprints untouched.
       #
       # Deliberately NOT `--all-targets`: the dead code lands in the `lib` target,
       # which the plain invocation covers. Measured by removing the four
@@ -2519,14 +2604,34 @@ jobs:
       # feature set BUILDS, not that these tests run a second time. `--lib
       # --bins` covers every `#[cfg(test)]` module under `src/`; the integration
       # tree is already compiled featureless by `test-build-soak`.
-      #
-      # In THIS job rather than one of its own, for the reason the release-profile
-      # lint above gives at length: the repository sits near the 10 GiB Actions
-      # cache cap and #1218 records eviction cascades caused by adding cache keys.
-      # `build` already owns `build-release` and is already a required check, so
-      # the guard blocks a merge instead of only reddening an optional job.
       - name: Unit tests compile with default features
         run: cargo test --no-run --lib --bins
+
+  # The release build + binary-size guard. On its own runner so its ~154s release
+  # compile of `ferro` runs in parallel with the lint job above rather than after
+  # it.
+  build-release-check:
+    name: Build release + size
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          submodules: true
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          # RESTORE-ONLY the shared `build-release` entry `build-lint` saves.
+          # `shared-key` (not `key`) so the job id is NOT appended and this
+          # genuinely restores `build-lint`'s entry — with `key` the two jobs get
+          # separate per-job entries, and since this one is `save-if: false` it
+          # would then restore nothing and recompile every release dependency cold
+          # on every run. `save-if: false` keeps `build-lint` the single saver.
+          save-if: false
+          shared-key: build-release
       - run: cargo build --release
       - name: Check binary size
         run: |
@@ -2535,5 +2640,27 @@ jobs:
           echo "Binary size: $size bytes"
           if [ "$size" -gt 10485760 ]; then
             echo "Error: Binary size exceeds 10MB limit"
+            exit 1
+          fi
+
+  # Reports the required `Build` context on behalf of the two jobs above, the same
+  # way `test-required` reports `Test`. Renaming or re-splitting the build work
+  # cannot break the required context as long as this rollup names its `needs`.
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [build-lint, build-release-check]
+    # `always()` so a failed dependency still reports a conclusion rather than
+    # leaving the required context pending forever.
+    if: always()
+    steps:
+      - name: Verify the build jobs succeeded
+        run: |
+          echo "build-lint          = ${{ needs.build-lint.result }}"
+          echo "build-release-check = ${{ needs.build-release-check.result }}"
+          if [ "${{ needs.build-lint.result }}" != "success" ] \
+            || [ "${{ needs.build-release-check.result }}" != "success" ]; then
+            echo "::error::one or more build jobs did not succeed"
             exit 1
           fi

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -21848,7 +21848,14 @@ mod tests {
         /// separate processes and `--partition` spread them across shards.
         /// Every case still sweeps every arm (see the module doc), so no arm is
         /// hard-coded; only the corpus is divided.
-        const NET_INSERTION_BLOCKS: usize = 8;
+        ///
+        /// Raised 8 -> 32 for CI shard balance: ARMED (in `test-oracle`, all four
+        /// oracle flags firing on every re-derivation) each block ran ~36s at 8
+        /// blocks, so four co-hashing into one shard was a ~140s load spike. At 32
+        /// each block is ~9s, small enough that `--partition hash` spreads the
+        /// family evenly instead of clustering it. 256 cores / 32 = 8 cores/block,
+        /// still an exact tiling (guarded below).
+        const NET_INSERTION_BLOCKS: usize = 32;
 
         /// Every word of length `n` over the DNA alphabet, in a fixed order.
         fn words(n: usize) -> Vec<String> {
@@ -22017,12 +22024,28 @@ mod tests {
         /// could have been justified after the fact.
         #[rstest]
         fn the_member_count_does_not_depend_on_the_shuffle_direction_on_any_arm(
-            #[values(0, 1, 2, 3, 4, 5, 6, 7)] block: usize,
+            #[values(
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31
+            )]
+            block: usize,
         ) {
             let cores = words(4);
             let per = cores.len() / NET_INSERTION_BLOCKS;
+            // Catch a `#[values]` entry that outran the constant (e.g. the list
+            // was left at 0..31 after NET_INSERTION_BLOCKS shrank): an
+            // out-of-range block would slice past the core space or overlap.
+            assert!(
+                block < NET_INSERTION_BLOCKS,
+                "block {block} is >= NET_INSERTION_BLOCKS {NET_INSERTION_BLOCKS}; \
+                 the #[values] list and the constant disagree"
+            );
             let lo = block * per;
             let slice = &cores[lo..lo + per];
+            assert!(
+                !slice.is_empty(),
+                "block {block} is empty — the slice covers no cores"
+            );
             let payloads = words(5);
             // payload_len (5) != core_len (4), so nothing is skipped and every
             // core × payload is a comparison; the 95% floor guards a collapse.
@@ -22057,8 +22080,15 @@ mod tests {
             );
             // rstest's `#[values]` needs literals, so the block list on the
             // sliced test is written out by hand; this pins it to the constant.
+            // Residual, stated because it cannot be closed here: rstest expands
+            // each value into its own test process, so no runtime check can count
+            // the list. A list left SHORTER than NET_INSERTION_BLOCKS silently
+            // drops its high blocks. Two guards narrow it — this literal pin forces
+            // any constant change to touch the list, and the sliced test asserts
+            // `block < NET_INSERTION_BLOCKS` — but on a count change a reviewer must
+            // still confirm the list runs 0..NET_INSERTION_BLOCKS-1 with no gaps.
             assert_eq!(
-                NET_INSERTION_BLOCKS, 8,
+                NET_INSERTION_BLOCKS, 32,
                 "update the #[values(0..)] list on the sliced test to match NET_INSERTION_BLOCKS"
             );
         }

--- a/tests/it/census_filter_invariant.rs
+++ b/tests/it/census_filter_invariant.rs
@@ -2,10 +2,11 @@
 //!
 //! `ci.yml`'s `CENSUS_FILTER` names the slow census modules that moved off the
 //! `test` / `test-oracle` partitions and onto the optimized archive. `test` and
-//! `test-oracle` **negate** it; the `censuses` job **selects** on it, in two
-//! steps — one with the seam oracles armed, one without, because
+//! `test-oracle` **negate** it; the `censuses` and `censuses-plain` jobs
+//! **select** on it — one with the seam oracles armed, one without, because
 //! `spec_conformance_axis` may not be measured with `FERRO_ASSERT_IDEMPOTENT`
-//! set (it counts the very rows that oracle panics on).
+//! set (it counts the very rows that oracle panics on). The two are separate
+//! jobs (not two steps of one) so their ~43s and ~50s halves run in parallel.
 //!
 //! **The failure mode is the silent, flattering kind, and there are two of it.**
 //!
@@ -141,6 +142,18 @@ fn selections_in(job: &str) -> Vec<String> {
         .collect()
 }
 
+/// The jobs that between them SELECT `CENSUS_FILTER`, armed and un-armed. The
+/// armed half (`normalize_axis_preserving` &c.) and the un-armed half
+/// (`spec_conformance_axis`, which may not be measured with
+/// `FERRO_ASSERT_IDEMPOTENT` set) run as two SEPARATE jobs so they parallelize;
+/// together their steps must cover the whole filter and nothing more.
+const CENSUS_JOBS: [&str; 2] = ["censuses", "censuses-plain"];
+
+/// Every `-E` selection across both census jobs, in job order.
+fn census_selections() -> Vec<String> {
+    CENSUS_JOBS.iter().flat_map(|j| selections_in(j)).collect()
+}
+
 /// Module names a nextest filter expression names via `test(...)`.
 fn modules_named_in(filter: &str) -> Vec<String> {
     filter
@@ -166,11 +179,11 @@ fn every_module_named_in_the_census_filter_is_run_by_the_censuses_job() {
          assertion in this file would be vacuous"
     );
 
-    let selections = selections_in("censuses");
+    let selections = census_selections();
     assert!(
         !selections.is_empty(),
-        "the `censuses` job passes no -E selection to nextest; its shape changed \
-         and this guard cannot see what it runs"
+        "the census jobs pass no -E selection to nextest; their shape changed \
+         and this guard cannot see what they run"
     );
     let selected: Vec<String> = selections
         .iter()
@@ -180,8 +193,8 @@ fn every_module_named_in_the_census_filter_is_run_by_the_censuses_job() {
     let unrun: Vec<&String> = named.iter().filter(|m| !selected.contains(m)).collect();
     assert!(
         unrun.is_empty(),
-        "ci.yml's CENSUS_FILTER reserves these modules for the `censuses` job, but \
-         none of that job's steps selects them: {unrun:?}\n\
+        "ci.yml's CENSUS_FILTER reserves these modules for the census jobs, but \
+         none of their steps selects them: {unrun:?}\n\
          `test` and `test-oracle` negate CENSUS_FILTER, so a module here runs in NO \
          job — CI stays green and gets faster, which is the coverage loss this \
          guard exists to make loud.\n\
@@ -199,19 +212,19 @@ fn every_module_named_in_the_census_filter_is_run_by_the_censuses_job() {
 #[test]
 fn the_censuses_job_runs_nothing_the_census_filter_does_not_reserve() {
     let named = modules_named_in(&ci_filter("CENSUS_FILTER"));
-    let selected: Vec<String> = selections_in("censuses")
+    let selected: Vec<String> = census_selections()
         .iter()
         .flat_map(|s| modules_named_in(s))
         .collect();
     assert!(
         !selected.is_empty(),
-        "the `censuses` job selects no modules; its shape changed"
+        "the census jobs select no modules; their shape changed"
     );
 
     let unreserved: Vec<&String> = selected.iter().filter(|m| !named.contains(m)).collect();
     assert!(
         unreserved.is_empty(),
-        "the `censuses` job selects these modules, but CENSUS_FILTER does not \
+        "the census jobs select these modules, but CENSUS_FILTER does not \
          name them: {unreserved:?}\n\
          `test` and `test-oracle` negate CENSUS_FILTER, so anything missing from it \
          still runs in whichever shard hashes it — these modules are being run \
@@ -219,30 +232,46 @@ fn the_censuses_job_runs_nothing_the_census_filter_does_not_reserve() {
     );
 }
 
-/// No module may be selected by both of the job's steps.
+/// No module may be selected by both census jobs.
 ///
-/// The two steps differ only in whether the seam oracles are armed, so a module
-/// in both runs its whole corpus twice inside one job — which is exactly the
-/// duplication the move was made to remove, relocated rather than removed.
+/// The two jobs differ only in whether the seam oracles are armed, so a module in
+/// both runs its whole corpus twice per CI run — the duplication the split was
+/// made to avoid, relocated rather than removed. Each job runs a single armed or
+/// un-armed step, so each carries exactly one `-E` selection.
 #[test]
-fn no_module_is_selected_by_both_of_the_jobs_steps() {
-    let selections = selections_in("censuses");
+fn no_module_is_selected_by_both_census_jobs() {
+    let armed_sel = selections_in("censuses");
+    let plain_sel = selections_in("censuses-plain");
     assert_eq!(
-        selections.len(),
-        2,
-        "the `censuses` job is documented as two steps — one with the seam oracles \
-         armed and one without, because spec_conformance_axis may not be measured \
-         with FERRO_ASSERT_IDEMPOTENT set. It now has {} selection(s); if that is \
-         deliberate, this guard needs updating along with the job's comment.",
-        selections.len()
+        (armed_sel.len(), plain_sel.len()),
+        (1, 1),
+        "each census job is documented as one step (armed / un-armed); found \
+         {} armed and {} plain selection(s). If that is deliberate, this guard \
+         needs updating along with the jobs' comments.",
+        armed_sel.len(),
+        plain_sel.len()
     );
 
-    let armed = modules_named_in(&selections[0]);
-    let unarmed = modules_named_in(&selections[1]);
-    let both: Vec<&String> = armed.iter().filter(|m| unarmed.contains(m)).collect();
+    let armed = modules_named_in(&armed_sel[0]);
+    let plain = modules_named_in(&plain_sel[0]);
+    // `test(P)` selects any test whose name CONTAINS `P`, so two terms select
+    // overlapping tests when either one contains the other — exact equality
+    // misses a subsuming term (armed `test(spec_conformance)` against plain
+    // `test(spec_conformance_axis)` picks the same module in both jobs). Compare
+    // both directions, as `oracle_only_filter_invariant.rs::
+    // assert_terms_do_not_overlap` already does.
+    let both: Vec<(&String, &String)> = armed
+        .iter()
+        .flat_map(|a| {
+            plain
+                .iter()
+                .filter(move |p| a.contains(p.as_str()) || p.contains(a.as_str()))
+                .map(move |p| (a, p))
+        })
+        .collect();
     assert!(
         both.is_empty(),
-        "these modules are selected by BOTH of the `censuses` job's steps, so their \
-         corpora run twice in one job: {both:?}"
+        "these modules are selected by BOTH census jobs, so their corpora run \
+         twice per CI run: {both:?}"
     );
 }

--- a/tests/it/cis_confluence_axis.rs
+++ b/tests/it/cis_confluence_axis.rs
@@ -533,6 +533,69 @@ const FIVE_PRIME: Census = Census {
     sequence_changed: 0,
 };
 
+/// Number of slices the armed confluence census is partitioned into, so nextest's
+/// name-hash `--partition` can spread its ~60s build across `test-oracle` shards
+/// instead of pinning it into one. Each direction becomes `SLICE_N` slice-tests
+/// plus a cheap (no-build) tiling meta-test that folds the per-slice pins back to
+/// the whole-corpus pin — so the strict per-direction guarantee is preserved as a
+/// superset. Re-measure the arrays below with the ignored `report_census_slice_pins`.
+const SLICE_N: usize = 8;
+
+/// Compact positional `Census` constructor for the per-slice pin arrays. The nine
+/// arguments are the nine `Census` fields in declaration order — a struct literal
+/// per slice would make the arrays unreadably tall, and the field order is fixed
+/// and documented on `Census`.
+#[allow(clippy::too_many_arguments)]
+const fn census(
+    classes: usize,
+    spellings: usize,
+    declined: usize,
+    converged: usize,
+    split_two: usize,
+    split_three: usize,
+    split_more: usize,
+    underdetermined: usize,
+    sequence_changed: usize,
+) -> Census {
+    Census {
+        classes,
+        spellings,
+        declined,
+        converged,
+        split_two,
+        split_three,
+        split_more,
+        underdetermined,
+        sequence_changed,
+    }
+}
+
+/// Per-slice 3'/5' censuses. Each array `.absorb`-folds to [`THREE_PRIME`] /
+/// [`FIVE_PRIME`] exactly — asserted by the tiling meta-tests, which is what keeps
+/// the strict whole-corpus pin intact. These are MEASURED pins, not placeholders;
+/// regenerate them with the ignored `report_census_slice_pins` diagnostic if the
+/// geometry moves — do not zero them out.
+const THREE_PRIME_SLICES: [Census; SLICE_N] = [
+    census(1410, 6070, 0, 1410, 0, 0, 0, 0, 0),
+    census(1410, 6070, 0, 1410, 0, 0, 0, 0, 0),
+    census(1409, 5519, 0, 1409, 0, 0, 0, 0, 0),
+    census(1409, 5519, 0, 1409, 0, 0, 0, 0, 0),
+    census(1408, 6392, 0, 1408, 0, 0, 0, 0, 0),
+    census(1408, 6392, 0, 1407, 1, 0, 0, 0, 0),
+    census(1409, 5715, 0, 1409, 0, 0, 0, 0, 0),
+    census(1409, 5715, 0, 1408, 1, 0, 0, 0, 0),
+];
+const FIVE_PRIME_SLICES: [Census; SLICE_N] = [
+    census(1410, 6070, 0, 1410, 0, 0, 0, 0, 0),
+    census(1410, 6070, 0, 1410, 0, 0, 0, 0, 0),
+    census(1409, 5519, 0, 1409, 0, 0, 0, 0, 0),
+    census(1409, 5519, 0, 1409, 0, 0, 0, 0, 0),
+    census(1408, 6392, 0, 1408, 0, 0, 0, 0, 0),
+    census(1408, 6392, 0, 1408, 0, 0, 0, 0, 0),
+    census(1409, 5715, 0, 1409, 0, 0, 0, 0, 0),
+    census(1409, 5715, 0, 1408, 1, 0, 0, 0, 0),
+];
+
 // ---------------------------------------------------------------------------
 // Corpus
 // ---------------------------------------------------------------------------
@@ -640,7 +703,7 @@ fn expected_sequence(class: &Class) -> String {
 
 /// What one direction's run found. Every field is pinned; see the module docs
 /// for which way each is allowed to move.
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 struct Census {
     /// Classes measured.
     classes: usize,
@@ -679,7 +742,7 @@ struct Divergence {
 impl Census {
     /// Fold another census in. Every field is a count over a partition of the
     /// classes, so summing is exact rather than approximate — which is what
-    /// makes [`measure`]'s per-group split safe.
+    /// makes [`measure_slice`]'s per-group split safe.
     fn absorb(&mut self, other: &Census) {
         self.classes += other.classes;
         self.spellings += other.spellings;
@@ -695,7 +758,7 @@ impl Census {
 
 /// How many divergent classes the failure message names. Applied per group and
 /// again to the concatenation, which is what keeps the parallel result
-/// byte-identical to a serial one — see [`measure`].
+/// byte-identical to a serial one — see [`measure_slice`].
 const WORST_LIMIT: usize = 10;
 
 /// The contiguous runs of `classes` that share one reference.
@@ -703,7 +766,7 @@ const WORST_LIMIT: usize = 10;
 /// Classes are sorted by an id that starts with the core index and the axis, so
 /// every class sharing a reference is contiguous. Building one provider and one
 /// normalizer per group instead of per class is the difference between this
-/// running in seconds and in minutes; [`measure`] additionally runs the groups
+/// running in seconds and in minutes; [`measure_slice`] additionally runs the groups
 /// concurrently, which it can do only because each one owns its provider.
 fn reference_groups(classes: &[Class]) -> Vec<&[Class]> {
     let mut groups = Vec::new();
@@ -801,12 +864,30 @@ fn measure_group(group: &[Class], direction: ShuffleDirection) -> (Census, Vec<D
 /// `Normalizer` (it already did — that is the per-group loop's whole point), and
 /// the only borrow that crosses is the immutable corpus slice. The normalization
 /// oracles' recursion guard is a thread-local, so it is per-task too.
-fn measure(direction: ShuffleDirection) -> (Census, Vec<Divergence>) {
+/// Census one direction over the reference groups whose index falls in slice `k`
+/// of `n` — or all groups when `slice` is `None` (the whole-corpus census).
+///
+/// Slicing by whole reference GROUPS (never by class) keeps every slice a valid
+/// sub-census: each `Census` field is still a count over a partition of the
+/// classes, so [`Census::absorb`] over the slices is exact and
+/// `SLICES.iter().fold(absorb) == <the whole-corpus pin>` — which the
+/// `*_confluence_census_slices_tile_the_pin` meta-tests assert, so the strict
+/// per-direction pin is preserved as a superset (each slice additionally catches
+/// a regression concentrated in it). The point is CI shard balance: this census
+/// ran ~60s armed in one process and one shard, so `--partition hash` could not
+/// spread it; as `SLICE_N` separate tests nextest runs them as separate
+/// processes and distributes them, exactly as #01 did for the geometry corpus.
+fn measure_slice(
+    direction: ShuffleDirection,
+    slice: Option<(usize, usize)>,
+) -> (Census, Vec<Divergence>) {
     let groups = reference_groups(&corpus().classes);
 
     let per_group: Vec<(Census, Vec<Divergence>)> = groups
         .par_iter()
-        .map(|group| measure_group(group, direction))
+        .enumerate()
+        .filter(|(i, _)| slice.is_none_or(|(k, n)| i % n == k))
+        .map(|(_, group)| measure_group(group, direction))
         .collect();
 
     let mut census = Census::default();
@@ -844,25 +925,41 @@ fn report(direction: &str, census: &Census, worst: &[Divergence]) -> String {
     out
 }
 
-/// Assert one direction's census against its pin, printing the measured numbers
-/// either way so a moved pin can be re-blessed from the test output.
-fn assert_census(direction: ShuffleDirection, label: &str, pinned: &Census) {
-    let (measured, worst) = measure(direction);
-    println!("{}", report(label, &measured, &worst));
+/// Assert slice `k` of [`SLICE_N`] against its per-slice pin. Strict `==` on the
+/// sub-census of the reference groups in this slice;
+/// the tiling meta-test proves the slices fold back to the whole-corpus pin.
+fn assert_census_slice(
+    direction: ShuffleDirection,
+    label: &str,
+    k: usize,
+    pinned: &[Census; SLICE_N],
+) {
+    let (measured, worst) = measure_slice(direction, Some((k, SLICE_N)));
+    let tag = format!("{label} slice {k}/{SLICE_N}");
+    println!("{}", report(&tag, &measured, &worst));
     assert_eq!(
         measured.sequence_changed, 0,
-        "{label}: {} normalized outputs no longer denote their class's sequence — a class that \
+        "{tag}: {} normalized outputs no longer denote their class's sequence — a class that \
          converges on the wrong sequence is worse than one that diverges",
         measured.sequence_changed
     );
     assert_eq!(
         &measured,
-        pinned,
-        "{label}: the confluence census moved. Every divergence figure must only ever go DOWN \
-         and `converged` only ever UP; if this change lowers one, re-bless the pin in the same \
+        &pinned[k],
+        "{tag}: the confluence census moved. Every divergence figure must only ever go DOWN and \
+         `converged` only ever UP; if this change lowers one, re-bless the slice pin in the same \
          commit and say so in the PR. Measured:\n{}",
-        report(label, &measured, &worst)
+        report(&tag, &measured, &worst)
     );
+}
+
+/// Fold a per-slice pin array back to one whole-corpus census.
+fn fold_slices(slices: &[Census; SLICE_N]) -> Census {
+    let mut whole = Census::default();
+    for slice in slices {
+        whole.absorb(slice);
+    }
+    whole
 }
 
 // ---------------------------------------------------------------------------
@@ -913,14 +1010,153 @@ fn the_corpus_is_a_dense_set_of_real_confluence_classes() {
     }
 }
 
+/// Generate `SLICE_N` slice-tests per direction. The whole-corpus census used to
+/// be one ~60s armed test per direction that `--partition hash` could not spread;
+/// as named slices nextest runs them as separate processes across shards. Every
+/// row is still measured armed; coverage is a superset (per-slice regression
+/// detection) guarded by the tiling meta-tests below.
+macro_rules! confluence_census_slices {
+    ($dir:expr, $label:literal, $pins:ident, $indices:ident, $($name:ident => $k:expr),+ $(,)?) => {
+        // The slice indices these arms actually run, captured from the SAME `$k`
+        // tokens the test bodies pass to `assert_census_slice`. `the_census_slice_
+        // arms_tile_zero_to_slice_n` asserts this covers `0..SLICE_N` exactly once,
+        // so a duplicated, omitted, or out-of-range arm fails instead of silently
+        // dropping a slice from CI — the coverage the old `SLICE_N == 8` count
+        // could not observe.
+        const $indices: &[usize] = &[$($k),+];
+        $(
+            #[test]
+            fn $name() {
+                assert_census_slice($dir, $label, $k, &$pins);
+            }
+        )+
+    };
+}
+
+confluence_census_slices! {
+    ShuffleDirection::ThreePrime, "3prime", THREE_PRIME_SLICES, THREE_PRIME_INDICES,
+    three_prime_confluence_census_slice_00 => 0,
+    three_prime_confluence_census_slice_01 => 1,
+    three_prime_confluence_census_slice_02 => 2,
+    three_prime_confluence_census_slice_03 => 3,
+    three_prime_confluence_census_slice_04 => 4,
+    three_prime_confluence_census_slice_05 => 5,
+    three_prime_confluence_census_slice_06 => 6,
+    three_prime_confluence_census_slice_07 => 7,
+}
+
+confluence_census_slices! {
+    ShuffleDirection::FivePrime, "5prime", FIVE_PRIME_SLICES, FIVE_PRIME_INDICES,
+    five_prime_confluence_census_slice_00 => 0,
+    five_prime_confluence_census_slice_01 => 1,
+    five_prime_confluence_census_slice_02 => 2,
+    five_prime_confluence_census_slice_03 => 3,
+    five_prime_confluence_census_slice_04 => 4,
+    five_prime_confluence_census_slice_05 => 5,
+    five_prime_confluence_census_slice_06 => 6,
+    five_prime_confluence_census_slice_07 => 7,
+}
+
+/// Cheap (no corpus build) meta-guards: the per-slice pins fold EXACTLY to the
+/// whole-corpus pins, so slicing preserves the strict census guarantee rather
+/// than weakening it. If a slice pin is re-blessed, this fails unless the whole
+/// still matches — the whole-corpus figure remains the thing under contract.
 #[test]
-fn three_prime_confluence_census() {
-    assert_census(ShuffleDirection::ThreePrime, "3prime", &THREE_PRIME);
+fn three_prime_confluence_census_slices_tile_the_pin() {
+    assert_eq!(
+        fold_slices(&THREE_PRIME_SLICES),
+        THREE_PRIME,
+        "the 3prime per-slice pins no longer fold to THREE_PRIME"
+    );
+}
+
+/// The slice-test arms tile `0..SLICE_N` exactly once per direction.
+///
+/// The arms are hand-written macro invocations, so a duplicated, omitted, or
+/// out-of-range arm would keep the fold meta-tests green (their array pins are
+/// separate) while a slice stops running in CI. Deriving the executed indices
+/// from the same `$k` tokens the arms expand to, and asserting they cover
+/// `0..SLICE_N` exactly once, catches that — the property the former
+/// `SLICE_N == 8` pin only stood in for. If SLICE_N changes, update both
+/// `confluence_census_slices!` invocations and the `*_SLICES` arrays to match.
+#[test]
+fn the_census_slice_arms_tile_zero_to_slice_n() {
+    assert_indices_tile("THREE_PRIME_INDICES", THREE_PRIME_INDICES);
+    assert_indices_tile("FIVE_PRIME_INDICES", FIVE_PRIME_INDICES);
+}
+
+/// Assert `indices` is a permutation of `0..SLICE_N` — every slice covered, none
+/// twice, none out of range.
+fn assert_indices_tile(label: &str, indices: &[usize]) {
+    let mut seen = [false; SLICE_N];
+    for &k in indices {
+        assert!(
+            k < SLICE_N,
+            "{label}: slice index {k} is out of range for SLICE_N ({SLICE_N})"
+        );
+        assert!(
+            !seen[k],
+            "{label}: slice index {k} is covered by more than one arm"
+        );
+        seen[k] = true;
+    }
+    let missing: Vec<usize> = (0..SLICE_N).filter(|&k| !seen[k]).collect();
+    assert!(
+        missing.is_empty(),
+        "{label}: slice indices {missing:?} are covered by no arm"
+    );
 }
 
 #[test]
-fn five_prime_confluence_census() {
-    assert_census(ShuffleDirection::FivePrime, "5prime", &FIVE_PRIME);
+fn five_prime_confluence_census_slices_tile_the_pin() {
+    assert_eq!(
+        fold_slices(&FIVE_PRIME_SLICES),
+        FIVE_PRIME,
+        "the 5prime per-slice pins no longer fold to FIVE_PRIME"
+    );
+}
+
+/// Diagnostic (ignored): print the per-slice pin arrays for both directions so
+/// they can be re-blessed mechanically after an intended census change. Run with
+/// `--run-ignored all --no-capture`, read the `census(...)` lines, paste them
+/// into `THREE_PRIME_SLICES` / `FIVE_PRIME_SLICES`. Also proves the slices tile:
+/// the folded per-slice measurement equals the whole-corpus measurement.
+#[test]
+#[ignore = "permanent diagnostic (#2161): prints per-slice census pin arrays and verifies \
+            tiling; a re-bless helper, not a CI gate, so it stays ignored"]
+fn report_census_slice_pins() {
+    for (dir, label, whole_pin) in [
+        (
+            ShuffleDirection::ThreePrime,
+            "THREE_PRIME_SLICES",
+            THREE_PRIME,
+        ),
+        (ShuffleDirection::FivePrime, "FIVE_PRIME_SLICES", FIVE_PRIME),
+    ] {
+        let mut folded = Census::default();
+        println!("const {label}: [Census; SLICE_N] = [");
+        for k in 0..SLICE_N {
+            let (c, _) = measure_slice(dir, Some((k, SLICE_N)));
+            folded.absorb(&c);
+            println!(
+                "    census({}, {}, {}, {}, {}, {}, {}, {}, {}),",
+                c.classes,
+                c.spellings,
+                c.declined,
+                c.converged,
+                c.split_two,
+                c.split_three,
+                c.split_more,
+                c.underdetermined,
+                c.sequence_changed,
+            );
+        }
+        println!("];");
+        assert_eq!(
+            folded, whole_pin,
+            "{label}: slices do not tile the whole-corpus pin"
+        );
+    }
 }
 
 /// [`THREE_PRIME`]'s headline restates three figures that live in the `const`

--- a/tests/it/issue_2161_from_sequences_inversion_converge.rs
+++ b/tests/it/issue_2161_from_sequences_inversion_converge.rs
@@ -36,15 +36,20 @@
 //! - [`from_sequences_decomposes_a_merged_sub_flanked_inversion`] — the over-merge
 //!   follow-up: a merged equal-length `sub`+`inv` `delins` split back to its
 //!   canonical members (`split_canonical_delins`).
-//! - [`the_inversion_geometry_corpus_converges_without_regression`] — the corpus
-//!   is fully built (a fixed count) and the number of convergent variants holds a
-//!   floor: a regression lowers it, a later increment only raises it.
+//! - `the_geometry_corpus_slice_{00..23}_converges_and_the_gate_holds` — the
+//!   corpus is built in `SLICE_N` parallel slices, because a whole-corpus build
+//!   is a single armed test nextest's `--partition hash:` cannot split across
+//!   shards, and it was the slowest test in `test-oracle`. Each slice checks, on
+//!   its 1/N, that the corpus is fully built (exact per-slice count), that
+//!   convergence and inversion-typing hold their floors, and that the gate moved
+//!   nothing. `slice_floors_preserve_the_global_guarantees` asserts the per-slice
+//!   pins still sum to the former whole-corpus floors, so slicing did not weaken
+//!   coverage.
 //!
 //! The guard is proven able to fail: on the pre-fix tree every curated row above
 //! diverges (the `NC_TEST.1:g.[14del;21_23inv]` reproducer is one of them); the
-//! shipped fix converges at least 60,731 of the 62,824 corpus rows (the floor
-//! `the_inversion_geometry_corpus_converges_without_regression` asserts; 60,904
-//! on the current tree).
+//! shipped fix converges at least 60,731 of the 62,824 corpus rows (the sum of the
+//! per-slice `CONVERGED_FLOOR` pins; 60,974 on the current tree).
 //!
 //! # The Drop and its gate (the #2161 Path 1 payoff)
 //!
@@ -54,10 +59,10 @@
 //! output. This file guards that the SHIPPED gated path is byte-identical to the
 //! full pre-drop path:
 //!
-//! - [`the_gated_drop_changes_no_output`] — over the inversion-geometry corpus:
-//!   the raw unconditional skip diverges on 72 shapes — the current measured
-//!   count, which the test asserts as a `>= 72` regression floor (not slack
-//!   below the measurement); the gate closes every one.
+//! - The `the_geometry_corpus_slice_*` tests each check this over their share of
+//!   the corpus: the raw unconditional skip diverges on 742 shapes corpus-wide
+//!   (`SKIP_FLOOR` sums to a `>= 72` non-vacuity floor), and the SHIPPED gated
+//!   path closes every one (`gated_diverged` empty, strictly per row).
 //! - [`the_gate_is_correct_on_dense_member_alleles`] +
 //!   [`report_gate_fallback_on_dense_member_alleles`] — correctness and the gate's
 //!   fallback rate over a densely-spaced multi-member cis corpus (the distribution
@@ -242,13 +247,32 @@ struct Outcome {
     drop_compared: Option<(String, String, String, bool)>,
 }
 
-/// Generate the whole corpus and run every variant through both surfaces.
+/// Generate the corpus and run every variant through both surfaces — the whole
+/// corpus, or one modulo-slice of it.
 ///
 /// Every generated variant is a flanked inversion — a genuine `inv` span beside
 /// at least one `del`/`sub` sibling — so the count of outcomes is the geometry
 /// this file guards, floored below.
-fn run_corpus() -> Vec<Outcome> {
+///
+/// `slice = Some((k, n))` does the expensive `normalize` work only for the
+/// outcomes whose global generation index `i` satisfies `i % n == k`, and skips
+/// it for the rest — so `n` slices partition the corpus's cost evenly and their
+/// row-sets tile it exactly, once each. `slice = None` builds the whole corpus
+/// (the diagnostic and the pin meta-check use this). The generation index is
+/// assigned in the deterministic iteration order, **independently of `slice`**,
+/// so a row's slice membership is stable no matter which slice is asked for.
+///
+/// Splitting the build this way is what lets nextest's `--partition hash:` (by
+/// test name) distribute the armed pass across shards: a single test can never be
+/// split, but N named slice-tests can. Coverage is unchanged — every row is still
+/// built armed in whichever slice owns it, and both properties are still checked
+/// on every row.
+fn run_corpus_slice(slice: Option<(usize, usize)>) -> Vec<Outcome> {
     let mut outcomes = Vec::new();
+    // Global generation index, incremented once per (input, direction) that
+    // reaches the normalize step, in deterministic order and independent of
+    // `slice`. This is the number the modulo partition is taken over.
+    let mut idx = 0usize;
 
     for (_name, seq) in contigs() {
         let bytes = seq.as_bytes();
@@ -341,6 +365,17 @@ fn run_corpus() -> Vec<Outcome> {
 
                         for direction in [ShuffleDirection::ThreePrime, ShuffleDirection::FivePrime]
                         {
+                            // Assign this outcome's stable global index, then skip
+                            // the expensive work unless it belongs to the asked-for
+                            // slice. The index advances regardless, so the same row
+                            // always lands in the same slice.
+                            let this_idx = idx;
+                            idx += 1;
+                            if let Some((k, n)) = slice {
+                                if this_idx % n != k {
+                                    continue;
+                                }
+                            }
                             let nz = if matches!(direction, ShuffleDirection::ThreePrime) {
                                 &nz_3p
                             } else {
@@ -385,16 +420,300 @@ fn run_corpus() -> Vec<Outcome> {
     outcomes
 }
 
-/// The geometry corpus is hermetic and deterministic, so its size is exact —
-/// both non-vacuity guards below assert against this single source of truth.
+/// The whole corpus. Kept for the ignored diagnostic and any full-corpus reader;
+/// the process-cached [`geometry_corpus`] wraps it.
+fn run_corpus() -> Vec<Outcome> {
+    run_corpus_slice(None)
+}
+
+/// The geometry corpus is hermetic and deterministic, so its size is exact — the
+/// per-slice `EXPECTED_COMPARED` pins tile it, and the slice guards assert against
+/// this single source of truth.
+///
+/// (There is no longer a process-cached `geometry_corpus()` wrapper: under
+/// nextest's process-per-test isolation an `OnceLock` cache never crossed tests,
+/// so each consumer rebuilt the whole corpus — the EXPENSIVE armed
+/// normalize/rederive work included. The slices split that expensive work 1/N
+/// via [`run_corpus_slice`] instead — one full pass of the costly work total,
+/// distributed and parallel. The cheap enumerating loop itself still runs in
+/// every slice process; only the per-row normalization it guards is slice-gated.)
 const GEOMETRY_CORPUS_SIZE: usize = 62_824;
 
-/// The geometry corpus, built once per test process and shared by the guards
-/// that read it. `run_corpus` is deterministic and ~45s to build, so consumers
-/// borrow this process-cached slice rather than each rebuilding it.
-fn geometry_corpus() -> &'static [Outcome] {
-    static CORPUS: std::sync::OnceLock<Vec<Outcome>> = std::sync::OnceLock::new();
-    CORPUS.get_or_init(run_corpus)
+// ===========================================================================
+// Sliced geometry-corpus guards
+// ===========================================================================
+//
+// The corpus's expensive armed build (`run_corpus_slice`) is split into
+// `SLICE_N` named slice-tests so nextest's `--partition hash:` (by test name)
+// distributes it across shards — a single test can never be split. Each slice
+// builds its 1/N armed and checks, on its own rows, exactly what the two former
+// whole-corpus tests checked on all of them:
+//
+//   - `gated_diverged` empty              — the SHIPPED gate's safety property,
+//                                            strictly per-row, the real guard;
+//   - `drop_compared == EXPECTED_COMPARED[k]` — non-vacuity for that guard: every
+//                                            row produced a drop comparison;
+//   - `compared == EXPECTED_COMPARED[k]`  — the corpus size/geometry, exact;
+//   - `converged  >= CONVERGED_FLOOR[k]`  — convergence regression floor;
+//   - `recommend_has_inv >= INV_FLOOR[k]` — non-vacuity: real inversions exist;
+//   - `skip_diverged     >= SKIP_FLOOR[k]`— non-vacuity: the gate is exercised.
+//
+// The four non-per-row floors were whole-corpus in the former tests; here they
+// are per-slice, and `slice_floors_preserve_the_global_guarantees` (a cheap
+// test, no corpus build) asserts the pins still sum to at least the former
+// global floors — so coverage is a superset: per-slice floors additionally
+// catch a regression concentrated in one slice. Re-tune with the ignored
+// `report_slice_pins` diagnostic, and heed the census-pin cautions in CLAUDE.md
+// ("Assert the property. Measure the count. Never let a count BE the property").
+
+/// Number of slices the geometry corpus's build is partitioned into.
+const SLICE_N: usize = 24;
+
+/// Exact per-slice outcome count; sums to [`GEOMETRY_CORPUS_SIZE`]. Guards that
+/// the generator still emits this slice's geometry unchanged.
+const EXPECTED_COMPARED: [usize; SLICE_N] = [
+    2618, 2618, 2618, 2618, 2618, 2618, 2618, 2618, 2618, 2618, 2618, 2618, 2618, 2618, 2618, 2618,
+    2617, 2617, 2617, 2617, 2617, 2617, 2617, 2617,
+];
+
+/// Per-slice convergence floor (measured minus a ~20-row margin). Sum ≥ 60_731,
+/// the former whole-corpus floor.
+const CONVERGED_FLOOR: [usize; SLICE_N] = [
+    2571, 2495, 2595, 2533, 2491, 2446, 2596, 2519, 2502, 2477, 2607, 2548, 2570, 2494, 2593, 2531,
+    2495, 2452, 2599, 2524, 2507, 2478, 2607, 2552,
+];
+
+/// Per-slice "the normalize output carries an inv" floor (measured minus ~30).
+/// Sum ≥ 39_760, the former whole-corpus floor.
+const INV_FLOOR: [usize; SLICE_N] = [
+    1642, 1642, 1764, 1764, 1411, 1411, 1729, 1729, 1520, 1520, 1874, 1874, 1656, 1656, 1768, 1768,
+    1431, 1431, 1737, 1737, 1516, 1516, 1869, 1869,
+];
+
+/// Per-slice raw-skip divergence floor — a loose non-vacuity floor (the gate is
+/// exercised), zero where a slice's geometries produce no skip divergence at
+/// all. Sum ≥ 72, the former whole-corpus floor.
+const SKIP_FLOOR: [usize; SLICE_N] = [
+    20, 36, 0, 0, 86, 71, 7, 0, 94, 58, 0, 0, 23, 38, 0, 0, 89, 74, 2, 0, 87, 57, 0, 0,
+];
+
+/// Build slice `k` of [`SLICE_N`] and assert its share of the corpus properties.
+fn assert_geometry_slice(k: usize) {
+    let outcomes = run_corpus_slice(Some((k, SLICE_N)));
+
+    let compared = outcomes.iter().filter(|o| o.compared.is_some()).count();
+    let converged = outcomes
+        .iter()
+        .filter(|o| o.compared.as_ref().is_some_and(|(d, r)| d == r))
+        .count();
+    let recommend_has_inv = outcomes
+        .iter()
+        .filter(|o| o.compared.as_ref().is_some_and(|(_, r)| r.contains("inv")))
+        .count();
+    let gated_diverged: Vec<&Outcome> = outcomes
+        .iter()
+        .filter(|o| {
+            o.drop_compared
+                .as_ref()
+                .is_some_and(|(full, _skip, gated, _fired)| full != gated)
+        })
+        .collect();
+    let skip_diverged = outcomes
+        .iter()
+        .filter(|o| {
+            o.drop_compared
+                .as_ref()
+                .is_some_and(|(full, skip, _gated, _fired)| full != skip)
+        })
+        .count();
+    let drop_compared = outcomes
+        .iter()
+        .filter(|o| o.drop_compared.is_some())
+        .count();
+
+    // Exact: the generator still emits this slice's geometry unchanged.
+    assert_eq!(
+        compared, EXPECTED_COMPARED[k],
+        "slice {k}/{SLICE_N}: compared {compared}, pinned {} — the corpus geometry moved",
+        EXPECTED_COMPARED[k],
+    );
+    // Non-vacuity: the geometry really produces inversions `normalize` types.
+    assert!(
+        recommend_has_inv >= INV_FLOOR[k],
+        "slice {k}/{SLICE_N}: only {recommend_has_inv} carry an inv, floor {}",
+        INV_FLOOR[k],
+    );
+    // Regression floor: convergence.
+    assert!(
+        converged >= CONVERGED_FLOOR[k],
+        "slice {k}/{SLICE_N}: convergence regressed, {converged} converge, floor {}",
+        CONVERGED_FLOOR[k],
+    );
+    // Non-vacuity: the raw unconditional skip still diverges on the shapes the
+    // gate exists to catch, so `gated_diverged.is_empty()` below is not vacuous.
+    assert!(
+        skip_diverged >= SKIP_FLOOR[k],
+        "slice {k}/{SLICE_N}: raw skip diverged on only {skip_diverged}, floor {} — \
+         this slice's gate coverage went vacuous",
+        SKIP_FLOOR[k],
+    );
+    // Non-vacuity for the gate below: every row must have produced a drop
+    // comparison at all, or `gated_diverged.is_empty()` passes on an empty
+    // population. This is the guarantee the deleted whole-corpus
+    // `the_gated_drop_changes_no_output` carried (it pinned this count at
+    // `GEOMETRY_CORPUS_SIZE`), restored per slice — `SKIP_FLOOR` is 0 on 10 of
+    // the 24 slices, so the skip floor alone cannot stand in for it.
+    assert_eq!(
+        drop_compared, EXPECTED_COMPARED[k],
+        "slice {k}/{SLICE_N}: only {drop_compared} rows produced a drop comparison, \
+         pinned {} — gated_diverged.is_empty() would be vacuous",
+        EXPECTED_COMPARED[k],
+    );
+    // The SHIPPED gate's safety property, strictly per row: it moved nothing.
+    for o in gated_diverged.iter().take(20) {
+        let (full, _skip, gated, _fired) = o.drop_compared.as_ref().unwrap();
+        eprintln!(
+            "GATED-DIVERGE\t{}\t{:?}\tfull={}\tgated={}",
+            o.input, o.direction, full, gated
+        );
+    }
+    assert!(
+        gated_diverged.is_empty(),
+        "slice {k}/{SLICE_N}: the SHIPPED gated Drop moved {} outputs (see GATED-DIVERGE \
+         lines) — the gate let a divergence through",
+        gated_diverged.len(),
+    );
+}
+
+macro_rules! geometry_slice_tests {
+    ($($name:ident => $k:expr),+ $(,)?) => {$(
+        #[test]
+        fn $name() {
+            assert_geometry_slice($k);
+        }
+    )+};
+}
+
+geometry_slice_tests! {
+    the_geometry_corpus_slice_00_converges_and_the_gate_holds => 0,
+    the_geometry_corpus_slice_01_converges_and_the_gate_holds => 1,
+    the_geometry_corpus_slice_02_converges_and_the_gate_holds => 2,
+    the_geometry_corpus_slice_03_converges_and_the_gate_holds => 3,
+    the_geometry_corpus_slice_04_converges_and_the_gate_holds => 4,
+    the_geometry_corpus_slice_05_converges_and_the_gate_holds => 5,
+    the_geometry_corpus_slice_06_converges_and_the_gate_holds => 6,
+    the_geometry_corpus_slice_07_converges_and_the_gate_holds => 7,
+    the_geometry_corpus_slice_08_converges_and_the_gate_holds => 8,
+    the_geometry_corpus_slice_09_converges_and_the_gate_holds => 9,
+    the_geometry_corpus_slice_10_converges_and_the_gate_holds => 10,
+    the_geometry_corpus_slice_11_converges_and_the_gate_holds => 11,
+    the_geometry_corpus_slice_12_converges_and_the_gate_holds => 12,
+    the_geometry_corpus_slice_13_converges_and_the_gate_holds => 13,
+    the_geometry_corpus_slice_14_converges_and_the_gate_holds => 14,
+    the_geometry_corpus_slice_15_converges_and_the_gate_holds => 15,
+    the_geometry_corpus_slice_16_converges_and_the_gate_holds => 16,
+    the_geometry_corpus_slice_17_converges_and_the_gate_holds => 17,
+    the_geometry_corpus_slice_18_converges_and_the_gate_holds => 18,
+    the_geometry_corpus_slice_19_converges_and_the_gate_holds => 19,
+    the_geometry_corpus_slice_20_converges_and_the_gate_holds => 20,
+    the_geometry_corpus_slice_21_converges_and_the_gate_holds => 21,
+    the_geometry_corpus_slice_22_converges_and_the_gate_holds => 22,
+    the_geometry_corpus_slice_23_converges_and_the_gate_holds => 23,
+}
+
+/// Cheap meta-guard (no corpus build): the per-slice pins still encode the former
+/// whole-corpus guarantees, so slicing did not silently weaken coverage. If a
+/// slice floor is lowered, this fails unless the global guarantee still holds.
+#[test]
+fn slice_floors_preserve_the_global_guarantees() {
+    let sum = |v: &[usize]| v.iter().sum::<usize>();
+    assert_eq!(
+        sum(&EXPECTED_COMPARED),
+        GEOMETRY_CORPUS_SIZE,
+        "the per-slice compared pins must tile the whole corpus exactly",
+    );
+    // The three former whole-corpus floors, restated as pin sums.
+    assert!(
+        sum(&CONVERGED_FLOOR) >= 60_731,
+        "converged floors sum to {}, below the former whole-corpus floor 60_731",
+        sum(&CONVERGED_FLOOR),
+    );
+    assert!(
+        sum(&INV_FLOOR) >= 39_760,
+        "inv floors sum to {}, below the former whole-corpus floor 39_760",
+        sum(&INV_FLOOR),
+    );
+    assert!(
+        sum(&SKIP_FLOOR) >= 72,
+        "skip floors sum to {}, below the former whole-corpus floor 72",
+        sum(&SKIP_FLOOR),
+    );
+}
+
+/// Diagnostic (ignored): print the per-slice pin arrays for [`SLICE_N`], so the
+/// slice guards can be re-tuned mechanically after an intended corpus change.
+/// Run with `--run-ignored all --no-capture`, read the arrays, paste them above.
+/// It also cross-checks that the slices tile the whole corpus: the summed slice
+/// metrics must equal the whole-corpus (`None`) build's.
+#[test]
+#[ignore = "permanent diagnostic (#2161): prints per-slice pin arrays and verifies the slices \
+            tile the corpus; a re-bless helper, not a CI gate, so it stays ignored"]
+fn report_slice_pins() {
+    let count = |os: &[Outcome], f: &dyn Fn(&Outcome) -> bool| os.iter().filter(|o| f(o)).count();
+    let is_compared = |o: &Outcome| o.compared.is_some();
+    let is_converged = |o: &Outcome| o.compared.as_ref().is_some_and(|(d, r)| d == r);
+    let has_inv = |o: &Outcome| o.compared.as_ref().is_some_and(|(_, r)| r.contains("inv"));
+    let skip_div = |o: &Outcome| o.drop_compared.as_ref().is_some_and(|(f, s, ..)| f != s);
+    let gated_div = |o: &Outcome| o.drop_compared.as_ref().is_some_and(|(f, _, g, _)| f != g);
+
+    let mut compared = vec![0usize; SLICE_N];
+    let mut converged = vec![0usize; SLICE_N];
+    let mut inv = vec![0usize; SLICE_N];
+    let mut skip_d = vec![0usize; SLICE_N];
+    let mut gated_d = vec![0usize; SLICE_N];
+    for k in 0..SLICE_N {
+        let os = run_corpus_slice(Some((k, SLICE_N)));
+        compared[k] = count(&os, &is_compared);
+        converged[k] = count(&os, &is_converged);
+        inv[k] = count(&os, &has_inv);
+        skip_d[k] = count(&os, &skip_div);
+        gated_d[k] = count(&os, &gated_div);
+    }
+    let sum = |v: &[usize]| v.iter().sum::<usize>();
+
+    // Tiling proof: the summed slices must equal the whole-corpus build.
+    let full = run_corpus_slice(None);
+    assert_eq!(
+        sum(&compared),
+        count(&full, &is_compared),
+        "compared does not tile"
+    );
+    assert_eq!(
+        sum(&converged),
+        count(&full, &is_converged),
+        "converged does not tile"
+    );
+    assert_eq!(sum(&inv), count(&full, &has_inv), "inv does not tile");
+    assert_eq!(
+        sum(&skip_d),
+        count(&full, &skip_div),
+        "skip_diverged does not tile"
+    );
+    assert_eq!(
+        sum(&gated_d),
+        count(&full, &gated_div),
+        "gated_diverged does not tile"
+    );
+
+    eprintln!("SLICE_N={SLICE_N}");
+    eprintln!("EXPECTED_COMPARED = {compared:?}  sum={}", sum(&compared));
+    eprintln!("converged(raw)    = {converged:?}  sum={}", sum(&converged));
+    eprintln!("inv(raw)          = {inv:?}  sum={}", sum(&inv));
+    eprintln!("skip_diverged(raw)= {skip_d:?}  sum={}", sum(&skip_d));
+    eprintln!(
+        "gated_diverged    = {gated_d:?}  sum={} (MUST be 0)",
+        sum(&gated_d)
+    );
 }
 
 /// The fix, stated as pins: a flanked inversion the derivation surface used to
@@ -551,73 +870,13 @@ fn from_sequences_decomposes_a_merged_sub_flanked_inversion() {
     );
 }
 
-/// The geometry corpus, as a regression floor. Increments 1 (the flanked/interior
-/// inversion port) and its over-merge follow-up (the `decompose_delins` split)
-/// close the flanked/interior inversion classes on the derivation surface; what
-/// remains is the shift, over-merge, and repeat-notation convergence that
-/// increments 2–3 address. So this asserts floors, not full convergence:
-///
-/// - the corpus is fully built (a fixed, deterministic count — a drop means the
-///   generator stopped emitting the geometry, the vacuity this file guards
-///   against);
-/// - `normalize` actually types an inversion on a large share of the corpus (the
-///   non-vacuity that matters: a generator that stopped producing genuine flanked
-///   inversions — every span palindromic, say — would still build 62,824 rows but
-///   type almost no `inv`, and the convergence floor alone could not tell);
-/// - the number of variants on which `derive` converges with `normalize` does not
-///   fall below what the ports achieved. A future regression lowers it; a later
-///   increment that closes the remaining gaps only raises it, so the floor is
-///   `>=`, not `==`.
-///
-/// Measured on the current corpus: 62,824 comparisons, 0 skipped, 60,904
-/// convergent, 39,760 carrying an `inv` in the `normalize` output — leaving 1,920
-/// divergences, the shift/over-merge/repeat-notation residue the later increments
-/// close. Each shuffle direction is normalized in its OWN direction (see
-/// `run_corpus`: a FivePrime derivation is held against a FivePrime `normalize`,
-/// not a 3'-canonical one), so the earlier "FivePrime direction-semantics"
-/// divergences — an artifact of that mismatch — no longer arise, which is why
-/// convergence sits well above the pre-consistency figure.
-#[test]
-fn the_inversion_geometry_corpus_converges_without_regression() {
-    let outcomes = geometry_corpus();
-    let compared = outcomes.iter().filter(|o| o.compared.is_some()).count();
-    let converged = outcomes
-        .iter()
-        .filter(|o| o.compared.as_ref().is_some_and(|(d, r)| d == r))
-        .count();
-    let recommend_has_inv = outcomes
-        .iter()
-        .filter(|o| o.compared.as_ref().is_some_and(|(_, r)| r.contains("inv")))
-        .count();
-
-    // The corpus is hermetic and deterministic, so this is exact: every generated
-    // variant put both surfaces through cleanly (0 skipped on the port).
-    assert_eq!(
-        compared, GEOMETRY_CORPUS_SIZE,
-        "the geometry corpus changed size — the generator is no longer emitting \
-         what this guard measures",
-    );
-    // Non-vacuity: the geometry really does produce inversions `normalize` types,
-    // so the convergence floor below is a claim about flanked inversions and not
-    // about a corpus that degenerated to palindromes or lone indels.
-    assert!(
-        recommend_has_inv >= 39_760,
-        "the corpus stopped producing genuine inversions: only {recommend_has_inv} \
-         of {compared} carry an inv in the normalize output, floor is 39,760",
-    );
-    assert!(
-        converged >= 60_731,
-        "convergence regressed: {converged} of {compared} converge, floor is 60,731",
-    );
-}
-
 /// Report mode: print the divergence landscape. Not an assertion — run with
 /// `--no-capture` while developing the corpus or a later increment, then read the
 /// floors off it.
 #[test]
 #[ignore = "permanent diagnostic (#2161): prints the divergence landscape used to set \
-            the floor in the_inversion_geometry_corpus_converges_without_regression; it \
-            never asserts, so it stays ignored"]
+            the floors in the geometry_corpus_slice tests; it never asserts, so it \
+            stays ignored"]
 fn report_inversion_convergence_landscape() {
     let outcomes = run_corpus();
     let compared = outcomes.iter().filter(|o| o.compared.is_some()).count();
@@ -688,77 +947,6 @@ fn report_inversion_convergence_landscape() {
         gated_diverged,
         gate_fired,
         100.0 * gate_fired as f64 / drop_compared.max(1) as f64,
-    );
-}
-
-/// The #2161 Path 1 gate guard: the SHIPPED `rederive(recommended_form = true)`
-/// path — skip the second block partition unless `repartition_gate` fires — must
-/// be byte-identical to the pre-drop full normalization on **every** output. That
-/// equality is the Drop's whole safety condition: the gate runs the full
-/// re-partition on exactly the shapes where it would change the output (inv /
-/// delins members) and skips it everywhere else.
-///
-/// The raw unconditional skip diverges on 72 of these (all inv-placement or
-/// delins-merge shapes), matched exactly by the `skip_diverged >= 72` floor
-/// below — a regression floor, not slack; the gate exists to catch those, and
-/// this asserts it does.
-#[test]
-fn the_gated_drop_changes_no_output() {
-    let outcomes = geometry_corpus();
-    let compared = outcomes
-        .iter()
-        .filter(|o| o.drop_compared.is_some())
-        .count();
-    let gated_diverged: Vec<&Outcome> = outcomes
-        .iter()
-        .filter(|o| {
-            o.drop_compared
-                .as_ref()
-                .is_some_and(|(full, _skip, gated, _fired)| full != gated)
-        })
-        .collect();
-    let skip_diverged = outcomes
-        .iter()
-        .filter(|o| {
-            o.drop_compared
-                .as_ref()
-                .is_some_and(|(full, skip, _gated, _fired)| full != skip)
-        })
-        .count();
-
-    // Non-vacuity: the guard must actually have compared a large population, or a
-    // corpus that stopped producing derivations would pass the emptiness check
-    // silently — the "a corpus zero is a claim about the corpus" trap.
-    assert_eq!(
-        compared, GEOMETRY_CORPUS_SIZE,
-        "the gate guard compared {compared} derived variants, expected \
-         {GEOMETRY_CORPUS_SIZE} — the corpus is no longer exercising the path on \
-         every generated variant",
-    );
-    // Non-vacuity, second half: the raw skip MUST still diverge on the shapes the
-    // gate exists to catch, or the guard is proving nothing (a corpus that stopped
-    // producing inv/delins shapes would pass while testing an empty gate).
-    assert!(
-        skip_diverged >= 72,
-        "the raw unconditional skip diverged on only {skip_diverged} outputs — the \
-         corpus stopped producing the inv/delins shapes the gate is meant to catch, \
-         so this guard is vacuous",
-    );
-
-    for o in gated_diverged.iter().take(20) {
-        let (full, _skip, gated, _fired) = o.drop_compared.as_ref().unwrap();
-        eprintln!(
-            "GATED-DIVERGE\t{}\t{:?}\tfull={}\tgated={}",
-            o.input, o.direction, full, gated
-        );
-    }
-
-    assert!(
-        gated_diverged.is_empty(),
-        "the SHIPPED gated Drop moved {} of {compared} outputs (raw skip moved \
-         {skip_diverged}) — the gate let a divergence through (see GATED-DIVERGE \
-         lines). Its predicate is missing a shape the re-partition changes.",
-        gated_diverged.len(),
     );
 }
 

--- a/tests/it/soak_package_membership.rs
+++ b/tests/it/soak_package_membership.rs
@@ -56,8 +56,10 @@ const CI_YML: &str = ".github/workflows/ci.yml";
 const SOAK_DRIVER: &str = "tests-soak/tests/soak/main.rs";
 
 /// The jobs that run off the archive `test-build-soak` produces. Every module
-/// any of them selects has to be compiled into it.
-const ARCHIVE_CONSUMERS: &[&str] = &["soak", "sweeps", "censuses"];
+/// any of them selects has to be compiled into it. `censuses-plain` is the
+/// un-armed half of the census job, split out so it runs in parallel with the
+/// armed half; both consume the soak archive.
+const ARCHIVE_CONSUMERS: &[&str] = &["soak", "sweeps", "censuses", "censuses-plain"];
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
Reduces the `CI` workflow's wall-clock from **~8:34 to ~4:10** (green, measured on this branch) on the free `ubuntu-latest` runners, with **no loss of per-PR coverage** — every gain comes from parallelizing existing work (finer test sharding, splitting slow jobs into parallel jobs), never from moving tests to nightly or shrinking corpora.

## Result

| | before | after |
|---|---|---|
| Whole `CI` workflow | ~8:34 | **~4:10** |

Every job now finishes under 4:00 except the release-build + binary-size job, which is the sole remaining pole at ~+4:08 (the whole-run figure is that plus the Build rollup's few-second hop): a ~212s `cargo build --release` under `lto = true, codegen-units = 1`, which is a genuine floor — the binary sits 9.9 MB against the 10 MB size-guard cap, so a faster/thinner profile would breach it, and the ferro-hgvs crate's own compile cannot be cross-commit cached (only its dependencies can). Taking the whole run under 4:00 would mean moving that size check off the per-PR push (for example onto the merge queue, where it would still gate every merge); that is a coverage-policy call and is deliberately not made here.

## What changed

**Test slicing (three commits).** Three heavy whole-corpus / whole-census tests were each refactored into N named per-slice tests, so nextest's name-hash `--partition` can distribute them across shards — a single test cannot be split. Each set adds a cheap meta-test that folds the per-slice pins back to the former whole-corpus floors, so coverage is a strict **superset**: the per-slice floors additionally catch a regression concentrated in one slice. The geometry corpus also re-pins, per slice, the drop-comparison population that its former whole-corpus guard used for non-vacuity.

**CI structure (one commit).** The slow censuses job and the Build job were each split into two parallel jobs behind a rollup that reports the required status context. The two Build jobs share one `rust-cache` entry via `shared-key` (plain `key` appends the job id, which gave two separate cold entries). The shard matrices were widened — `test` 6→8, `test-oracle` 8→10, `soak` 8→10 — with the soak per-shard case count lowered so the product stays exactly 1,000,000 cases per property. Because hash partitioning balances test counts and is blind to cost, the un-partitioned oracle sequence-exclusion step is placed on a light shard so it is not the pole.

## Suggested reading order

1. `test(normalize): slice the direction-symmetry net-insertion sweep` — smallest; establishes the slice-count guard.
2. `test: slice the issue_2161 geometry corpus` — the full pattern: slices + tiling meta-test + per-slice non-vacuity pin.
3. `test: slice the cis_confluence census` — the same pattern on the confluence axis.
4. `ci: cut CI wall-time…` — the workflow changes; the three test-slicing commits above are what it distributes.

Representation-Change: none. Tests and CI configuration only — the one `src/normalize/merge.rs` edit is a `#[cfg(test)]` constant and its test, so no normalized output moves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded and rebalanced automated coverage across parallel execution shards, including larger soak runs.
  - Added separate validation for standard and plain census processing, including archive membership checks.
  - Improved coverage for sequence insertion, confluence, geometry convergence, inversion, and package membership.
  - Added consistency checks to ensure partitioned tests preserve whole-corpus results.

- **Chores**
  - Streamlined build validation with parallel linting and release-build checks.
  - Improved shared build-cache handling and related documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->