### PR TITLE
docs(spec) Attempt to make READING_THE_SPEC more understandable to me…

### DIFF
--- a/docs/READING_THE_SPEC.md
+++ b/docs/READING_THE_SPEC.md
@@ -46,7 +46,7 @@ alternative description" as a split, `c.[850_869del;874_881del;887_897del;901_90
 deletes 39 bases and inserts one. `:47` recommends the delins: "it is simpler and prevents
 software tools making incorrect predictions for the consequences on protein level". State that
 direction when you cite the passage, and cite the ruling that scopes it,
-`rulings[delins-merge-vs-individual-gap-two-or-more]`.
+`rulings[delins-merge-vs-individual-gap-two-or-more]`. That is the spec preferring the larger form *for this example's stated reasons*, not a general "prefer the larger delins" — the scope is that ruling, nothing wider.
 
 ## A split is rarely unique, which is a stability argument by itself
 

--- a/docs/READING_THE_SPEC.md
+++ b/docs/READING_THE_SPEC.md
@@ -81,7 +81,7 @@ have been reported (or might occur) individually". That reason is provenance: ho
 were observed. No rule over the sequence alone can recover it. So any sequence-local merge or
 split rule in ferro is a house approximation of the spec's criterion; argue it as one. The
 governing records are `rulings[delins-merge-vs-individual-gap-two-or-more]` and
-`rulings[canonical-form-choice-when-both-legal]`.
+`rulings[canonical-form-choice-when-both-legal]`. Provenance is how the change was observed, not "preserve the input's spelling": ferro re-derives from the resulting sequence, so the input's spelling gets no weight.
 
 `DNA/delins.md:86-89` answers a BRCA1 case: a substitution plus an adjacent insertion is
 `NM_007294.3:c.2077delinsATA`. `:89` records that a sentence permitting the two-member spelling

--- a/docs/READING_THE_SPEC.md
+++ b/docs/READING_THE_SPEC.md
@@ -1,107 +1,133 @@
 # Reading the HGVS recommendations
 
-Findings about the spec text in `assets/hgvs-nomenclature` that change how a clause
-argument should be framed. Each is checkable against the pinned checkout; re-check
-rather than trust. Moved out of `CLAUDE.md` on 2026-09-02.
+Findings about the spec text in `assets/hgvs-nomenclature` that change how a clause argument
+should be framed. The submodule is the HGVS nomenclature repository, pinned at one commit. Every
+`file:line` below cites it. Open the cited lines; do not trust this summary. Where a reading is a
+house choice, the section names the ruling record in `docs/NORMALIZATION_CONTRACT.md`. The record
+holds the reasoning.
 
 ## Almost nothing in the recommendations is normative
 
-`style.md:9` binds the spec to RFC 2119, which invites the habit of arguing that clause A is a
-SHOULD and clause B a MUST. That argument almost never works here, because **uppercase RFC 2119
-keywords appear exactly twice outside `style.md` itself**, and both are in one file:
+Do not rank clauses by RFC 2119 keyword strength. `style.md:9` binds the document to RFC 2119,
+but the recommendations almost never use the keywords. At the pinned commit, uppercase RFC 2119
+keywords appear exactly twice outside `style.md`, both in one file:
 
 ```bash
 grep -rnoE '\b(MUST|SHOULD|RECOMMENDED|MAY|SHALL|REQUIRED|REQUIRES|OPTIONAL)( NOT)?\b' \
   assets/hgvs-nomenclature/docs/recommendations/ | grep -v '/style\.md'
-# -> docs/recommendations/RNA/adjoined_transcript.md:20:REQUIRES
-# -> docs/recommendations/RNA/adjoined_transcript.md:21:SHOULD    (and nothing else)
+# -> assets/hgvs-nomenclature/docs/recommendations/RNA/adjoined_transcript.md:20:REQUIRES
+# -> assets/hgvs-nomenclature/docs/recommendations/RNA/adjoined_transcript.md:21:SHOULD
+# (and nothing else)
 ```
 
-Every clause this project has litigated — `general.md:33`, `:34`, `:55`, `:57`,
-`DNA/delins.md:17`, `:18`, `:47`, `DNA/inversion.md:20` — is lowercase prose. Read strictly,
-none of them is normative. That does not make them ignorable: it makes most of these questions
-house-style choices the spec leaves open, which ferro still has to answer. Argue them on the
-spec's worked examples and on downstream cost, not on keyword strength. (`general.md:57` and
-`DNA/duplication.md:18` are read as strong because of their wording — "are not allowed",
-"**must**" — not because RFC 2119 makes them so; say which you mean.)
+`REQUIRES` is not in `style.md:9`'s list. The census counts it as the authors' intent: a
+capitalised form of REQUIRED in a document bound to RFC 2119. Under the strict list the count is
+one, at `:21`.
 
-The `rulings[delins-merge-vs-individual-gap-two-or-more]` record used to argue from "the two
-clauses are the same RFC 2119 strength". It does not any more, for this reason.
+Every merge and split clause this repository argues over (`general.md:33`, `:34`, `:55`, `:57`,
+`DNA/delins.md:16`, `:17`, `:18`, `:47`, `DNA/inversion.md:20`) is lowercase prose. Read strictly,
+none is normative. They are not ignorable: each raises a house choice the spec leaves open, which
+ferro must answer and record. Argue them from the spec's worked examples and from downstream cost.
+
+Some clauses read as prohibitions because of their wording: `general.md:57` says such
+descriptions "are not allowed"; `DNA/duplication.md:18` says a duplication "**must**" be
+described as one. They are strong because of their words, not because of RFC 2119. Say which you
+mean.
 
 ## There is no minimality principle, and stability is the spec's first stated value
 
-`background/basics.md:38`: "The recommendations for the description of sequence variants are
-designed to be **stable**, **meaningful**, **memorable**, and **unequivocal**." Minimality is
-absent, and stability leads. Ferro's column-minimal objective is therefore **our policy**, not
-compliance — never cite the spec for it. `DNA/delins.md:44-47` in fact recommends a
-*non-minimal* description in its own worked example (66 columns where 40 suffice), and `:47`
-recommends the **spanning delins**; the split is what `:46` calls the "alternative description".
-That direction has been retold backwards at least once, so state it explicitly whenever you
-cite the passage.
+Never cite the spec for minimality. `background/basics.md:38` states the design values: "stable,
+meaningful, memorable, and unequivocal". Minimality is not among them; stability is first. An
+argument from length, or from bases touched, is a house argument.
+
+The spec's own worked example prefers the larger form. `DNA/delins.md:44` gives
+`LRG_199t1:c.850_901delinsTTCCTCGATGCCTG`, a delins that replaces 52 bases. `:46` gives "an
+alternative description" as a split, `c.[850_869del;874_881del;887_897del;901_902insG]`, which
+deletes 39 bases and inserts one. `:47` recommends the delins: "it is simpler and prevents
+software tools making incorrect predictions for the consequences on protein level". State that
+direction when you cite the passage, and cite the ruling that scopes it,
+`rulings[delins-merge-vs-individual-gap-two-or-more]`.
 
 ## A split is rarely unique, which is a stability argument by itself
 
-Exact enumeration over 40 rows found **27 that admit more than one equally-compliant split**,
-median 2 and **max 125**; the spec's own `:44-47` example admits five. So adopting a split
-trades one stable canonical form for an arbitrary pick out of a family — and the arbitrariness
-is invisible in any single-row before/after comparison, which is how it keeps getting missed.
+The spec has two explicit tie-breaks: type prioritisation at `general.md:55` and the 3' rule at
+`general.md:40`. Beyond those it gives no rule for choosing among equally compliant splits of one
+change, and it never claims a split is unique. Before you adopt a split, count the alternatives.
+In the rows ferro enumerated, most admit more than one compliant set of members. Picking one
+trades a stable canonical form for an arbitrary member of a family, and one before-and-after
+comparison cannot show that. Check the family, not the row. An argument for a split is an
+argument against `basics.md:38`'s stability; say so.
+
+There are two kinds of stability. `basics.md:38` means a variant keeps one description across
+time and tools. Ferro also requires determinism, rule 4 of
+`docs/src/reference/normalization-rules.md`: same input, same output, on every run. That is not
+confluence, rule 3, which is about inputs denoting one variant producing one output. The spec
+says nothing about determinism; do not cite it for that. Where ferro must pick, the pick depends
+on the input alone, never on iteration order or scheduling, and it is a house choice to record.
+For splits the record is `rulings[canonical-form-choice-when-both-legal]`: re-derive from the
+resulting sequence, then make a deterministic choice among equally-minimal partitions. The record
+also holds the enumeration behind "most": 27 of 40 rows admit more than one split, the worst
+admits 125, and the spec's own split at `DNA/delins.md:46` is one of five.
 
 ## Read the Q&A, not only the Notes and Examples
 
-`DNA/delins.md`'s trailing `!!! note` blocks are adjudicative, not colour. A claim that "no
-sequence-local rule separates these two cases" was withdrawn once `:86-89` was read: the Q&A
-carries the worked answer (`NM_007294.3:c.2077delinsATA`) and `:89` records that the passage
-permitting the two-member spelling was *removed* by the committee. `:79-84` likewise carries the
-spec's own discriminator — "the two variants may have been reported (or might occur)
-individually" — which is **provenance**, recoverable only from the input's spelling.
+Read each recommendations page to its end. The `!!! note` blocks at the foot are community
+questions and suggestions with the committee's answers. They can settle what the body leaves
+open, and they can record a changed decision.
 
-## A forward-looking note is a suggestion, and may describe a proposal that FAILED
+`DNA/delins.md:79-84` answers whether two nearby substitutions are one delins or two variants:
+two, unless together they affect one amino acid. The first reason is that "the two variants may
+have been reported (or might occur) individually". That reason is provenance: how the changes
+were observed. No rule over the sequence alone can recover it. So any sequence-local merge or
+split rule in ferro is a house approximation of the spec's criterion; argue it as one. The
+governing records are `rulings[delins-merge-vs-individual-gap-two-or-more]` and
+`rulings[canonical-form-choice-when-both-legal]`.
 
-`general.md:35-38` reads as forward guidance — "the SVD-WG is preparing a proposal… The new
-recommendation will be: two variants separated by less than two nucleotides should be described
-as a `delins`" — and it is tempting to treat it as the direction of travel and discount the
-current rule accordingly.
+`DNA/delins.md:86-89` answers a BRCA1 case: a substitution plus an adjacent insertion is
+`NM_007294.3:c.2077delinsATA`. `:89` records that a sentence permitting the two-member spelling
+was removed. Do not cite the removed text.
 
-**That proposal is SVD-WG010, and it was rejected.** Word for word, including its rationale.
-So the note is stale text describing a change that never happened, and three conclusions drawn
-from reading it as guidance are all withdrawn: the codon exception is *not* going away, the
-proposal to replace it having failed; it *strengthens* `codon-carve-out-shape-restriction`
-rather than undercutting it; and the "spec-admitted instability" argument built on it does not
-stand.
+## Cross-check forward-looking statements against `consultation/`
 
-So a rejected proposal earns a **negative guard**, not an expectation. The spec corpus builds
-210 rows whose only purpose is to catch a frameless separation floor of two — what implementing
-SVD-WG010 looks like from the outside — and pins `guard_violations` over them (read the pinned count off
-`tests/it/spec_conformance_axis.rs`; it has moved since this was written), with the
-denominator asserted non-zero so `0 of 0` cannot pass as a result. See
-`spec_conformance_axis.rs`.
+A sentence that describes a future rule is not a rule. The sign is future tense about the
+recommendations themselves: "is preparing", "is being prepared", "will suggest", "the new
+recommendation will be". Before you cite or build on such a sentence, find its proposal in
+`consultation/` and read the status. If the proposal is rejected or undecided, the current text
+stands. If it is rejected and you write a test about it, the test must fail when ferro produces
+what the proposal asked for; it must never expect that output. No forward-looking note at the
+pinned commit points at an accepted proposal. If one appears, record an adjudication in the
+ledger; do not infer a reading from this page. A reference to an adopted proposal, such as
+"based on Community Consultation proposal SVD-WG005" at `DNA/other.md:41`, is not
+forward-looking. The text around it is current.
 
-**So: cross-check every forward-looking statement in `recommendations/` against the
-`consultation/` dispositions before citing it.** "is preparing", "will be", "the new
-recommendation" are all flags. The disposition table is inventoried in the consultation slice:
-9 accepted, 3 rejected, 8 open, 3 unclear — a rejected proposal is generated as a NEGATIVE
-guard, never as an expectation.
+The notes found at the pinned commit:
+
+- `general.md:35-38`: "the SVD-WG is preparing a proposal to modify this recommendation ... The
+  new recommendation will be: two variants separated by less than two nucleotides should be
+  described as a delins." Read alone, it says the rule at `:33-34` will change. The proposal is
+  SVD-WG010: `consultation/SVD-WG010.md:12` states the same rule, `:27` the same reason, and
+  `:30-33` names `general.md:33-34` as the rule to replace. It was rejected (`SVD-WG010.md:5`).
+  The note was not updated. The rule at `:33-34` stands, codon exception included.
+- `DNA/duplication.md:86` marks the worked example above it as "part of proposal SVD-WG003
+  (undecided)". `SVD-WG003.md:5` reads "new proposal to be made"; `:10` says the example's format
+  "does follow current recommendations". The example stands.
+- `DNA/repeated.md:9` and `RNA/repeated.md:9` say a proposal "is being prepared" to require the
+  full range in repeat descriptions. No such proposal exists in `consultation/`; the topic is in
+  `consultation/open-issues.md:82-110`. The syntax after the note stands.
 
 ## Comparing `c.` positions across numbering zones is OUR policy, not compliance
 
-`c.` has three numbering zones — `-n` upstream of the ATG, plain `n` in the CDS, `*n` downstream
-of the stop — and a cis allele's members can sit in different ones. Ferro therefore needs an
-endpoint ordering that spans zones, to sort members, detect overlap and decide separation.
+Never cite the spec for how two `c.` positions in different numbering zones compare. The `c.`
+axis has three zones: `-n` upstream of the ATG, plain `n` in the CDS, `*n` downstream of the
+stop. `background/numbering.md` defines each zone and the flat `n.` numbering under them. It
+states no rule for comparing positions across zones, and it never mentions alleles or members:
+zero occurrences of "allele", zero of "member". `refseq.md`'s only uses of "allele" (`:264-265`)
+are the population-genetics sense.
 
-**The spec does not give one.** `background/numbering.md` defines each zone but states no rule
-for comparing positions across them, and it never speaks about alleles at all: it contains zero
-occurrences of "allele" and zero of "member". `refseq.md` contains "allele" twice (`:264-265`),
-but both are the population-genetics sense — the wild-type "major allele present in the human
-population" — not cis-allele membership.
-
-So ferro's cross-zone ordering is a house rule. **Never cite the spec for it.** Argue it from the
-underlying transcript coordinate, which is unambiguous, and say plainly that the `c.` spelling is
-a presentation of that.
-
-This is not theoretical. The sequence-changing and denotes-no-sequence classes the spec corpus
-found both localise to the `c.72`/`c.*1` transition and to nothing else: the same flush
-deletion-plus-insertion shape collapses correctly at all 22 other homopolymer runs in the test
-transcript and mis-normalizes only where the pair straddles the CDS/3'UTR zone boundary. See
-`the_cds_end_flush_pair_is_its_two_members_normalized_separately` and
-`the_five_prime_boundary_masks_the_same_per_member_defect` in `tests/it/spec_corpus_regressions.rs`
-— the second is the reminder that the 5' boundary is not a working case, only a masked one.
+Ferro needs such an order: a cis allele's members can sit in different zones, and normalization
+must sort them, detect overlap and decide separation. The order is a house choice,
+`rulings[cross-zone-c-positions-order-by-transcript-coordinate]`: positions are ordered by their
+flat transcript coordinate, and the `c.` spelling is a presentation of that coordinate. Argue
+from the coordinate. The failure point is the CDS/3'UTR boundary, where the last coding base and
+`c.*1` are adjacent on the transcript and far apart in zone-local arithmetic. The defect class is
+pinned in `tests/it/spec_corpus_regressions.rs`.


### PR DESCRIPTION
…atbags & clankers

The original intent was to trim this down, and in particular "invert" the structure of each section. I spotted that each section had that Claude-ish storytelling approach (like I'm doing here) where it just walks through what it saw, how it reacted, and its takeaways. Instead, I felt it was more human readable and hypothesized more agent useful for it to have the more classic shape of a problem statement/rule, potentially followed by exemplars.

**NB** This took an unexpected turn. My original intent was to trim it down, but I wound up with something longer. Methodology was to iterate with a couple of Claude sessions to develop an understanding of what rules this file was going to convey. Then created a loop where we'd iterate on wording, and then farm A/B tests out to waves of Opus & Sonnet agents instructed to interpret the document as if they were coding agents and report what rules they infer. Scoring was based on their ability to track the specific rules as well as minimize unintended rules, with a tiebreaker going to conciseness. At each checkpoint, I interpreted the set of unintended rules to see if perhaps **my** understanding was incorrect, so the rubric also evolved.

## The set of rules we wound up with (cc @nh13 for a veracity check):

  #### Normativity
  1. Do not rank clauses by RFC 2119 keyword strength.
  2. The questions those clauses raise are house choices; ferro answers and records them in the ledger.
  3. "Are not allowed" and bold "must" are strong by wording, not by RFC 2119; say which you mean.
  #### Minimality
  4. Never cite the spec for minimality; length or bases touched is a house argument.
  5. The spec's own example prefers the larger delins for its stated reasons; ferro's scope for that is `rulings[delins-merge-vs-individual-gap-two-or-more]`, not a general preference for larger forms.
  #### Split uniqueness
  6. Before adopting a split, count the family; one before-and-after row proves nothing.
  7. Determinism: same input, same output, every run (rule 4 of `normalization-rules.md`).
  8. Where ferro must pick among equal splits, the pick depends on the input alone and is a house choice recorded in `rulings[canonical-form-choice-when-both-legal]`.
  9. `basics.md:38` is not a citation for determinism; the spec is silent on it.
  #### Q&A
  10. Read each page to its end; the note blocks carry answers.
  11. The spec's merge-versus-individual criterion is provenance, which no sequence-local rule can recover.
  12. Ferro's merge or split rule is therefore a house approximation, argued as one and governed by the two named records; provenance does not mean "preserve the input's spelling".
  13. The BRCA1 two-member spelling is closed; do not cite the removed text.
  #### Forward-looking
  14. Check a proposal's status in `consultation/` before citing forward-looking text; rejected or undecided means the current text stands, and SVD-WG010 is rejected so the codon exception stays.
  15. A test about a rejected proposal guards against its behaviour, never expects it.
  16. An accepted proposal is an adjudication for the ledger, not a reading to infer from the page.
  #### Cross-zone
  17. Never cite the spec for how `c.` positions in different zones compare.
  18. Order by the flat transcript coordinate, per `rulings[cross-zone-c-positions-order-by-transcript-coordinate]`.
  #### Things a reader must not take away
  - An obligation to write or update a test now.
  - A count to pin in a test.
  - A component or table to go find or build.
  - A policy that lives in no ledger record.
  - A pinned defect read as a bug to fix in passing.
  - Column-minimality as a live house policy.
  - The 9/3/8/3 consultation inventory as fact.
  - Provenance as a constraint on the normalizer, or as "preserve the input's spelling".

## Follow-ups, not in this PR
  - `src/normalize/merge.rs`, doc comment on `changed_columns_of_pieces`: says the spec example
    "covers 66 columns" under a measure it defines as `max(span, replacement)`, which gives 52.
  - `src/normalize/merge.rs`, doc comment on `split_concealed_separations`: cites this page for "confluence outranks stability", which the page has never said.
  - `src/conformance/spec_corpus.rs` (`Strength` doc comment), `tests/it/coding_frame_merge_axis_asymmetry.rs`, and the
    `rulings[delins-merge-vs-individual-gap-two-or-more]` rationale say "exactly once" outside `style.md`. That is the count under `style.md:9`'s strict list; the page counts two because it also counts `REQUIRES` as the authors' intent, and says so. Each should say which list it counts.
  - `CLAUDE.md`, "Reading the HGVS spec": says "several forward-looking notes describe proposals that were later rejected". One rejected proposal exists in the checkout; the page documents three notes with three fates.

Representation-Change: none. One Markdown file under `docs/`, outside every watched directory; no code, test, fixture or ledger record is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reworked HGVS guidance to distinguish normative wording from house policy.
  - Clarified keyword requirements, merge/split interpretation, stability, deterministic partition selection, enumeration counts, and consultation-status checks.
  - Added provenance guidance for Q&A content and transcript-coordinate ordering across cross-zone `c.` positions.
  - Updated examples, rulings, and regression references; removed spelling guidance.

- **Tests**
  - Expanded documentation citation coverage across general guidance, deletion/insertion, duplication, and foundational concepts.
  - Updated citation comments and replaced exact citation counts with a minimum coverage requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->