### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.17.2...v1.0.0) - 2026-08-25
+
+### Added
+
+- add a from_sequences/rederive lane to dump_normalized_corpus ([#2205](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2205))
+
+### Other
+
+- *(ci)* reduce CI wall-time via test slicing, job splits, and shard rebalance ([#2202](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2202))
+
 ## [0.17.2](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.17.1...v0.17.2) - 2026-08-25
 
 ### Representation changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.17.2"
+version = "1.0.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.17.2"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]

--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@
 
 A high-performance HGVS variant nomenclature parser and normalizer written in Rust.
 
-**WARNING: ALPHA SOFTWARE - USE AT YOUR OWN RISK**
-
-This software is currently in **ALPHA**. While we have extensively tested it
-across a wide variety of HGVS patterns, **no guarantees are made** regarding
-correctness or stability.
-
 <p>
 <a href="https://fulcrumgenomics.com">
   <picture>
@@ -258,7 +252,7 @@ Licensed under the MIT License. See [LICENSE](LICENSE) for details.
 
 ## Disclaimer
 
-This software is under active development.
+This software is actively maintained.
 While we make a best effort to test this software and to fix issues as they are reported, this software is provided as-is without any warranty (see the [license](https://github.com/fulcrumgenomics/ferro-hgvs/blob/main/LICENSE) for details).
 Please submit an [issue](https://github.com/fulcrumgenomics/ferro-hgvs/issues), and better yet a [pull request](https://github.com/fulcrumgenomics/ferro-hgvs/pulls) as well, if you discover a bug or identify a missing feature.
 Please contact [Fulcrum Genomics](https://www.fulcrumgenomics.com) if you are considering using this software or are interested in sponsoring its development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "MIT"}
 requires-python = ">=3.10"
 keywords = ["hgvs", "variant", "normalization", "bioinformatics", "genomics"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Representation stability

Any PR that moves a normalized output should carry a `Representation-Change:`
trailer (see CONTRIBUTING.md). Those are collected into the **Representation
changes** section of the changelog below, and each entry's trailer text is
attached under its bullet by `scripts/inject_representation_disclosure.py`.

Reviewer checklist:

- [ ] Either that section lists every output-moving change in this cycle, or
      there were none and it is absent.
- [ ] Nothing in it merely *declined*. A decline reads `Representation-Change:
      none`, optionally followed by a reason, and belongs under its own type —
      not here. Spot-check two entries against their PR descriptions.
- [ ] Every entry carries its trailer's own text, quoted under the bullet, and
      that text says whether the affected inputs were previously **rejected**
      (no stored string, so free) or previously **accepted** (a real migration
      for the consumer). release-plz writes the bullet from the commit subject
      alone; `python scripts/inject_representation_disclosure.py` attaches the
      rest, and CI's `Changelog grouping audit` fails until it has been run.
      Re-run it after any push that regenerates this section — it is idempotent.

A commit under `src/normalize/`, `src/hgvs/`, `src/spdi/`, `src/project/`,
`src/reference/` or `src/error_handling/` that moved output without declaring it
means the trailer is missing. Fix that before releasing, not after.

---


### [0.18.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.17.2...v0.18.0) - 2026-08-25
### Added

- add a from_sequences/rederive lane to dump_normalized_corpus ([#2205](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2205))

### Other

- *(ci)* reduce CI wall-time via test slicing, job splits, and shard rebalance ([#2202](https://github.com/fulcrumgenomics/ferro-hgvs/pull/2202))


#### cargo-semver-checks

compatible


