### PR TITLE
chore: release v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.17.1...v0.17.2) - 2026-08-25
+
+### Representation changes
+
+- *(normalize)* fold coincident insertions the derivation leaves on one junction ([#2203](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2203))
+  > none on the shipped `normalize` output — a
+  > synthetic-corpus before/after diff moves 0 of 96,698 rows across all 27
+  > shape families, including `dup_plus_ins`, `adjacent_junction_ins`, and
+  > `run_beside_a_distant_member` (the shapes closest to this bug). That
+  > corpus exercises `Normalizer::normalize` only, which this change does
+  > not touch. The change is confined to the `from_sequences`/`rederive`
+  > derivation surface, where it moves the eleven reported families and
+  > their geometry neighbourhood from an unapplyable "could not be
+  > re-applied to its window" error to a valid single insertion —
+  > meaning-preserving and idempotent.
+
+### Other
+
+- *(normalize)* harden #2201 merge shape coverage ([#2206](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2206)) ([#2208](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2208))
+
 ## [0.17.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.17.0...v0.17.1) - 2026-08-24
 
 ### Representation changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]


### PR DESCRIPTION
## Representation stability

Any PR that moves a normalized output should carry a `Representation-Change:`
trailer (see CONTRIBUTING.md). Those are collected into the **Representation
changes** section of the changelog below, and each entry's trailer text is
attached under its bullet by `scripts/inject_representation_disclosure.py`.

Reviewer checklist:

- [ ] Either that section lists every output-moving change in this cycle, or
      there were none and it is absent.
- [ ] Nothing in it merely *declined*. A decline reads `Representation-Change:
      none`, optionally followed by a reason, and belongs under its own type —
      not here. Spot-check two entries against their PR descriptions.
- [ ] Every entry carries its trailer's own text, quoted under the bullet, and
      that text says whether the affected inputs were previously **rejected**
      (no stored string, so free) or previously **accepted** (a real migration
      for the consumer). release-plz writes the bullet from the commit subject
      alone; `python scripts/inject_representation_disclosure.py` attaches the
      rest, and CI's `Changelog grouping audit` fails until it has been run.
      Re-run it after any push that regenerates this section — it is idempotent.

A commit under `src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`,
`src/reference/` or `src/error_handling/` that moved output without declaring it
means the trailer is missing. Fix that before releasing, not after.

---


### [0.17.2](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.17.1...v0.17.2) - 2026-08-25
### Representation changes

- *(normalize)* fold coincident insertions the derivation leaves on one junction ([#2203](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2203))

### Other

- *(normalize)* harden #2201 merge shape coverage ([#2206](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2206)) ([#2208](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2208))


#### cargo-semver-checks

compatible


